### PR TITLE
quinn.set_up_publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish 
+
+on:
+    workflow_dispatch:
+    release:
+        types: [published]
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest 
+
+        steps:
+            - name: Checkout code 
+              uses: actions/checkout@v4
+
+            - name: Set up JDK 
+              uses: actions/setup-java@v4
+              with:
+                java-version: 21
+                distribution: "temurin"
+
+            - name: Setup Gradle 
+              uses: gradle/actions/setup-gradle@v4
+              with:
+                gradle-home-cache-cleanup: true 
+
+            - name: Verify build
+              run: ./gradlew check
+
+            - name: Extract version from tag
+              id: extract_version
+              run: |
+                  echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+            - name: Verify gradle.properties
+              run: |
+                VERSION='${{ steps.extract_version.outputs.VERSION }}'
+                if [ -f gradle.properties ]; then
+                    FILE_VERSION=$(grep -E '^version=' gradle.properties | cut -d= -f2)
+                    if [ "$FILE_VERSION" != "$VERSION" ]; then
+                        echo "::error::gradle.properties version ($FILE_VERSION) != tag version ($VERSION)"
+                        exit 1
+                    fi
+                fi
+
+            - name: Publish the artifacts
+              env:
+                  ORG_GRADLE_PROJECT_version: ${{ steps.extract_version.outputs.VERSION }}
+                  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_USERNAME }}
+                  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PASSWORD }}
+                  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+                  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
+              run: |
+                  ./gradlew publishAndReleaseToMavenCentral --no-parallel --no-configuration-cache
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,17 +1,19 @@
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.plugins.signing.SigningExtension
 import org.gradle.api.plugins.JavaPluginExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.JavadocJar
 
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.vanniktech.maven.publish) apply false
 }
 
 allprojects {
     group = "com.faire.yawn"
-    version = "1.0.0"
+    version = providers.gradleProperty("version").orElse("0.0.0-SNAPSHOT").get()
     
     repositories {
         mavenCentral()
@@ -20,22 +22,20 @@ allprojects {
 
 subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
-    apply(plugin = "maven-publish")
-    apply(plugin = "signing")
     apply(plugin = "org.jetbrains.dokka")
+    apply(plugin = "com.vanniktech.maven.publish")
 
     configure<JavaPluginExtension> {
         withSourcesJar()
-        withJavadocJar()
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(17))
         }
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions {
-            jvmTarget = "17"
-            freeCompilerArgs = listOf("-Xjsr305=strict")
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+            freeCompilerArgs.add("-Xjsr305=strict")
         }
     }
 
@@ -43,60 +43,48 @@ subprojects {
         useJUnitPlatform()
     }
 
-    configure<PublishingExtension> {
-        publications {
-            create<MavenPublication>("maven") {
-                from(components["java"])
-                
-                pom {
-                    name.set("${project.group}:${project.name}")
-                    description.set("Yawn - Hibernate ORM type-safe wrapper")
-                    url.set("https://github.com/faire/yawn")
-                    
-                    licenses {
-                        license {
-                            name.set("MIT License")
-                            url.set("https://github.com/faire/yawn/blob/main/LICENSE")
-                        }
-                    }
-                    
-                    developers {
-                        developer {
-                            id.set("luan")
-                            name.set("Luan Nico")
-                            email.set("luan@faire.com")
-                        }
-                    }
-                    
-                    scm {
-                        connection.set("scm:git:git://github.com/faire/yawn.git")
-                        developerConnection.set("scm:git:ssh://github.com/faire/yawn.git")
-                        url.set("https://github.com/faire/yawn")
-                    }
-                }
-            }
-        }
-        
-        repositories {
-            maven {
-                name = "OSSRH"
-                url = if (version.toString().endsWith("SNAPSHOT")) {
-                    uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-                } else {
-                    uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                }
-                credentials {
-                    username = project.findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME")
-                    password = project.findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD")
-                }
-            }
-        }
-    }
+    extensions.configure<MavenPublishBaseExtension> {
+        configure(
+            KotlinJvm(
+                javadocJar = JavadocJar.Dokka("dokkaHtml"),
+                sourcesJar = true
+            )
+        )
 
-    configure<SigningExtension> {
-        val signingKey: String? by project
-        val signingPassword: String? by project
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(the<PublishingExtension>().publications["maven"])
+        publishToMavenCentral(automaticRelease = true)
+        signAllPublications()
+
+        pom {
+            name.set("${project.group}:${project.name}")
+            description.set("Yawn - Hibernate ORM type-safe wrapper")
+            url.set("https://github.com/faire/yawn")
+            
+            licenses {
+                license {
+                    name.set("MIT License")
+                    url.set("https://github.com/faire/yawn/blob/main/LICENSE")
+                }
+            }
+            
+            developers {
+                developer {
+                    id.set("luan")
+                    name.set("Luan Nico")
+                    email.set("luan@faire.com")
+                }
+                developer {
+                    id.set("quinn")
+                    name.set("Quinn Budan")
+                    email.set("quinn.budan@faire.com")
+                }
+            }
+
+            scm {
+                connection.set("scm:git:https://github.com/faire/yawn.git")
+                developerConnection.set("scm:git:git@github.com:faire/yawn.git")
+                url.set("https://github.com/faire/yawn")
+            }
+        }
     }
 }
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ h2database = "2.3.232"
 assertj = "3.26.3"
 junit-jupiter = "5.11.3"
 junit-platform = "1.11.3"
+vanniktech = "0.34.0"
 
 [libraries]
 # Kotlin
@@ -50,3 +51,4 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech" }


### PR DESCRIPTION
Updating `build.gradle.kts` to use the [Vanniktech plugin](https://github.com/vanniktech/gradle-maven-publish-plugin/?tab=readme-ov-file) to sign and publish jars for the subproject. It's one of the recommended plugins on Sonatype's website and is the highest level, it handles creating publications, signing, auto-releasing, etc.