### PR TITLE
chore: Reformat all files to use 4-space indentation standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,20 +3,22 @@ insert_final_newline = true
 charset = utf-8
 end_of_line = lf
 indent_size = 4
-tab_width = 4
 indent_style = space
 max_line_length = 120
+tab_width = 4
+ij_continuation_indent_size = 4
 ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
 ij_formatter_tags_enabled = false
 ij_smart_tabs = false
-ij_visual_guides = 120
+ij_visual_guides = 160
 ij_wrap_on_typing = false
 
 [*.txt]
 insert_final_newline = false
 
 [*.java]
+ij_continuation_indent_size = 4
 ij_java_align_consecutive_assignments = false
 ij_java_align_consecutive_variable_declarations = false
 ij_java_align_group_field_declarations = false
@@ -105,7 +107,7 @@ ij_java_for_statement_wrap = off
 ij_java_generate_final_locals = false
 ij_java_generate_final_parameters = false
 ij_java_if_brace_force = never
-ij_java_imports_layout = *,|,$*
+ij_java_imports_layout = *, |, $*
 ij_java_indent_case_from_switch = true
 ij_java_insert_inner_class_imports = false
 ij_java_insert_override_annotation = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,37 +11,37 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+            -   name: Checkout code
+                uses: actions/checkout@v4
 
-            - name: Set up JDK
-              uses: actions/setup-java@v4
-              with:
-                  java-version: 21
-                  distribution: "temurin"
+            -   name: Set up JDK
+                uses: actions/setup-java@v4
+                with:
+                    java-version: 21
+                    distribution: "temurin"
 
-            - name: Setup Gradle
-              uses: gradle/actions/setup-gradle@v4
-              with:
-                  gradle-home-cache-cleanup: true
+            -   name: Setup Gradle
+                uses: gradle/actions/setup-gradle@v4
+                with:
+                    gradle-home-cache-cleanup: true
 
-            - name: Check build configuration
-              run: ./gradlew projects
+            -   name: Check build configuration
+                run: ./gradlew projects
 
-            - name: Assemble all modules
-              run: ./gradlew assemble
+            -   name: Assemble all modules
+                run: ./gradlew assemble
 
-            - name: Run test, lint and checks
-              run: ./gradlew check
+            -   name: Run test, lint and checks
+                run: ./gradlew check
 
-            - name: Generate documentation
-              run: ./gradlew dokkaHtml
+            -   name: Generate documentation
+                run: ./gradlew dokkaHtml
 
-            - name: Generate test report
-              uses: dorny/test-reporter@v1
-              if: success() || failure()
-              with:
-                  name: Test Results
-                  path: "**/build/test-results/test/*.xml"
-                  reporter: java-junit
-                  fail-on-error: true
+            -   name: Generate test report
+                uses: dorny/test-reporter@v1
+                if: success() || failure()
+                with:
+                    name: Test Results
+                    path: "**/build/test-results/test/*.xml"
+                    reporter: java-junit
+                    fail-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish 
+name: Publish
 
 on:
     workflow_dispatch:
@@ -7,38 +7,38 @@ on:
 
 jobs:
     publish:
-        runs-on: ubuntu-latest 
+        runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout code 
-              uses: actions/checkout@v4
+            -   name: Checkout code
+                uses: actions/checkout@v4
 
-            - name: Set up JDK 
-              uses: actions/setup-java@v4
-              with:
-                java-version: 21
-                distribution: "temurin"
+            -   name: Set up JDK
+                uses: actions/setup-java@v4
+                with:
+                    java-version: 21
+                    distribution: "temurin"
 
-            - name: Setup Gradle 
-              uses: gradle/actions/setup-gradle@v4
-              with:
-                gradle-home-cache-cleanup: true 
+            -   name: Setup Gradle
+                uses: gradle/actions/setup-gradle@v4
+                with:
+                    gradle-home-cache-cleanup: true
 
-            - name: Verify build
-              run: ./gradlew check
+            -   name: Verify build
+                run: ./gradlew check
 
-            - name: Extract version from tag
-              id: extract_version
-              run: |
-                  echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            -   name: Extract version from tag
+                id: extract_version
+                run: |
+                    echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-            - name: Publish the artifacts
-              env:
-                  ORG_GRADLE_PROJECT_version: ${{ steps.extract_version.outputs.VERSION }}
-                  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-                  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-                  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-                  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
-              run: |
-                  ./gradlew publishAndReleaseToMavenCentral --no-parallel --no-configuration-cache
+            -   name: Publish the artifacts
+                env:
+                    ORG_GRADLE_PROJECT_version: ${{ steps.extract_version.outputs.VERSION }}
+                    ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+                    ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+                    ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+                    ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
+                run: |
+                    ./gradlew publishAndReleaseToMavenCentral --no-parallel --no-configuration-cache
 

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,21 +1,21 @@
 rootProject.name = "build-logic"
 
 pluginManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }
 
 dependencyResolutionManagement {
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
-  
-  versionCatalogs {
-    create("libs") {
-      from(files("../gradle/libs.versions.toml"))
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
     }
-  }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }

--- a/build-logic/src/main/kotlin/yawn.detekt.gradle.kts
+++ b/build-logic/src/main/kotlin/yawn.detekt.gradle.kts
@@ -1,37 +1,36 @@
 import io.gitlab.arturbosch.detekt.Detekt
-import org.gradle.api.artifacts.VersionCatalogsExtension
 
 plugins {
-  java
-  kotlin("jvm")
-  id("io.gitlab.arturbosch.detekt")
+    java
+    kotlin("jvm")
+    id("io.gitlab.arturbosch.detekt")
 }
 
 detekt {
-  val rootConfig = rootProject.file("detekt.yaml")
-  if (rootConfig.exists()) config.from(rootConfig)
+    val rootConfig = rootProject.file("detekt.yaml")
+    if (rootConfig.exists()) config.from(rootConfig)
 
-  buildUponDefaultConfig = true
-  allRules = true
-  autoCorrect = true
-  parallel = true
+    buildUponDefaultConfig = true
+    allRules = true
+    autoCorrect = true
+    parallel = true
 }
 
 tasks.withType<Detekt>().configureEach {
-  reports {
-    xml.required.set(false)
-    html.required.set(true)
-    txt.required.set(false)
-    sarif.required.set(true)
-  }
-  exclude("**/build/**", "**/.gradle/**")
+    reports {
+        xml.required.set(false)
+        html.required.set(true)
+        txt.required.set(false)
+        sarif.required.set(true)
+    }
+    exclude("**/build/**", "**/.gradle/**")
 }
 
 tasks.named("check") { dependsOn("detekt") }
 
 val libsProvider = rootProject.extensions.getByType<VersionCatalogsExtension>().find("libs")
 dependencies {
-  val libs = libsProvider.get()
-  detektPlugins(libs.findLibrary("detekt-formatting").get())
-  detektPlugins(libs.findLibrary("faire-detekt-rules").get())
+    val libs = libsProvider.get()
+    detektPlugins(libs.findLibrary("detekt-formatting").get())
+    detektPlugins(libs.findLibrary("faire-detekt-rules").get())
 }

--- a/build-logic/src/main/kotlin/yawn.library.gradle.kts
+++ b/build-logic/src/main/kotlin/yawn.library.gradle.kts
@@ -1,6 +1,6 @@
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     id("yawn.kotlin")

--- a/detekt.yaml
+++ b/detekt.yaml
@@ -1,595 +1,595 @@
 complexity:
-  active: true
-  ComplexCondition:
     active: true
-    threshold: 9
-  ComplexInterface:
-    active: true
-    threshold: 64
-    includeStaticDeclarations: false
-  CyclomaticComplexMethod:
-    active: true
-    threshold: 180
-    ignoreSingleWhenExpression: false
-    ignoreSimpleWhenEntries: false
-  LabeledExpression:
-    active: false
-  LargeClass:
-    active: true
-    threshold: 1280
-  LongMethod:
-    active: true
-    threshold: 320
-    excludes:
-  LongParameterList:
-    active: false
-    ignoreDefaultParameters: false
-  MethodOverloading:
-    active: false
-    threshold: 6
-  NestedBlockDepth:
-    active: false
-    threshold: 4
-  StringLiteralDuplication:
-    active: false
-    threshold: 3
-    ignoreAnnotation: true
-    excludeStringsWithLessThan5Characters: true
-    ignoreStringsRegex: $^
-  TooManyFunctions:
-    active: false
-    thresholdInFiles: 11
-    thresholdInClasses: 11
-    thresholdInInterfaces: 11
-    thresholdInObjects: 11
-    thresholdInEnums: 11
-    ignoreDeprecated: false
-    ignorePrivate: false
+    ComplexCondition:
+        active: true
+        threshold: 9
+    ComplexInterface:
+        active: true
+        threshold: 64
+        includeStaticDeclarations: false
+    CyclomaticComplexMethod:
+        active: true
+        threshold: 180
+        ignoreSingleWhenExpression: false
+        ignoreSimpleWhenEntries: false
+    LabeledExpression:
+        active: false
+    LargeClass:
+        active: true
+        threshold: 1280
+    LongMethod:
+        active: true
+        threshold: 320
+        excludes:
+    LongParameterList:
+        active: false
+        ignoreDefaultParameters: false
+    MethodOverloading:
+        active: false
+        threshold: 6
+    NestedBlockDepth:
+        active: false
+        threshold: 4
+    StringLiteralDuplication:
+        active: false
+        threshold: 3
+        ignoreAnnotation: true
+        excludeStringsWithLessThan5Characters: true
+        ignoreStringsRegex: $^
+    TooManyFunctions:
+        active: false
+        thresholdInFiles: 11
+        thresholdInClasses: 11
+        thresholdInInterfaces: 11
+        thresholdInObjects: 11
+        thresholdInEnums: 11
+        ignoreDeprecated: false
+        ignorePrivate: false
 
 empty-blocks:
-  EmptyTryBlock:
-    active: true
-  EmptyCatchBlock:
-    active: true
-    allowedExceptionNameRegex: ^(_|(ignore|expected).*)
-  EmptyClassBlock:
-    active: true
-  EmptyDefaultConstructor:
-    active: true
-  EmptyDoWhileBlock:
-    active: true
-  EmptyElseBlock:
-    active: true
-  EmptyFinallyBlock:
-    active: true
-  EmptyForBlock:
-    active: true
-  EmptyFunctionBlock:
-    active: true
-    ignoreOverridden: true
-  EmptyIfBlock:
-    active: true
-  EmptyInitBlock:
-    active: true
-  EmptyKtFile:
-    active: true
-    excludes: ["**/build.gradle.kts"]
-  EmptySecondaryConstructor:
-    active: true
-  EmptyWhenBlock:
-    active: true
-  EmptyWhileBlock:
-    active: true
+    EmptyTryBlock:
+        active: true
+    EmptyCatchBlock:
+        active: true
+        allowedExceptionNameRegex: ^(_|(ignore|expected).*)
+    EmptyClassBlock:
+        active: true
+    EmptyDefaultConstructor:
+        active: true
+    EmptyDoWhileBlock:
+        active: true
+    EmptyElseBlock:
+        active: true
+    EmptyFinallyBlock:
+        active: true
+    EmptyForBlock:
+        active: true
+    EmptyFunctionBlock:
+        active: true
+        ignoreOverridden: true
+    EmptyIfBlock:
+        active: true
+    EmptyInitBlock:
+        active: true
+    EmptyKtFile:
+        active: true
+        excludes: ["**/build.gradle.kts"]
+    EmptySecondaryConstructor:
+        active: true
+    EmptyWhenBlock:
+        active: true
+    EmptyWhileBlock:
+        active: true
 
 exceptions:
-  active: false
+    active: false
 
 FaireRuleSet:
-  active: true
-  AlwaysUseIsTrueOrIsFalse:
     active: true
-    autoCorrect: true
-  DoNotAccessVisibleForTesting:
-    active: true
-    excludes: ["**/*Test.kt"]
-  DoNotSplitByRegex:
-    active: true
-  DoNotUseDirectReceiverReferenceInsideWith:
-    active: true
-  DoNotUseHasSizeForEmptyListInAssert:
-    active: true
-    autoCorrect: true
-  DoNotUseIsEqualToWhenArgumentIsOne:
-    active: false # we use DoNotUseIsOneAssertions instead
-  DoNotUseIsOneAssertions:
-    active: true
-    autoCorrect: true
-  DoNotUseIsEqualToWhenArgumentIsZero:
-    active: false # we use DoNotUseIsZeroAssertions instead
-  DoNotUseIsZeroAssertions:
-    active: true
-    autoCorrect: true
-  DoNotUsePropertyAccessInAssert:
-    active: true
-    autoCorrect: true
-  DoNotUseSingleOnFilter:
-    active: true
-    autoCorrect: true
-  DoNotUseSizePropertyInAssert:
-    active: true
-  GetOrDefaultShouldBeReplacedWithGetOrElse:
-    active: true
-  NoDuplicateKeysInMapOf:
-    active: true
-  NoExtensionFunctionOnNullableReceiver:
-    active: true
-  NoNonPrivateGlobalVariables:
-    active: true
-  NoNullableLambdaWithDefaultNull:
-    active: true
-  NoPairWithAmbiguousTypes:
-    active: true
-  PreferIgnoreCase:
-    active: true
-    autoCorrect: true
-  PreventBannedImports:
-    # until we have an import to prevent, just disable this rule
-    active: false
-    autoCorrect: true
-  ReturnValueOfLetMustBeUsed:
-    active: true
-  UseEntriesInsteadOfValuesOnEnum:
-    active: true
-  UseFirstOrNullInsteadOfFind:
-    active: true
-    autoCorrect: true
-  UseMapNotNullInsteadOfFilterNotNull:
-    active: true
-    autoCorrect: true
-  UseOfCollectionInsteadOfEmptyCollection:
-    active: true
-    autoCorrect: true
-  UseSetInsteadOfListToSet:
-    active: true
-    autoCorrect: true
+    AlwaysUseIsTrueOrIsFalse:
+        active: true
+        autoCorrect: true
+    DoNotAccessVisibleForTesting:
+        active: true
+        excludes: ["**/*Test.kt"]
+    DoNotSplitByRegex:
+        active: true
+    DoNotUseDirectReceiverReferenceInsideWith:
+        active: true
+    DoNotUseHasSizeForEmptyListInAssert:
+        active: true
+        autoCorrect: true
+    DoNotUseIsEqualToWhenArgumentIsOne:
+        active: false # we use DoNotUseIsOneAssertions instead
+    DoNotUseIsOneAssertions:
+        active: true
+        autoCorrect: true
+    DoNotUseIsEqualToWhenArgumentIsZero:
+        active: false # we use DoNotUseIsZeroAssertions instead
+    DoNotUseIsZeroAssertions:
+        active: true
+        autoCorrect: true
+    DoNotUsePropertyAccessInAssert:
+        active: true
+        autoCorrect: true
+    DoNotUseSingleOnFilter:
+        active: true
+        autoCorrect: true
+    DoNotUseSizePropertyInAssert:
+        active: true
+    GetOrDefaultShouldBeReplacedWithGetOrElse:
+        active: true
+    NoDuplicateKeysInMapOf:
+        active: true
+    NoExtensionFunctionOnNullableReceiver:
+        active: true
+    NoNonPrivateGlobalVariables:
+        active: true
+    NoNullableLambdaWithDefaultNull:
+        active: true
+    NoPairWithAmbiguousTypes:
+        active: true
+    PreferIgnoreCase:
+        active: true
+        autoCorrect: true
+    PreventBannedImports:
+        # until we have an import to prevent, just disable this rule
+        active: false
+        autoCorrect: true
+    ReturnValueOfLetMustBeUsed:
+        active: true
+    UseEntriesInsteadOfValuesOnEnum:
+        active: true
+    UseFirstOrNullInsteadOfFind:
+        active: true
+        autoCorrect: true
+    UseMapNotNullInsteadOfFilterNotNull:
+        active: true
+        autoCorrect: true
+    UseOfCollectionInsteadOfEmptyCollection:
+        active: true
+        autoCorrect: true
+    UseSetInsteadOfListToSet:
+        active: true
+        autoCorrect: true
 
 formatting:
-  active: true
-  android: false
-  autoCorrect: true
-  AnnotationOnSeparateLine:
-    active: false
-  AnnotationSpacing:
-    active: false
-  ArgumentListWrapping:
-    active: false
-  ChainWrapping:
-    active: false
+    active: true
+    android: false
     autoCorrect: true
-  CommentSpacing:
-    active: true
-    autoCorrect: true
-  EnumEntryNameCase:
-    active: true
-    ignoreAnnotated: [kotlin.Deprecated]
-  # Use MatchingDeclarationName instead.
-  Filename:
-    active: false
-  FinalNewline:
-    active: true
-    autoCorrect: true
-  ImportOrdering:
-    active: true
-    autoCorrect: true
-  Indentation:
-    active: false
-    autoCorrect: true
-    indentSize: 4
-  # Use MaxLineLength instead.
-  MaximumLineLength:
-    active: false
-    maxLineLength: 120
-  ModifierOrdering:
-    active: true
-    autoCorrect: true
-  MultiLineIfElse:
-    active: true
-    autoCorrect: true
-  NoAnonymousArgumentAfterNamedArguments:
-    active: true
-  NoBlankLineBeforeRbrace:
-    active: true
-    autoCorrect: true
-  NoConsecutiveBlankLines:
-    active: true
-    autoCorrect: true
-  NoCreateWithPrefix:
-    active: true
-  NoEmptyClassBody:
-    active: true
-    autoCorrect: true
-  NoEmptyFirstLineInMethodBlock:
-    active: true
-  NoLineBreakAfterElse:
-    active: true
-    autoCorrect: true
-  NoLineBreakBeforeAssignment:
-    active: true
-    autoCorrect: true
-  NoMultipleSpaces:
-    active: true
-    autoCorrect: true
-  NoSemicolons:
-    active: true
-    autoCorrect: true
-  NoTrailingSpaces:
-    active: true
-    autoCorrect: true
-  NoUnitReturn:
-    active: true
-    autoCorrect: true
-  NoUnusedImports:
-    active: true
-    autoCorrect: true
-  NoWildcardImports:
-    active: true
-    autoCorrect: true
-  PackageName:
-    active: false
-    autoCorrect: true
-  ParameterListWrapping:
-    active: true
-    autoCorrect: true
-  SpacingAroundAngleBrackets:
-    active: true
-    autoCorrect: true
-  SpacingAroundColon:
-    active: true
-    autoCorrect: true
-  SpacingAroundComma:
-    active: true
-    autoCorrect: true
-  SpacingAroundCurly:
-    active: true
-    autoCorrect: true
-  SpacingAroundKeyword:
-    active: true
-    autoCorrect: true
-  SpacingAroundOperators:
-    active: true
-    autoCorrect: true
-  SpacingAroundParens:
-    active: true
-    autoCorrect: true
-  SpacingAroundRangeOperator:
-    active: true
-    autoCorrect: true
-  SpacingBetweenDeclarationsWithAnnotations:
-    active: false
-  SpacingBetweenDeclarationsWithComments:
-    active: false
-  StringTemplate:
-    active: true
-    autoCorrect: true
-  TrailingCommaOnCallSite:
-    active: true
-    autoCorrect: true
-  TrailingCommaOnDeclarationSite:
-    active: true
-    autoCorrect: true
-  Wrapping:
-    active: true
-  UnnecessaryParenthesesBeforeTrailingLambda:
-    active: true
-  PropertyWrapping:
-    active: true
-    excludes:
-      - "**/*Test.kt"
-  FunctionReturnTypeSpacing:
-    active: true
-  BlockCommentInitialStarAlignment:
-    active: true
-  CommentWrapping:
-    active: true
+    AnnotationOnSeparateLine:
+        active: false
+    AnnotationSpacing:
+        active: false
+    ArgumentListWrapping:
+        active: false
+    ChainWrapping:
+        active: false
+        autoCorrect: true
+    CommentSpacing:
+        active: true
+        autoCorrect: true
+    EnumEntryNameCase:
+        active: true
+        ignoreAnnotated: [kotlin.Deprecated]
+    # Use MatchingDeclarationName instead.
+    Filename:
+        active: false
+    FinalNewline:
+        active: true
+        autoCorrect: true
+    ImportOrdering:
+        active: true
+        autoCorrect: true
+    Indentation:
+        active: true
+        autoCorrect: true
+        indentSize: 4
+    # Use MaxLineLength instead.
+    MaximumLineLength:
+        active: false
+        maxLineLength: 160
+    ModifierOrdering:
+        active: true
+        autoCorrect: true
+    MultiLineIfElse:
+        active: true
+        autoCorrect: true
+    NoAnonymousArgumentAfterNamedArguments:
+        active: true
+    NoBlankLineBeforeRbrace:
+        active: true
+        autoCorrect: true
+    NoConsecutiveBlankLines:
+        active: true
+        autoCorrect: true
+    NoCreateWithPrefix:
+        active: true
+    NoEmptyClassBody:
+        active: true
+        autoCorrect: true
+    NoEmptyFirstLineInMethodBlock:
+        active: true
+    NoLineBreakAfterElse:
+        active: true
+        autoCorrect: true
+    NoLineBreakBeforeAssignment:
+        active: true
+        autoCorrect: true
+    NoMultipleSpaces:
+        active: true
+        autoCorrect: true
+    NoSemicolons:
+        active: true
+        autoCorrect: true
+    NoTrailingSpaces:
+        active: true
+        autoCorrect: true
+    NoUnitReturn:
+        active: true
+        autoCorrect: true
+    NoUnusedImports:
+        active: true
+        autoCorrect: true
+    NoWildcardImports:
+        active: true
+        autoCorrect: true
+    PackageName:
+        active: false
+        autoCorrect: true
+    ParameterListWrapping:
+        active: true
+        autoCorrect: true
+    SpacingAroundAngleBrackets:
+        active: true
+        autoCorrect: true
+    SpacingAroundColon:
+        active: true
+        autoCorrect: true
+    SpacingAroundComma:
+        active: true
+        autoCorrect: true
+    SpacingAroundCurly:
+        active: true
+        autoCorrect: true
+    SpacingAroundKeyword:
+        active: true
+        autoCorrect: true
+    SpacingAroundOperators:
+        active: true
+        autoCorrect: true
+    SpacingAroundParens:
+        active: true
+        autoCorrect: true
+    SpacingAroundRangeOperator:
+        active: true
+        autoCorrect: true
+    SpacingBetweenDeclarationsWithAnnotations:
+        active: false
+    SpacingBetweenDeclarationsWithComments:
+        active: false
+    StringTemplate:
+        active: true
+        autoCorrect: true
+    TrailingCommaOnCallSite:
+        active: true
+        autoCorrect: true
+    TrailingCommaOnDeclarationSite:
+        active: true
+        autoCorrect: true
+    Wrapping:
+        active: true
+    UnnecessaryParenthesesBeforeTrailingLambda:
+        active: true
+    PropertyWrapping:
+        active: true
+        excludes:
+            - "**/*Test.kt"
+    FunctionReturnTypeSpacing:
+        active: true
+    BlockCommentInitialStarAlignment:
+        active: true
+    CommentWrapping:
+        active: true
 
 naming:
-  active: true
-  ClassNaming:
     active: true
-    classPattern: "[A-Z$][a-zA-Z0-9$]*"
-  ConstructorParameterNaming:
-    active: false
-    parameterPattern: "[a-z][A-Za-z0-9]*"
-    privateParameterPattern: "[a-z][A-Za-z0-9]*"
-    excludeClassPattern: $^
-  EnumNaming:
-    active: false
-    enumEntryPattern: ^[A-Z][_a-zA-Z0-9]*
-  ForbiddenClassName:
-    active: false
-  FunctionMaxLength:
-    active: false
-    maximumFunctionNameLength: 30
-  FunctionMinLength:
-    active: false
-    minimumFunctionNameLength: 3
-  FunctionNaming:
-    active: false
-    functionPattern: ^([a-z$][a-zA-Z$0-9]*)|(`.*`)$
-    excludeClassPattern: $^
-  FunctionParameterNaming:
-    active: false
-    parameterPattern: "[a-z][A-Za-z0-9]*"
-    excludeClassPattern: $^
-  InvalidPackageDeclaration:
-    active: true
-  MatchingDeclarationName:
-    active: true
-  MemberNameEqualsClassName:
-    active: false
-    ignoreOverridden: true
-  NoNameShadowing:
-    active: true
-  ObjectPropertyNaming:
-    active: true
-    constantPattern: "[A-Za-z][_A-Za-z0-9]*"
-    propertyPattern: "[A-Za-z][_A-Za-z0-9]*"
-    privatePropertyPattern: (_)?[A-Za-z][_A-Za-z0-9]*
-  PackageNaming:
-    active: true
-    packagePattern: ^[a-z]+(\.[a-z][a-zA-Z0-9_]*)*$
-  TopLevelPropertyNaming:
-    active: false
-    constantPattern: "[A-Z][_A-Z0-9]*"
-    propertyPattern: "[A-Za-z][_A-Za-z0-9]*"
-    privatePropertyPattern: (_)?[A-Za-z][A-Za-z0-9]*
-  VariableMaxLength:
-    active: false
-    maximumVariableNameLength: 64
-  VariableMinLength:
-    active: false
-    minimumVariableNameLength: 1
-  VariableNaming:
-    active: false
-    variablePattern: "[a-z][A-Za-z0-9]*"
-    privateVariablePattern: (_)?[a-z][A-Za-z0-9]*
-    excludeClassPattern: $^
+    ClassNaming:
+        active: true
+        classPattern: "[A-Z$][a-zA-Z0-9$]*"
+    ConstructorParameterNaming:
+        active: false
+        parameterPattern: "[a-z][A-Za-z0-9]*"
+        privateParameterPattern: "[a-z][A-Za-z0-9]*"
+        excludeClassPattern: $^
+    EnumNaming:
+        active: false
+        enumEntryPattern: ^[A-Z][_a-zA-Z0-9]*
+    ForbiddenClassName:
+        active: false
+    FunctionMaxLength:
+        active: false
+        maximumFunctionNameLength: 30
+    FunctionMinLength:
+        active: false
+        minimumFunctionNameLength: 3
+    FunctionNaming:
+        active: false
+        functionPattern: ^([a-z$][a-zA-Z$0-9]*)|(`.*`)$
+        excludeClassPattern: $^
+    FunctionParameterNaming:
+        active: false
+        parameterPattern: "[a-z][A-Za-z0-9]*"
+        excludeClassPattern: $^
+    InvalidPackageDeclaration:
+        active: true
+    MatchingDeclarationName:
+        active: true
+    MemberNameEqualsClassName:
+        active: false
+        ignoreOverridden: true
+    NoNameShadowing:
+        active: true
+    ObjectPropertyNaming:
+        active: true
+        constantPattern: "[A-Za-z][_A-Za-z0-9]*"
+        propertyPattern: "[A-Za-z][_A-Za-z0-9]*"
+        privatePropertyPattern: (_)?[A-Za-z][_A-Za-z0-9]*
+    PackageNaming:
+        active: true
+        packagePattern: ^[a-z]+(\.[a-z][a-zA-Z0-9_]*)*$
+    TopLevelPropertyNaming:
+        active: false
+        constantPattern: "[A-Z][_A-Z0-9]*"
+        propertyPattern: "[A-Za-z][_A-Za-z0-9]*"
+        privatePropertyPattern: (_)?[A-Za-z][A-Za-z0-9]*
+    VariableMaxLength:
+        active: false
+        maximumVariableNameLength: 64
+    VariableMinLength:
+        active: false
+        minimumVariableNameLength: 1
+    VariableNaming:
+        active: false
+        variablePattern: "[a-z][A-Za-z0-9]*"
+        privateVariablePattern: (_)?[a-z][A-Za-z0-9]*
+        excludeClassPattern: $^
 
 performance:
-  ArrayPrimitive:
-    active: true
-  CouldBeSequence:
-    active: true
-  ForEachOnRange:
-    active: true
-  SpreadOperator:
-    active: false
-  UnnecessaryTemporaryInstantiation:
-    active: true
+    ArrayPrimitive:
+        active: true
+    CouldBeSequence:
+        active: true
+    ForEachOnRange:
+        active: true
+    SpreadOperator:
+        active: false
+    UnnecessaryTemporaryInstantiation:
+        active: true
 
 potential-bugs:
-  active: true
-  AvoidReferentialEquality:
     active: true
-  CastToNullableType:
-    active: false
-  DoubleMutabilityForCollection:
-    active: false
-  EqualsAlwaysReturnsTrueOrFalse:
-    active: true
-  EqualsWithHashCodeExist:
-    active: false
-  ExplicitGarbageCollectionCall:
-    active: true
-  HasPlatformType:
-    active: true
-    excludes: ["**/*Test.kt"]
-  IgnoredReturnValue:
-    active: true
-  ImplicitDefaultLocale:
-    active: false
-  InvalidRange:
-    active: true
-  IteratorHasNextCallsNextMethod:
-    active: false
-  IteratorNotThrowingNoSuchElementException:
-    active: false
-  LateinitUsage:
-    active: false
-    ignoreAnnotated: [""]
-    ignoreOnClassesPattern: ""
-  MapGetWithNotNullAssertionOperator:
-    active: true
-  MissingPackageDeclaration:
-    active: true
-  UnconditionalJumpStatementInLoop:
-    active: false
-  UnnecessaryNotNullOperator:
-    active: true
-  UnnecessarySafeCall:
-    active: true
-  UnreachableCode:
-    active: true
-  UnsafeCallOnNullableType:
-    active: false
-  UnsafeCast:
-    active: false
-  UselessPostfixExpression:
-    active: true
-  WrongEqualsTypeParameter:
-    active: true
+    AvoidReferentialEquality:
+        active: true
+    CastToNullableType:
+        active: false
+    DoubleMutabilityForCollection:
+        active: false
+    EqualsAlwaysReturnsTrueOrFalse:
+        active: true
+    EqualsWithHashCodeExist:
+        active: false
+    ExplicitGarbageCollectionCall:
+        active: true
+    HasPlatformType:
+        active: true
+        excludes: ["**/*Test.kt"]
+    IgnoredReturnValue:
+        active: true
+    ImplicitDefaultLocale:
+        active: false
+    InvalidRange:
+        active: true
+    IteratorHasNextCallsNextMethod:
+        active: false
+    IteratorNotThrowingNoSuchElementException:
+        active: false
+    LateinitUsage:
+        active: false
+        ignoreAnnotated: [""]
+        ignoreOnClassesPattern: ""
+    MapGetWithNotNullAssertionOperator:
+        active: true
+    MissingPackageDeclaration:
+        active: true
+    UnconditionalJumpStatementInLoop:
+        active: false
+    UnnecessaryNotNullOperator:
+        active: true
+    UnnecessarySafeCall:
+        active: true
+    UnreachableCode:
+        active: true
+    UnsafeCallOnNullableType:
+        active: false
+    UnsafeCast:
+        active: false
+    UselessPostfixExpression:
+        active: true
+    WrongEqualsTypeParameter:
+        active: true
 
 style:
-  active: true
-  ClassOrdering:
-    active: false
-  CollapsibleIfStatements:
-    active: false
-  DataClassContainsFunctions:
-    active: false
-    conversionFunctionPrefix: [to]
-  DataClassShouldBeImmutable:
-    active: false
-  DestructuringDeclarationWithTooManyEntries:
-    active: false
-  EqualsNullCall:
     active: true
-  EqualsOnSignatureLine:
-    active: false
-  ExplicitItLambdaParameter:
-    active: true
-  ExpressionBodySyntax:
-    active: false
-    includeLineWrapping: false
-  ForbiddenComment:
-    active: false
-    comments:
-      - reason: ""
-        value: "TODO:"
-      - reason: ""
-        value: "FIXME:"
-      - reason: ""
-        value: "STOPSHIP:"
-  # We use PreventBannedImports instead which has autocorrect.
-  ForbiddenImport:
-    active: false
-    imports: []
-  ForbiddenMethodCall:
-    active: false
-  ForbiddenVoid:
-    active: false
-  FunctionOnlyReturningConstant:
-    active: false
-    ignoreOverridableFunction: true
-    excludedFunctions: [describeContents]
-  LoopWithTooManyJumpStatements:
-    active: false
-    maxJumpCount: 1
-  MagicNumber:
-    active: false
-    ignoreNumbers: ["-1", "0", "1", "2"]
-    ignoreHashCodeFunction: true
-    ignorePropertyDeclaration: false
-    ignoreConstantDeclaration: true
-    ignoreCompanionObjectPropertyDeclaration: true
-    ignoreAnnotation: false
-    ignoreNamedArgument: true
-    ignoreEnums: false
-  BracesOnIfStatements:
-    active: false
-    singleLine: always
-    multiLine: always
-  MaxLineLength:
-    active: true
-    maxLineLength: 120
-    excludePackageStatements: true
-    excludeImportStatements: true
-    excludeCommentStatements: false
-  MayBeConst:
-    active: false
-  ModifierOrder:
-    active: true
-  MultilineLambdaItParameter:
-    active: true
-  NestedClassesVisibility:
-    active: false
-  # Use FinalNewLine instead.
-  NewLineAtEndOfFile:
-    active: false
-  NoTabs:
-    active: false
-  ObjectLiteralToLambda:
-    active: true
-  OptionalAbstractKeyword:
-    active: true
-  OptionalUnit:
-    active: false
-  PreferToOverPairSyntax:
-    active: false
-  ProtectedMemberInFinalClass:
-    active: false
-  RedundantVisibilityModifierRule:
-    active: true
-  ReturnCount:
-    active: false
-    max: 2
-    excludedFunctions: [equals]
-    excludeLabeled: false
-    excludeReturnFromLambda: true
-  SafeCast:
-    active: true
-  SerialVersionUIDInSerializableClass:
-    active: false
-  SpacingBetweenPackageAndImports:
-    active: false
-  ThrowsCount:
-    active: false
-    max: 2
-  TrailingWhitespace:
-    active: true
-  UnnecessaryFilter:
-    active: true
-  UnderscoresInNumericLiterals:
-    active: false
-  UnnecessaryAbstractClass:
-    active: false
-    ignoreAnnotated: [dagger.Module]
-  UnnecessaryApply:
-    active: false
-  UnnecessaryInheritance:
-    active: false
-  UnnecessaryAnnotationUseSiteTarget:
-    active: false
-  UnnecessaryLet:
-    active: true
-  UnnecessaryParentheses:
-    active: false
-  UntilInsteadOfRangeTo:
-    active: false
-  UnusedImports:
-    # Has false positives with type resolution enabled. Redundant with NoUnusedImports rule.
-    active: false
-  UnusedPrivateClass:
-    active: false
-  UnusedPrivateMember:
-    active: true
-    allowedNames: (_|i|ignored|expected|serialVersionUID|session|module)
-  # Replaced by UseFirstOrNullInsteadOfFind
-  UseAnyOrNoneInsteadOfFind:
-    active: false
-  UseCheckNotNull:
-    active: true
-  UseCheckOrError:
-    active: false
-  UseDataClass:
-    active: false
-    ignoreAnnotated: [""]
-  UseIfInsteadOfWhen:
-    active: false
-  UseIsNullOrEmpty:
-    active: true
-  UseOrEmpty:
-    active: true
-  UseRequire:
-    active: true
-  UseRequireNotNull:
-    active: true
-  UselessCallOnNotNull:
-    active: true
-  UtilityClassWithPublicConstructor:
-    active: false
-  VarCouldBeVal:
-    active: true
-    ignoreAnnotated: [Column, Inject, JoinColumn, OneToMany, Parameter]
-  WildcardImport:
-    active: true
-    excludeImports: [java.util.*, kotlinx.android.synthetic.*]
-  UnusedPrivateProperty:
-    active: true
-    allowedNames: _|ignored|expected|serialVersionUID|module|i|gson|env
-  UnusedParameter:
-    active: true
-    allowedNames: session|witness
+    ClassOrdering:
+        active: false
+    CollapsibleIfStatements:
+        active: false
+    DataClassContainsFunctions:
+        active: false
+        conversionFunctionPrefix: [to]
+    DataClassShouldBeImmutable:
+        active: false
+    DestructuringDeclarationWithTooManyEntries:
+        active: false
+    EqualsNullCall:
+        active: true
+    EqualsOnSignatureLine:
+        active: false
+    ExplicitItLambdaParameter:
+        active: true
+    ExpressionBodySyntax:
+        active: false
+        includeLineWrapping: false
+    ForbiddenComment:
+        active: false
+        comments:
+            -   reason: ""
+                value: "TODO:"
+            -   reason: ""
+                value: "FIXME:"
+            -   reason: ""
+                value: "STOPSHIP:"
+    # We use PreventBannedImports instead which has autocorrect.
+    ForbiddenImport:
+        active: false
+        imports: []
+    ForbiddenMethodCall:
+        active: false
+    ForbiddenVoid:
+        active: false
+    FunctionOnlyReturningConstant:
+        active: false
+        ignoreOverridableFunction: true
+        excludedFunctions: [describeContents]
+    LoopWithTooManyJumpStatements:
+        active: false
+        maxJumpCount: 1
+    MagicNumber:
+        active: false
+        ignoreNumbers: ["-1", "0", "1", "2"]
+        ignoreHashCodeFunction: true
+        ignorePropertyDeclaration: false
+        ignoreConstantDeclaration: true
+        ignoreCompanionObjectPropertyDeclaration: true
+        ignoreAnnotation: false
+        ignoreNamedArgument: true
+        ignoreEnums: false
+    BracesOnIfStatements:
+        active: false
+        singleLine: always
+        multiLine: always
+    MaxLineLength:
+        active: true
+        maxLineLength: 160
+        excludePackageStatements: true
+        excludeImportStatements: true
+        excludeCommentStatements: false
+    MayBeConst:
+        active: false
+    ModifierOrder:
+        active: true
+    MultilineLambdaItParameter:
+        active: true
+    NestedClassesVisibility:
+        active: false
+    # Use FinalNewLine instead.
+    NewLineAtEndOfFile:
+        active: false
+    NoTabs:
+        active: false
+    ObjectLiteralToLambda:
+        active: true
+    OptionalAbstractKeyword:
+        active: true
+    OptionalUnit:
+        active: false
+    PreferToOverPairSyntax:
+        active: false
+    ProtectedMemberInFinalClass:
+        active: false
+    RedundantVisibilityModifierRule:
+        active: true
+    ReturnCount:
+        active: false
+        max: 2
+        excludedFunctions: [equals]
+        excludeLabeled: false
+        excludeReturnFromLambda: true
+    SafeCast:
+        active: true
+    SerialVersionUIDInSerializableClass:
+        active: false
+    SpacingBetweenPackageAndImports:
+        active: false
+    ThrowsCount:
+        active: false
+        max: 2
+    TrailingWhitespace:
+        active: true
+    UnnecessaryFilter:
+        active: true
+    UnderscoresInNumericLiterals:
+        active: false
+    UnnecessaryAbstractClass:
+        active: false
+        ignoreAnnotated: [dagger.Module]
+    UnnecessaryApply:
+        active: false
+    UnnecessaryInheritance:
+        active: false
+    UnnecessaryAnnotationUseSiteTarget:
+        active: false
+    UnnecessaryLet:
+        active: true
+    UnnecessaryParentheses:
+        active: false
+    UntilInsteadOfRangeTo:
+        active: false
+    UnusedImports:
+        # Has false positives with type resolution enabled. Redundant with NoUnusedImports rule.
+        active: false
+    UnusedPrivateClass:
+        active: false
+    UnusedPrivateMember:
+        active: true
+        allowedNames: (_|i|ignored|expected|serialVersionUID|session|module)
+    # Replaced by UseFirstOrNullInsteadOfFind
+    UseAnyOrNoneInsteadOfFind:
+        active: false
+    UseCheckNotNull:
+        active: true
+    UseCheckOrError:
+        active: false
+    UseDataClass:
+        active: false
+        ignoreAnnotated: [""]
+    UseIfInsteadOfWhen:
+        active: false
+    UseIsNullOrEmpty:
+        active: true
+    UseOrEmpty:
+        active: true
+    UseRequire:
+        active: true
+    UseRequireNotNull:
+        active: true
+    UselessCallOnNotNull:
+        active: true
+    UtilityClassWithPublicConstructor:
+        active: false
+    VarCouldBeVal:
+        active: true
+        ignoreAnnotated: [Column, Inject, JoinColumn, OneToMany, Parameter]
+    WildcardImport:
+        active: true
+        excludeImports: [java.util.*, kotlinx.android.synthetic.*]
+    UnusedPrivateProperty:
+        active: true
+        allowedNames: _|ignored|expected|serialVersionUID|module|i|gson|env
+    UnusedParameter:
+        active: true
+        allowedNames: session|witness
 
 coroutines:
-  active: false
+    active: false

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,9 @@ org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
-
 # Kotlin optimizations
 kotlin.code.style=official
 kotlin.incremental=true
-
 # Yawn KSP processor configuration
 yawn.ksp.project=:yawn-processor
 

--- a/yawn-api/src/main/kotlin/com/faire/yawn/Yawn.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/Yawn.kt
@@ -16,39 +16,39 @@ import com.faire.yawn.query.YawnQueryFactory
 class Yawn(
     private val queryFactory: YawnQueryFactory,
 ) {
-  fun <T : Any, DEF : YawnTableDef<T, T>> query(
-      tClass: Class<T>,
-      tableRef: YawnTableRef<T, DEF>,
-      lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit = {},
-  ): TypeSafeCriteriaBuilder<T, DEF> {
-    val query = YawnQuery<T, T>(tClass)
-    val tableDef = tableRef.create(parent = RootTableDefParent)
-    return TypeSafeCriteriaBuilder.create(tableDef, queryFactory, query, lambda)
-  }
-
-  fun <T : Any, DEF : YawnTableDef<T, T>, PROJECTION : Any?> project(
-      tClass: Class<T>,
-      tableRef: YawnTableRef<T, DEF>,
-      lambda: ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(
-        tableDef: DEF,
-    ) -> YawnQueryProjection<T, PROJECTION>,
-  ): ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION> {
-    val query = YawnQuery<T, T>(tClass)
-    val tableDef = tableRef.create(parent = RootTableDefParent)
-    return ProjectedTypeSafeCriteriaBuilder.create(tableDef, queryFactory, query, lambda)
-  }
-
-  companion object {
-    inline fun <reified T : Any, DEF : YawnTableDef<T, T>, PROJECTION : Any?> createProjectedDetachedCriteria(
+    fun <T : Any, DEF : YawnTableDef<T, T>> query(
+        tClass: Class<T>,
         tableRef: YawnTableRef<T, DEF>,
-        noinline lambda:
-        ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(tableDef: DEF) -> YawnQueryProjection<T, PROJECTION>,
-    ): DetachedProjectedTypeSafeCriteriaBuilder<T, T, DEF, PROJECTION> {
-      val query = YawnQuery<T, T>(T::class.java)
-
-      @Suppress("UNCHECKED_CAST") // DEF is YawnTableDef<T, T>, so this cast is safe
-      val tableDef = tableRef.forSubQuery<T>() as DEF
-      return DetachedProjectedTypeSafeCriteriaBuilder.create(tableDef, query, lambda)
+        lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit = {},
+    ): TypeSafeCriteriaBuilder<T, DEF> {
+        val query = YawnQuery<T, T>(tClass)
+        val tableDef = tableRef.create(parent = RootTableDefParent)
+        return TypeSafeCriteriaBuilder.create(tableDef, queryFactory, query, lambda)
     }
-  }
+
+    fun <T : Any, DEF : YawnTableDef<T, T>, PROJECTION : Any?> project(
+        tClass: Class<T>,
+        tableRef: YawnTableRef<T, DEF>,
+        lambda: ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(
+            tableDef: DEF,
+        ) -> YawnQueryProjection<T, PROJECTION>,
+    ): ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION> {
+        val query = YawnQuery<T, T>(tClass)
+        val tableDef = tableRef.create(parent = RootTableDefParent)
+        return ProjectedTypeSafeCriteriaBuilder.create(tableDef, queryFactory, query, lambda)
+    }
+
+    companion object {
+        inline fun <reified T : Any, DEF : YawnTableDef<T, T>, PROJECTION : Any?> createProjectedDetachedCriteria(
+            tableRef: YawnTableRef<T, DEF>,
+            noinline lambda:
+            ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(tableDef: DEF) -> YawnQueryProjection<T, PROJECTION>,
+        ): DetachedProjectedTypeSafeCriteriaBuilder<T, T, DEF, PROJECTION> {
+            val query = YawnQuery<T, T>(T::class.java)
+
+            @Suppress("UNCHECKED_CAST") // DEF is YawnTableDef<T, T>, so this cast is safe
+            val tableDef = tableRef.forSubQuery<T>() as DEF
+            return DetachedProjectedTypeSafeCriteriaBuilder.create(tableDef, query, lambda)
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnDef.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnDef.kt
@@ -13,22 +13,22 @@ import org.hibernate.criterion.Projections
  * @param D the type of the entity or projection.
  */
 abstract class YawnDef<SOURCE : Any, D : Any> {
-  /**
-   * Base class for all Yawn Column-like definitions.
-   * This can be either a column from a table or a projection.
-   *
-   * @param F the type of the column.
-   */
-  abstract inner class YawnColumnDef<F> : YawnQueryProjection<SOURCE, F> {
-    abstract fun generatePath(context: YawnCompilationContext): String
+    /**
+     * Base class for all Yawn Column-like definitions.
+     * This can be either a column from a table or a projection.
+     *
+     * @param F the type of the column.
+     */
+    abstract inner class YawnColumnDef<F> : YawnQueryProjection<SOURCE, F> {
+        abstract fun generatePath(context: YawnCompilationContext): String
 
-    override fun compile(context: YawnCompilationContext): Projection {
-      return Projections.property(generatePath(context))
-    }
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.property(generatePath(context))
+        }
 
-    override fun project(value: Any?): F {
-      @Suppress("UNCHECKED_CAST")
-      return value as F
+        override fun project(value: Any?): F {
+            @Suppress("UNCHECKED_CAST")
+            return value as F
+        }
     }
-  }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDef.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDef.kt
@@ -18,153 +18,153 @@ abstract class YawnTableDef<SOURCE : Any, D : Any>(
     internal val parent: YawnTableDefParent,
 ) : YawnDef<SOURCE, D>() {
 
-  /**
-   * Base class for all Yawn embedded definitions.
-   * This class is automatically extended by KSP to generate the embedded definitions for you for all Yawn entities.
-   * Note that it can be treated as a column definition, as well as a container for sub-columns.
-   * Accessing this requires no joins.
-   *
-   * @param F the type of the embedded entity.
-   */
-  abstract inner class EmbeddedDef<F>(
-      private val rootPath: String?,
-      private val path: String,
-  ) : YawnColumnDef<F>() {
-    override fun generatePath(context: YawnCompilationContext): String {
-      return listOfNotNull(context.generateAlias(parent), rootPath, path).joinToString(".")
-    }
-  }
-
-  /**
-   * This is used by Yawn to represent the implicit join reference created by the usage of the @ElementCollection
-   * annotation.
-   * Note that the synthetic column name "elements" is employed by Hibernate to reference the relationship column.
-   */
-  inner class ElementCollectionDef<D : Any>(
-      parent: YawnTableDefParent,
-  ) : YawnTableDef<SOURCE, D>(parent) {
-    val elements: ColumnDef<D> = ColumnDef("elements")
-  }
-
-  /**
-   * Base class for all Yawn Column Definitions.
-   * This class is automatically extended by KSP to generate the column definitions for you for all Yawn entities.
-   *
-   * @param F the type of the column.
-   */
-  inner class ColumnDef<F>(private vararg val path: String?) : YawnColumnDef<F>() {
-    override fun generatePath(context: YawnCompilationContext): String {
-      return listOfNotNull(context.generateAlias(parent), *path).joinToString(".")
-    }
-  }
-
-  /**
-   * Base class for all Yawn Join Column Definitions.
-   *
-   * @param T the type of the entity class of the join table
-   * @param DEF the type definition (YawnTableDef) for T
-   */
-  open inner class JoinColumnDef<T : Any, DEF : YawnTableDef<SOURCE, T>>(
-      private val parent: YawnTableDefParent,
-      protected val name: String,
-      private val tableDefProvider: (YawnTableDefParent) -> DEF,
-  ) {
-    fun path(context: YawnCompilationContext): String {
-      return listOfNotNull(context.generateAlias(parent), name).joinToString(".")
+    /**
+     * Base class for all Yawn embedded definitions.
+     * This class is automatically extended by KSP to generate the embedded definitions for you for all Yawn entities.
+     * Note that it can be treated as a column definition, as well as a container for sub-columns.
+     * Accessing this requires no joins.
+     *
+     * @param F the type of the embedded entity.
+     */
+    abstract inner class EmbeddedDef<F>(
+        private val rootPath: String?,
+        private val path: String,
+    ) : YawnColumnDef<F>() {
+        override fun generatePath(context: YawnCompilationContext): String {
+            return listOfNotNull(context.generateAlias(parent), rootPath, path).joinToString(".")
+        }
     }
 
-    fun joinTableDef(parent: YawnTableDefParent): DEF {
-      return tableDefProvider(parent)
-    }
-  }
-
-  /**
-   * [JoinColumnDef] but for when there is a trackable foreign key reference.
-   * This is a base class that should not be used directly; use instead:
-   *
-   * * [JoinColumnDefWithForeignKey] for when the reference can be backed by an @Id.
-   * * [JoinColumnDefWithCompositeKey] for when the reference can be backed by an @EmbeddedId.
-   *
-   * @param T the type of the entity class of the join table
-   * @param DEF the type definition (YawnTableDef) for T
-   * @param REF the type of the reference
-   */
-  abstract inner class JoinColumnDefWithReference<T : Any, DEF : YawnTableDef<SOURCE, T>, REF>(
-      parent: YawnTableDefParent,
-      name: String,
-      private val foreignKeyProvider: (String) -> REF,
-      tableDefProvider: (YawnTableDefParent) -> DEF,
-  ) : JoinColumnDef<T, DEF>(
-      parent,
-      name,
-      tableDefProvider,
-  ),
-      YawnQueryProjection<SOURCE, T> {
-    val foreignKey: REF
-      get() = foreignKeyProvider(name)
-
-    override fun compile(context: YawnCompilationContext): Projection {
-      return Projections.property(path(context))
+    /**
+     * This is used by Yawn to represent the implicit join reference created by the usage of the @ElementCollection
+     * annotation.
+     * Note that the synthetic column name "elements" is employed by Hibernate to reference the relationship column.
+     */
+    inner class ElementCollectionDef<D : Any>(
+        parent: YawnTableDefParent,
+    ) : YawnTableDef<SOURCE, D>(parent) {
+        val elements: ColumnDef<D> = ColumnDef("elements")
     }
 
-    override fun project(value: Any?): T {
-      @Suppress("UNCHECKED_CAST")
-      return value as T
+    /**
+     * Base class for all Yawn Column Definitions.
+     * This class is automatically extended by KSP to generate the column definitions for you for all Yawn entities.
+     *
+     * @param F the type of the column.
+     */
+    inner class ColumnDef<F>(private vararg val path: String?) : YawnColumnDef<F>() {
+        override fun generatePath(context: YawnCompilationContext): String {
+            return listOfNotNull(context.generateAlias(parent), *path).joinToString(".")
+        }
     }
-  }
 
-  /**
-   * [JoinColumnDef] but for when the reference can be backed by an @Id.
-   *
-   * @param T the type of the entity class of the join table
-   * @param DEF the type definition (YawnTableDef) for T
-   * @param ID the type of the id of the joined entity class
-   */
-  inner class JoinColumnDefWithForeignKey<T : Any, DEF : YawnTableDef<SOURCE, T>, ID>(
-      parent: YawnTableDefParent,
-      name: String,
-      foreignKeyName: String,
-      tableDefProvider: (YawnTableDefParent) -> DEF,
-  ) : JoinColumnDefWithReference<T, DEF, ColumnDef<ID>>(
-      parent,
-      name,
-      { ColumnDef(it, foreignKeyName) },
-      tableDefProvider,
-  )
+    /**
+     * Base class for all Yawn Join Column Definitions.
+     *
+     * @param T the type of the entity class of the join table
+     * @param DEF the type definition (YawnTableDef) for T
+     */
+    open inner class JoinColumnDef<T : Any, DEF : YawnTableDef<SOURCE, T>>(
+        private val parent: YawnTableDefParent,
+        protected val name: String,
+        private val tableDefProvider: (YawnTableDefParent) -> DEF,
+    ) {
+        fun path(context: YawnCompilationContext): String {
+            return listOfNotNull(context.generateAlias(parent), name).joinToString(".")
+        }
 
-  /**
-   * [JoinColumnDef] but for when the reference can be backed by an @EmbeddedId.
-   *
-   * @param T the type of the entity class of the join table
-   * @param DEF the type definition (YawnTableDef) for T
-   * @param CID the type of the composite key id of the joined entity class
-   */
-  inner class JoinColumnDefWithCompositeKey<
-      T : Any,
-      DEF : YawnTableDef<SOURCE, T>,
-      CID : YawnTableDef<SOURCE, T>.EmbeddedDef<*>,
-      >(
-      parent: YawnTableDefParent,
-      name: String,
-      foreignKeyProvider: (String) -> CID,
-      tableDefProvider: (YawnTableDefParent) -> DEF,
-  ) : JoinColumnDefWithReference<T, DEF, CID>(
-      parent,
-      name,
-      foreignKeyProvider,
-      tableDefProvider,
-  )
+        fun joinTableDef(parent: YawnTableDefParent): DEF {
+            return tableDefProvider(parent)
+        }
+    }
 
-  /**
-   * Class to represent OneToMany and ManyToMany relations.
-   * Extends [JoinColumnDef]
-   *
-   * @param T the type of the entity class of the join table which is the type of the generic of the collection.
-   * @param DEF the type definition (YawnTableDef) for T
-   */
-  inner class CollectionJoinColumnDef<T : Any, DEF : YawnTableDef<SOURCE, T>>(
-      parent: YawnTableDefParent,
-      name: String,
-      tableDefProvider: (YawnTableDefParent) -> DEF,
-  ) : JoinColumnDef<T, DEF>(parent, name, tableDefProvider)
+    /**
+     * [JoinColumnDef] but for when there is a trackable foreign key reference.
+     * This is a base class that should not be used directly; use instead:
+     *
+     * * [JoinColumnDefWithForeignKey] for when the reference can be backed by an @Id.
+     * * [JoinColumnDefWithCompositeKey] for when the reference can be backed by an @EmbeddedId.
+     *
+     * @param T the type of the entity class of the join table
+     * @param DEF the type definition (YawnTableDef) for T
+     * @param REF the type of the reference
+     */
+    abstract inner class JoinColumnDefWithReference<T : Any, DEF : YawnTableDef<SOURCE, T>, REF>(
+        parent: YawnTableDefParent,
+        name: String,
+        private val foreignKeyProvider: (String) -> REF,
+        tableDefProvider: (YawnTableDefParent) -> DEF,
+    ) : JoinColumnDef<T, DEF>(
+        parent,
+        name,
+        tableDefProvider,
+    ),
+        YawnQueryProjection<SOURCE, T> {
+        val foreignKey: REF
+            get() = foreignKeyProvider(name)
+
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.property(path(context))
+        }
+
+        override fun project(value: Any?): T {
+            @Suppress("UNCHECKED_CAST")
+            return value as T
+        }
+    }
+
+    /**
+     * [JoinColumnDef] but for when the reference can be backed by an @Id.
+     *
+     * @param T the type of the entity class of the join table
+     * @param DEF the type definition (YawnTableDef) for T
+     * @param ID the type of the id of the joined entity class
+     */
+    inner class JoinColumnDefWithForeignKey<T : Any, DEF : YawnTableDef<SOURCE, T>, ID>(
+        parent: YawnTableDefParent,
+        name: String,
+        foreignKeyName: String,
+        tableDefProvider: (YawnTableDefParent) -> DEF,
+    ) : JoinColumnDefWithReference<T, DEF, ColumnDef<ID>>(
+        parent,
+        name,
+        { ColumnDef(it, foreignKeyName) },
+        tableDefProvider,
+    )
+
+    /**
+     * [JoinColumnDef] but for when the reference can be backed by an @EmbeddedId.
+     *
+     * @param T the type of the entity class of the join table
+     * @param DEF the type definition (YawnTableDef) for T
+     * @param CID the type of the composite key id of the joined entity class
+     */
+    inner class JoinColumnDefWithCompositeKey<
+        T : Any,
+        DEF : YawnTableDef<SOURCE, T>,
+        CID : YawnTableDef<SOURCE, T>.EmbeddedDef<*>,
+        >(
+        parent: YawnTableDefParent,
+        name: String,
+        foreignKeyProvider: (String) -> CID,
+        tableDefProvider: (YawnTableDefParent) -> DEF,
+    ) : JoinColumnDefWithReference<T, DEF, CID>(
+        parent,
+        name,
+        foreignKeyProvider,
+        tableDefProvider,
+    )
+
+    /**
+     * Class to represent OneToMany and ManyToMany relations.
+     * Extends [JoinColumnDef]
+     *
+     * @param T the type of the entity class of the join table which is the type of the generic of the collection.
+     * @param DEF the type definition (YawnTableDef) for T
+     */
+    inner class CollectionJoinColumnDef<T : Any, DEF : YawnTableDef<SOURCE, T>>(
+        parent: YawnTableDefParent,
+        name: String,
+        tableDefProvider: (YawnTableDefParent) -> DEF,
+    ) : JoinColumnDef<T, DEF>(parent, name, tableDefProvider)
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDefParent.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDefParent.kt
@@ -11,39 +11,39 @@ private const val ROOT_ALIAS = "root"
  * parent containing the column used to join to it. This allows us to build a tree structure for compilation.
  */
 interface YawnTableDefParent {
-  /**
-   * Returns a base string to use for generating aliases for the table definition.
-   */
-  fun getAliasBaseString(context: YawnCompilationContext): String?
+    /**
+     * Returns a base string to use for generating aliases for the table definition.
+     */
+    fun getAliasBaseString(context: YawnCompilationContext): String?
 
-  /**
-   * To be used for the root query being compiled
-   */
-  object RootTableDefParent : YawnTableDefParent {
-    override fun getAliasBaseString(context: YawnCompilationContext): String? {
-      /**
-       * Hibernate can occasionally break with root aliases, but they're necessary for correlated subqueries, so
-       * we only generate a root alias if we need to.
-       */
-      return if (context.withSubQuery) ROOT_ALIAS else null
+    /**
+     * To be used for the root query being compiled
+     */
+    object RootTableDefParent : YawnTableDefParent {
+        override fun getAliasBaseString(context: YawnCompilationContext): String? {
+            /**
+             * Hibernate can occasionally break with root aliases, but they're necessary for correlated subqueries, so
+             * we only generate a root alias if we need to.
+             */
+            return if (context.withSubQuery) ROOT_ALIAS else null
+        }
     }
-  }
 
-  /**
-   * To be used to generate aliases for sub queries
-   */
-  class SubqueryTableDefParent(val tableName: String) : YawnTableDefParent {
-    override fun getAliasBaseString(context: YawnCompilationContext): String? = tableName
-  }
-
-  /**
-   * To be used for association parents
-   */
-  class AssociationTableDefParent(
-      val parentColumnDef: YawnTableDef<*, *>.JoinColumnDef<*, *>,
-  ) : YawnTableDefParent {
-    override fun getAliasBaseString(context: YawnCompilationContext): String? {
-      return parentColumnDef.path(context)
+    /**
+     * To be used to generate aliases for sub queries
+     */
+    class SubqueryTableDefParent(val tableName: String) : YawnTableDefParent {
+        override fun getAliasBaseString(context: YawnCompilationContext): String? = tableName
     }
-  }
+
+    /**
+     * To be used for association parents
+     */
+    class AssociationTableDefParent(
+        val parentColumnDef: YawnTableDef<*, *>.JoinColumnDef<*, *>,
+    ) : YawnTableDefParent {
+        override fun getAliasBaseString(context: YawnCompilationContext): String? {
+            return parentColumnDef.path(context)
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableRef.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableRef.kt
@@ -5,7 +5,7 @@ package com.faire.yawn
  * It allows Yawn to create table definitions [DEF] representing the given entity [T].
  */
 interface YawnTableRef<T : Any, DEF : YawnTableDef<T, T>> : YawnRef<T, DEF> {
-  fun create(parent: YawnTableDefParent): DEF
+    fun create(parent: YawnTableDefParent): DEF
 
-  fun <PARENT_SOURCE : Any> forSubQuery(): YawnTableDef<PARENT_SOURCE, T>
+    fun <PARENT_SOURCE : Any> forSubQuery(): YawnTableDef<PARENT_SOURCE, T>
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
@@ -40,100 +40,100 @@ abstract class BaseTypeSafeCriteriaBuilder<
     // are no projections. while for uniqueResult we always need apply the cast, for the list we could
     // potentially skip an iteration.
     protected var mapper: (Any?) -> RETURNS = { value ->
-      @Suppress("UNCHECKED_CAST")
-      value as RETURNS
+        @Suppress("UNCHECKED_CAST")
+        value as RETURNS
     },
 ) {
-  /**
-   * Following the "builder" pattern, each method on the various TypedCriteriaBuilders returns itself.
-   * However, since we have an inheritance chain, in order for the type to match what you had before, we need this
-   * override.
-   * This should always just return `this`, but will ensure the correct [CRITERIA] typing.
-   */
-  protected abstract fun builderReturn(): CRITERIA
+    /**
+     * Following the "builder" pattern, each method on the various TypedCriteriaBuilders returns itself.
+     * However, since we have an inheritance chain, in order for the type to match what you had before, we need this
+     * override.
+     * This should always just return `this`, but will ensure the correct [CRITERIA] typing.
+     */
+    protected abstract fun builderReturn(): CRITERIA
 
-  /**
-   * The various TypedCriteriaBuilders are mutable, which means changes are accumulated within the instance.
-   * If you want to run two different queries with the same base, you can either create e method that returns
-   * a new "base" instance each time, or, if you already have the instance, you can use the clone method.
-   * Note that this relies on the data class `copy()` method being correctly implemented in the underlying
-   * [YawnQuery] class.
-   */
-  protected abstract fun clone(): CRITERIA
+    /**
+     * The various TypedCriteriaBuilders are mutable, which means changes are accumulated within the instance.
+     * If you want to run two different queries with the same base, you can either create e method that returns
+     * a new "base" instance each time, or, if you already have the instance, you can use the clone method.
+     * Note that this relies on the data class `copy()` method being correctly implemented in the underlying
+     * [YawnQuery] class.
+     */
+    protected abstract fun clone(): CRITERIA
 
-  fun list(): List<RETURNS> {
-    return compile().list().map { mapper(it) }
-  }
+    fun list(): List<RETURNS> {
+        return compile().list().map { mapper(it) }
+    }
 
-  fun set(): Set<RETURNS> {
-    return compile().list().asSequence()
-        .map { mapper(it) }
-        .toSet()
-  }
+    fun set(): Set<RETURNS> {
+        return compile().list().asSequence()
+            .map { mapper(it) }
+            .toSet()
+    }
 
-  fun uniqueResult(): RETURNS? {
-    return compile().uniqueResult()?.let { mapper(it) }
-  }
+    fun uniqueResult(): RETURNS? {
+        return compile().uniqueResult()?.let { mapper(it) }
+    }
 
-  fun first(): RETURNS? {
-    return maxResults(1).uniqueResult()
-  }
+    fun first(): RETURNS? {
+        return maxResults(1).uniqueResult()
+    }
 
-  fun compile(): CompiledYawnQuery<T> {
-    return queryFactory.compile(query, tableDef)
-  }
+    fun compile(): CompiledYawnQuery<T> {
+        return queryFactory.compile(query, tableDef)
+    }
 
-  fun offset(offset: Int): CRITERIA {
-    query.offset = offset
-    return builderReturn()
-  }
+    fun offset(offset: Int): CRITERIA {
+        query.offset = offset
+        return builderReturn()
+    }
 
-  fun maxResults(maxResults: Int): CRITERIA {
-    query.maxResults = maxResults
-    return builderReturn()
-  }
+    fun maxResults(maxResults: Int): CRITERIA {
+        query.maxResults = maxResults
+        return builderReturn()
+    }
 
-  fun maxBy(orderProperty: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? = maxBy(*arrayOf(orderProperty))
+    fun maxBy(orderProperty: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? = maxBy(*arrayOf(orderProperty))
 
-  fun maxBy(vararg orderProperties: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? {
-    val orders = orderProperties.map { YawnQueryOrder.desc(it(tableDef)) }
-    query.orders.addAll(orders)
+    fun maxBy(vararg orderProperties: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? {
+        val orders = orderProperties.map { YawnQueryOrder.desc(it(tableDef)) }
+        query.orders.addAll(orders)
 
-    return maxResults(1).uniqueResult()
-  }
+        return maxResults(1).uniqueResult()
+    }
 
-  fun minBy(orderProperty: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? = minBy(*arrayOf(orderProperty))
+    fun minBy(orderProperty: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? = minBy(*arrayOf(orderProperty))
 
-  fun minBy(vararg orderProperties: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? {
-    val orders = orderProperties.map { YawnQueryOrder.asc(it(tableDef)) }
-    query.orders.addAll(orders)
+    fun minBy(vararg orderProperties: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>): RETURNS? {
+        val orders = orderProperties.map { YawnQueryOrder.asc(it(tableDef)) }
+        query.orders.addAll(orders)
 
-    return maxResults(1).uniqueResult()
-  }
+        return maxResults(1).uniqueResult()
+    }
 
-  fun paginateZeroIndexed(
-      pageNumber: Int,
-      pageSize: Int,
-      orders: List<DEF.() -> YawnQueryOrder<T>>,
-  ): CRITERIA {
-    check(pageSize >= 1) { "$pageSize is not a valid page size" }
-    check(pageNumber >= 0) { "$pageNumber is not a valid page number" }
-    applyOrders(orders)
-    return offset(pageNumber * pageSize)
-        .maxResults(pageSize)
-  }
+    fun paginateZeroIndexed(
+        pageNumber: Int,
+        pageSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+    ): CRITERIA {
+        check(pageSize >= 1) { "$pageSize is not a valid page size" }
+        check(pageNumber >= 0) { "$pageNumber is not a valid page number" }
+        applyOrders(orders)
+        return offset(pageNumber * pageSize)
+            .maxResults(pageSize)
+    }
 
-  fun applyOrders(orders: List<DEF.() -> YawnQueryOrder<T>>): CRITERIA {
-    query.orders.addAll(orders.map { it(tableDef) })
-    return builderReturn()
-  }
+    fun applyOrders(orders: List<DEF.() -> YawnQueryOrder<T>>): CRITERIA {
+        query.orders.addAll(orders.map { it(tableDef) })
+        return builderReturn()
+    }
 
-  /**
-   * Currently, Yawn does not track database indexes in order to provide type-safe wrappers,
-   * so query hints are just provided as Strings.
-   */
-  fun addQueryHint(hint: String): CRITERIA {
-    query.queryHints.add(YawnQueryHint(hint))
-    return builderReturn()
-  }
+    /**
+     * Currently, Yawn does not track database indexes in order to provide type-safe wrappers,
+     * so query hints are just provided as Strings.
+     */
+    fun addQueryHint(hint: String): CRITERIA {
+        query.queryHints.add(YawnQueryHint(hint))
+        return builderReturn()
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/DetachedProjectedTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/DetachedProjectedTypeSafeCriteriaBuilder.kt
@@ -1,12 +1,12 @@
 package com.faire.yawn.criteria.builder
 
 import com.faire.yawn.YawnTableDef
+import com.faire.yawn.criteria.builder.DetachedProjectedTypeSafeCriteriaBuilder.Companion.create
 import com.faire.yawn.criteria.query.ProjectedTypeSafeCriteriaQuery
 import com.faire.yawn.project.YawnQueryProjection
 import com.faire.yawn.query.YawnCompilationContext
 import com.faire.yawn.query.YawnQuery
 import com.faire.yawn.query.YawnQueryRestriction.And
-import net.bytebuddy.implementation.InvokeDynamic.lambda
 import org.hibernate.criterion.DetachedCriteria
 
 /**
@@ -28,72 +28,72 @@ class DetachedProjectedTypeSafeCriteriaBuilder<SOURCE : Any, T : Any, DEF : Yawn
     private val tableDef: DEF,
 ) {
 
-  fun compile(context: YawnCompilationContext): DetachedCriteria {
-    return buildDetachedCriteria(context)
-  }
-
-  // to be used by `create` only
-  internal fun applyFilter(
-      lambda:
-      ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, RETURNS>.(tableDef: DEF) -> YawnQueryProjection<SOURCE, RETURNS>,
-  ) {
-    ProjectedTypeSafeCriteriaQuery.applyLambda<SOURCE, T, DEF, RETURNS>(query) {
-      check(query.projection == null) { "At most one projection can be configured per query." }
-      val projection = lambda(tableDef)
-      query.projection = projection
-    }
-  }
-
-  // TODO (yawn): Factor out the factory
-  private fun buildDetachedCriteria(context: YawnCompilationContext): DetachedCriteria {
-    val alias = checkNotNull(context.generateAlias(tableDef.parent)) { "Unable to alias subquery" }
-    val detachedCriteria = DetachedCriteria.forClass(query.clazz, alias)
-
-    for (join in query.joins) {
-      val alias = checkNotNull(context.generateAlias(join.parent)) {
-        "Unable to alias join in subquery"
-      }
-
-      if (join.joinCriteria.isNotEmpty()) {
-        val criterion = And(join.joinCriteria)
-        detachedCriteria.createAlias(
-            join.path(context),
-            alias,
-            join.joinType,
-            criterion.compile(context),
-        )
-      } else {
-        detachedCriteria.createAlias(join.path(context), alias, join.joinType)
-      }
+    fun compile(context: YawnCompilationContext): DetachedCriteria {
+        return buildDetachedCriteria(context)
     }
 
-    for (criterion in query.criteria.map { it.yawnRestriction.compile(context) }) {
-      detachedCriteria.add(criterion)
+    // to be used by `create` only
+    internal fun applyFilter(
+        lambda:
+        ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, RETURNS>.(tableDef: DEF) -> YawnQueryProjection<SOURCE, RETURNS>,
+    ) {
+        ProjectedTypeSafeCriteriaQuery.applyLambda<SOURCE, T, DEF, RETURNS>(query) {
+            check(query.projection == null) { "At most one projection can be configured per query." }
+            val projection = lambda(tableDef)
+            query.projection = projection
+        }
     }
 
-    for (order in query.orders) {
-      detachedCriteria.addOrder(order.compile(context))
+    // TODO (yawn): Factor out the factory
+    private fun buildDetachedCriteria(context: YawnCompilationContext): DetachedCriteria {
+        val alias = checkNotNull(context.generateAlias(tableDef.parent)) { "Unable to alias subquery" }
+        val detachedCriteria = DetachedCriteria.forClass(query.clazz, alias)
+
+        for (join in query.joins) {
+            val alias = checkNotNull(context.generateAlias(join.parent)) {
+                "Unable to alias join in subquery"
+            }
+
+            if (join.joinCriteria.isNotEmpty()) {
+                val criterion = And(join.joinCriteria)
+                detachedCriteria.createAlias(
+                    join.path(context),
+                    alias,
+                    join.joinType,
+                    criterion.compile(context),
+                )
+            } else {
+                detachedCriteria.createAlias(join.path(context), alias, join.joinType)
+            }
+        }
+
+        for (criterion in query.criteria.map { it.yawnRestriction.compile(context) }) {
+            detachedCriteria.add(criterion)
+        }
+
+        for (order in query.orders) {
+            detachedCriteria.addOrder(order.compile(context))
+        }
+
+        val hibernateProjection = query.projection?.compile(context)
+        if (hibernateProjection != null) {
+            detachedCriteria.setProjection(hibernateProjection)
+        }
+
+        return detachedCriteria
     }
 
-    val hibernateProjection = query.projection?.compile(context)
-    if (hibernateProjection != null) {
-      detachedCriteria.setProjection(hibernateProjection)
-    }
-
-    return detachedCriteria
-  }
-
-  companion object {
-    fun <SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>, PROJECTION : Any?> create(
-        tableDef: DEF,
-        query: YawnQuery<SOURCE, T>,
-        lambda: ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION>.(
+    companion object {
+        fun <SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>, PROJECTION : Any?> create(
             tableDef: DEF,
-        ) -> YawnQueryProjection<SOURCE, PROJECTION>,
-    ): DetachedProjectedTypeSafeCriteriaBuilder<SOURCE, T, DEF, PROJECTION> {
-      val typeSafeCriteria = DetachedProjectedTypeSafeCriteriaBuilder<SOURCE, T, DEF, PROJECTION>(query, tableDef)
-      typeSafeCriteria.applyFilter(lambda)
-      return typeSafeCriteria
+            query: YawnQuery<SOURCE, T>,
+            lambda: ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION>.(
+                tableDef: DEF,
+            ) -> YawnQueryProjection<SOURCE, PROJECTION>,
+        ): DetachedProjectedTypeSafeCriteriaBuilder<SOURCE, T, DEF, PROJECTION> {
+            val typeSafeCriteria = DetachedProjectedTypeSafeCriteriaBuilder<SOURCE, T, DEF, PROJECTION>(query, tableDef)
+            typeSafeCriteria.applyFilter(lambda)
+            return typeSafeCriteria
+        }
     }
-  }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/ProjectedTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/ProjectedTypeSafeCriteriaBuilder.kt
@@ -31,50 +31,50 @@ class ProjectedTypeSafeCriteriaBuilder<T : Any, DEF : YawnTableDef<T, T>, RETURN
     queryFactory,
     query,
 ) {
-  override fun builderReturn(): ProjectedTypeSafeCriteriaBuilder<T, DEF, RETURNS> = this
+    override fun builderReturn(): ProjectedTypeSafeCriteriaBuilder<T, DEF, RETURNS> = this
 
-  override fun clone(): ProjectedTypeSafeCriteriaBuilder<T, DEF, RETURNS> {
-    return ProjectedTypeSafeCriteriaBuilder(tableDef, queryFactory, query.copy())
-  }
-
-  // to be used by `create` only
-  internal fun applyFilter(
-      lambda: ProjectedTypeSafeCriteriaQuery<T, T, DEF, RETURNS>.(tableDef: DEF) -> YawnQueryProjection<T, RETURNS>,
-  ) {
-    ProjectedTypeSafeCriteriaQuery.applyLambda<T, T, DEF, RETURNS>(query) {
-      check(query.projection == null) { "At most one projection can be configured per query." }
-      val projection = lambda(tableDef)
-      query.projection = projection
-      mapper = { projection.project(it) }
+    override fun clone(): ProjectedTypeSafeCriteriaBuilder<T, DEF, RETURNS> {
+        return ProjectedTypeSafeCriteriaBuilder(tableDef, queryFactory, query.copy())
     }
-  }
 
-  inline fun doPaginated(
-      pageSize: Int,
-      orders: List<DEF.() -> YawnQueryOrder<T>>,
-      action: (List<RETURNS>) -> Unit,
-  ) {
-    // only apply the orders once
-    applyOrders(orders)
-
-    var pageNumber = 0
-    do {
-      val results = paginateZeroIndexed(pageNumber++, pageSize, orders = listOf()).list()
-      action(results)
-    } while (results.size == pageSize)
-  }
-
-  companion object {
-    fun <T : Any, DEF : YawnTableDef<T, T>, PROJECTION : Any?> create(
-        tableDef: DEF,
-        queryFactory: YawnQueryFactory,
-        query: YawnQuery<T, T>,
-        lambda:
-        ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(tableDef: DEF) -> YawnQueryProjection<T, PROJECTION>,
-    ): ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION> {
-      val typeSafeCriteria = ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION>(tableDef, queryFactory, query)
-      typeSafeCriteria.applyFilter(lambda)
-      return typeSafeCriteria
+    // to be used by `create` only
+    internal fun applyFilter(
+        lambda: ProjectedTypeSafeCriteriaQuery<T, T, DEF, RETURNS>.(tableDef: DEF) -> YawnQueryProjection<T, RETURNS>,
+    ) {
+        ProjectedTypeSafeCriteriaQuery.applyLambda<T, T, DEF, RETURNS>(query) {
+            check(query.projection == null) { "At most one projection can be configured per query." }
+            val projection = lambda(tableDef)
+            query.projection = projection
+            mapper = { projection.project(it) }
+        }
     }
-  }
+
+    inline fun doPaginated(
+        pageSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+        action: (List<RETURNS>) -> Unit,
+    ) {
+        // only apply the orders once
+        applyOrders(orders)
+
+        var pageNumber = 0
+        do {
+            val results = paginateZeroIndexed(pageNumber++, pageSize, orders = listOf()).list()
+            action(results)
+        } while (results.size == pageSize)
+    }
+
+    companion object {
+        fun <T : Any, DEF : YawnTableDef<T, T>, PROJECTION : Any?> create(
+            tableDef: DEF,
+            queryFactory: YawnQueryFactory,
+            query: YawnQuery<T, T>,
+            lambda:
+            ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(tableDef: DEF) -> YawnQueryProjection<T, PROJECTION>,
+        ): ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION> {
+            val typeSafeCriteria = ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION>(tableDef, queryFactory, query)
+            typeSafeCriteria.applyFilter(lambda)
+            return typeSafeCriteria
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/TypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/TypeSafeCriteriaBuilder.kt
@@ -25,175 +25,175 @@ class TypeSafeCriteriaBuilder<T : Any, DEF : YawnTableDef<T, T>>(
     queryFactory: YawnQueryFactory,
     query: YawnQuery<T, T>,
 ) : BaseTypeSafeCriteriaBuilder<T, DEF, T, TypeSafeCriteriaBuilder<T, DEF>>(tableDef, queryFactory, query) {
-  override fun builderReturn(): TypeSafeCriteriaBuilder<T, DEF> = this
-  override fun clone(): TypeSafeCriteriaBuilder<T, DEF> {
-    return TypeSafeCriteriaBuilder(tableDef, queryFactory, query.copy())
-  }
-
-  inner class YawnJoinRef<F : Any, D : YawnTableDef<T, F>>(
-      private val columnDef: DEF.() -> YawnTableDef<T, *>.JoinColumnDef<F, D>,
-      private val parent: AssociationTableDefParent,
-  ) {
-    fun get(tableDef: DEF): D {
-      val column = tableDef.columnDef()
-      return column.joinTableDef(parent)
+    override fun builderReturn(): TypeSafeCriteriaBuilder<T, DEF> = this
+    override fun clone(): TypeSafeCriteriaBuilder<T, DEF> {
+        return TypeSafeCriteriaBuilder(tableDef, queryFactory, query.copy())
     }
-  }
 
-  fun <F : Any, D : YawnTableDef<T, F>> joinRef(
-      joinType: JoinType = JoinType.INNER_JOIN,
-      columnDef: DEF.() -> YawnTableDef<T, *>.JoinColumnDef<F, D>,
-  ): YawnJoinRef<F, D> {
-    val joinColumnDef = tableDef.columnDef()
-    val joinParent = TypeSafeCriteriaWithJoinDelegate(query).registerJoin(joinColumnDef, joinType = joinType)
-    return YawnJoinRef(columnDef, joinParent)
-  }
-
-  fun applyFilter(
-      lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit,
-  ): TypeSafeCriteriaBuilder<T, DEF> {
-    TypeSafeCriteriaQuery.applyLambda<T, DEF>(query) { lambda(tableDef) }
-    return this
-  }
-
-  fun <RETURNS : Any?> applyProjection(
-      lambda: ProjectedTypeSafeCriteriaQuery<T, T, DEF, RETURNS>.(tableDef: DEF) -> YawnQueryProjection<T, RETURNS>,
-  ): ProjectedTypeSafeCriteriaBuilder<T, DEF, RETURNS> {
-    return ProjectedTypeSafeCriteriaBuilder.create(tableDef, queryFactory, query, lambda)
-  }
-
-  fun listBatched(
-      batchSize: Int,
-      orders: List<DEF.() -> YawnQueryOrder<T>>,
-  ): List<T> {
-    val results = mutableListOf<T>()
-    doPaginated(
-        pageSize = batchSize,
-        orders = orders,
-        action = { results.addAll(it) },
-    )
-    return results
-  }
-
-  fun listPaginatedZeroIndexed(
-      pageNumber: Int,
-      pageSize: Int,
-      orders: List<DEF.() -> YawnQueryOrder<T>>,
-  ): List<T> {
-    check(pageSize >= 1) { "$pageSize is not a valid page size" }
-    check(pageNumber >= 0) { "$pageNumber is not a valid page number" }
-
-    return applyOrders(orders)
-        .offset(pageNumber * pageSize)
-        .maxResults(pageSize)
-        .list()
-  }
-
-  fun countDistinct(
-      uniqueColumn: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
-  ): Long {
-    return applyProjection { table ->
-      project(YawnProjections.countDistinct(table.uniqueColumn()))
-    }.uniqueResult() ?: 0
-  }
-
-  fun listPaginatedWithTotalResultsZeroIndexed(
-      pageNumber: Int,
-      pageSize: Int,
-      orders: List<DEF.() -> YawnQueryOrder<T>>,
-      uniqueColumn: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
-      forceAnsiCompliance: Boolean = false,
-  ): Pair<Long, List<T>> {
-    if (forceAnsiCompliance) {
-      throw UnsupportedOperationException("forceAnsiCompliance=true is not supported yet in Yawn")
+    inner class YawnJoinRef<F : Any, D : YawnTableDef<T, F>>(
+        private val columnDef: DEF.() -> YawnTableDef<T, *>.JoinColumnDef<F, D>,
+        private val parent: AssociationTableDefParent,
+    ) {
+        fun get(tableDef: DEF): D {
+            val column = tableDef.columnDef()
+            return column.joinTableDef(parent)
+        }
     }
-    val totalResults = clone().countDistinct(uniqueColumn)
-    val entities = listPaginatedZeroIndexed(
-        pageNumber = pageNumber,
-        pageSize = pageSize,
-        orders = orders,
-    )
 
-    return Pair(totalResults, entities)
-  }
+    fun <F : Any, D : YawnTableDef<T, F>> joinRef(
+        joinType: JoinType = JoinType.INNER_JOIN,
+        columnDef: DEF.() -> YawnTableDef<T, *>.JoinColumnDef<F, D>,
+    ): YawnJoinRef<F, D> {
+        val joinColumnDef = tableDef.columnDef()
+        val joinParent = TypeSafeCriteriaWithJoinDelegate(query).registerJoin(joinColumnDef, joinType = joinType)
+        return YawnJoinRef(columnDef, joinParent)
+    }
 
-  inline fun doPaginated(
-      pageSize: Int,
-      orders: List<DEF.() -> YawnQueryOrder<T>>,
-      action: (List<T>) -> Unit,
-  ) {
-    // only apply the orders once
-    applyOrders(orders)
-
-    var pageNumber = 0
-    do {
-      val results = listPaginatedZeroIndexed(pageNumber++, pageSize, listOf())
-      action(results)
-    } while (results.size == pageSize)
-  }
-
-  fun rowCount(): Long {
-    return applyProjection {
-      project(YawnProjections.rowCount())
-    }.maxResults(1).uniqueResult() ?: 0
-  }
-
-  fun exists(): Boolean {
-    return applyProjection {
-      project(YawnProjections.selectConstant("1"))
-    }.maxResults(1).uniqueResult() != null
-  }
-
-  fun <FROM : Comparable<FROM>> maxValueOf(
-      column: DEF.() -> YawnTableDef<T, *>.ColumnDef<FROM>,
-  ): FROM? {
-    return applyProjection { table ->
-      project(YawnProjections.max(table.column()))
-    }.uniqueResult()
-  }
-
-  fun <FROM : Comparable<FROM>> minValueOf(
-      column: DEF.() -> YawnTableDef<T, *>.ColumnDef<FROM>,
-  ): FROM? {
-    return applyProjection { table ->
-      project(YawnProjections.min(table.column()))
-    }.uniqueResult()
-  }
-
-  fun orderAsc(
-      column: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
-  ): TypeSafeCriteriaBuilder<T, DEF> {
-    applyOrder { YawnQueryOrder.asc(tableDef.column()) }
-    return this
-  }
-
-  fun orderDesc(
-      column: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
-  ): TypeSafeCriteriaBuilder<T, DEF> {
-    applyOrder { YawnQueryOrder.desc(tableDef.column()) }
-    return this
-  }
-
-  fun applyOrder(
-      order: DEF.() -> YawnQueryOrder<T>,
-  ): TypeSafeCriteriaBuilder<T, DEF> {
-    return applyOrders(listOf(order))
-  }
-
-  companion object {
-    /**
-     * Create a TypeSafeCriteria from a raw Criteria, wiring in the generics from a provided [tableDef].
-     * The lambda is optional if you want to immediately apply some filtering.
-     */
-    fun <T : Any, DEF : YawnTableDef<T, T>> create(
-        tableDef: DEF,
-        queryFactory: YawnQueryFactory,
-        query: YawnQuery<T, T>,
-        lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit = {},
+    fun applyFilter(
+        lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit,
     ): TypeSafeCriteriaBuilder<T, DEF> {
-      val typeSafeCriteria = TypeSafeCriteriaBuilder(tableDef, queryFactory, query)
-      typeSafeCriteria.applyFilter(lambda)
-      return typeSafeCriteria
+        TypeSafeCriteriaQuery.applyLambda<T, DEF>(query) { lambda(tableDef) }
+        return this
     }
-  }
+
+    fun <RETURNS : Any?> applyProjection(
+        lambda: ProjectedTypeSafeCriteriaQuery<T, T, DEF, RETURNS>.(tableDef: DEF) -> YawnQueryProjection<T, RETURNS>,
+    ): ProjectedTypeSafeCriteriaBuilder<T, DEF, RETURNS> {
+        return ProjectedTypeSafeCriteriaBuilder.create(tableDef, queryFactory, query, lambda)
+    }
+
+    fun listBatched(
+        batchSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+    ): List<T> {
+        val results = mutableListOf<T>()
+        doPaginated(
+            pageSize = batchSize,
+            orders = orders,
+            action = { results.addAll(it) },
+        )
+        return results
+    }
+
+    fun listPaginatedZeroIndexed(
+        pageNumber: Int,
+        pageSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+    ): List<T> {
+        check(pageSize >= 1) { "$pageSize is not a valid page size" }
+        check(pageNumber >= 0) { "$pageNumber is not a valid page number" }
+
+        return applyOrders(orders)
+            .offset(pageNumber * pageSize)
+            .maxResults(pageSize)
+            .list()
+    }
+
+    fun countDistinct(
+        uniqueColumn: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
+    ): Long {
+        return applyProjection { table ->
+            project(YawnProjections.countDistinct(table.uniqueColumn()))
+        }.uniqueResult() ?: 0
+    }
+
+    fun listPaginatedWithTotalResultsZeroIndexed(
+        pageNumber: Int,
+        pageSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+        uniqueColumn: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
+        forceAnsiCompliance: Boolean = false,
+    ): Pair<Long, List<T>> {
+        if (forceAnsiCompliance) {
+            throw UnsupportedOperationException("forceAnsiCompliance=true is not supported yet in Yawn")
+        }
+        val totalResults = clone().countDistinct(uniqueColumn)
+        val entities = listPaginatedZeroIndexed(
+            pageNumber = pageNumber,
+            pageSize = pageSize,
+            orders = orders,
+        )
+
+        return Pair(totalResults, entities)
+    }
+
+    inline fun doPaginated(
+        pageSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+        action: (List<T>) -> Unit,
+    ) {
+        // only apply the orders once
+        applyOrders(orders)
+
+        var pageNumber = 0
+        do {
+            val results = listPaginatedZeroIndexed(pageNumber++, pageSize, listOf())
+            action(results)
+        } while (results.size == pageSize)
+    }
+
+    fun rowCount(): Long {
+        return applyProjection {
+            project(YawnProjections.rowCount())
+        }.maxResults(1).uniqueResult() ?: 0
+    }
+
+    fun exists(): Boolean {
+        return applyProjection {
+            project(YawnProjections.selectConstant("1"))
+        }.maxResults(1).uniqueResult() != null
+    }
+
+    fun <FROM : Comparable<FROM>> maxValueOf(
+        column: DEF.() -> YawnTableDef<T, *>.ColumnDef<FROM>,
+    ): FROM? {
+        return applyProjection { table ->
+            project(YawnProjections.max(table.column()))
+        }.uniqueResult()
+    }
+
+    fun <FROM : Comparable<FROM>> minValueOf(
+        column: DEF.() -> YawnTableDef<T, *>.ColumnDef<FROM>,
+    ): FROM? {
+        return applyProjection { table ->
+            project(YawnProjections.min(table.column()))
+        }.uniqueResult()
+    }
+
+    fun orderAsc(
+        column: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
+    ): TypeSafeCriteriaBuilder<T, DEF> {
+        applyOrder { YawnQueryOrder.asc(tableDef.column()) }
+        return this
+    }
+
+    fun orderDesc(
+        column: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
+    ): TypeSafeCriteriaBuilder<T, DEF> {
+        applyOrder { YawnQueryOrder.desc(tableDef.column()) }
+        return this
+    }
+
+    fun applyOrder(
+        order: DEF.() -> YawnQueryOrder<T>,
+    ): TypeSafeCriteriaBuilder<T, DEF> {
+        return applyOrders(listOf(order))
+    }
+
+    companion object {
+        /**
+         * Create a TypeSafeCriteria from a raw Criteria, wiring in the generics from a provided [tableDef].
+         * The lambda is optional if you want to immediately apply some filtering.
+         */
+        fun <T : Any, DEF : YawnTableDef<T, T>> create(
+            tableDef: DEF,
+            queryFactory: YawnQueryFactory,
+            query: YawnQuery<T, T>,
+            lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit = {},
+        ): TypeSafeCriteriaBuilder<T, DEF> {
+            val typeSafeCriteria = TypeSafeCriteriaBuilder(tableDef, queryFactory, query)
+            typeSafeCriteria.applyFilter(lambda)
+            return typeSafeCriteria
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/BaseTypeSafeCriteriaQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/BaseTypeSafeCriteriaQuery.kt
@@ -6,7 +6,6 @@ import com.faire.yawn.criteria.builder.DetachedProjectedTypeSafeCriteriaBuilder
 import com.faire.yawn.project.YawnQueryProjection
 import com.faire.yawn.query.YawnCriteriaQuery
 import com.faire.yawn.query.YawnQuery
-import kotlin.jvm.java
 
 /**
  * An abstract super-class for all type-safe Yawn queries DSL; not be used directly.
@@ -24,33 +23,33 @@ import kotlin.jvm.java
 abstract class BaseTypeSafeCriteriaQuery<SOURCE : Any, T : Any, DEF : YawnDef<SOURCE, T>> protected constructor(
     protected val query: YawnCriteriaQuery<SOURCE, T>,
 ) {
-  /**
-   * Creates a correlatable projected subquery that can be used on the parent query in criteria.
-   *
-   * @param ST the type of the entity being subqueried.
-   * @param DEF the table definition of the entity being subqueried.
-   * @param PROJECTION the type of the projection being returned by the subquery.
-   *
-   * @param tableDef the table definition of the entity being subqueried.
-   * @param lambda to be used to add criteria to the subquery.
-   */
-  inline fun <reified ST : Any, DEF : YawnTableDef<SOURCE, ST>, PROJECTION : Any?> createProjectedSubQuery(
-      tableDef: DEF,
-      noinline lambda:
-      ProjectedTypeSafeCriteriaQuery<SOURCE, ST, DEF, PROJECTION>.(
-          tableDef: DEF,
-      ) -> YawnQueryProjection<SOURCE, PROJECTION>,
-  ): DetachedProjectedTypeSafeCriteriaBuilder<SOURCE, ST, DEF, PROJECTION> {
-    val query = YawnQuery<SOURCE, ST>(ST::class.java)
-    return DetachedProjectedTypeSafeCriteriaBuilder.create(tableDef, query, lambda)
-  }
+    /**
+     * Creates a correlatable projected subquery that can be used on the parent query in criteria.
+     *
+     * @param ST the type of the entity being subqueried.
+     * @param DEF the table definition of the entity being subqueried.
+     * @param PROJECTION the type of the projection being returned by the subquery.
+     *
+     * @param tableDef the table definition of the entity being subqueried.
+     * @param lambda to be used to add criteria to the subquery.
+     */
+    inline fun <reified ST : Any, DEF : YawnTableDef<SOURCE, ST>, PROJECTION : Any?> createProjectedSubQuery(
+        tableDef: DEF,
+        noinline lambda:
+        ProjectedTypeSafeCriteriaQuery<SOURCE, ST, DEF, PROJECTION>.(
+            tableDef: DEF,
+        ) -> YawnQueryProjection<SOURCE, PROJECTION>,
+    ): DetachedProjectedTypeSafeCriteriaBuilder<SOURCE, ST, DEF, PROJECTION> {
+        val query = YawnQuery<SOURCE, ST>(ST::class.java)
+        return DetachedProjectedTypeSafeCriteriaBuilder.create(tableDef, query, lambda)
+    }
 
-  fun <F : Any> nullable(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnDef<SOURCE, *>.YawnColumnDef<F?> {
-    // a Long _is_ a Long?
-    // a Long? _is not_ a Long
-    @Suppress("UNCHECKED_CAST")
-    return column as YawnDef<SOURCE, *>.YawnColumnDef<F?>
-  }
+    fun <F : Any> nullable(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnDef<SOURCE, *>.YawnColumnDef<F?> {
+        // a Long _is_ a Long?
+        // a Long? _is not_ a Long
+        @Suppress("UNCHECKED_CAST")
+        return column as YawnDef<SOURCE, *>.YawnColumnDef<F?>
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/JoinTypeSafeCriteriaQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/JoinTypeSafeCriteriaQuery.kt
@@ -7,13 +7,13 @@ class JoinTypeSafeCriteriaQuery<SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE
     query: YawnCriteriaQuery<SOURCE, T>,
 ) : BaseTypeSafeCriteriaQuery<SOURCE, T, DEF>(query),
     TypeSafeCriteriaWithWhere<SOURCE, T> by TypeSafeCriteriaWithWhereDelegate(query) {
-  companion object {
-    internal fun <SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>> applyLambda(
-        query: YawnCriteriaQuery<SOURCE, T>,
-        tableDef: DEF,
-        lambda: JoinTypeSafeCriteriaQuery<SOURCE, T, DEF>.(tableDef: DEF) -> Unit,
-    ): JoinTypeSafeCriteriaQuery<SOURCE, T, DEF> {
-      return JoinTypeSafeCriteriaQuery<SOURCE, T, DEF>(query).apply { lambda(tableDef) }
+    companion object {
+        internal fun <SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>> applyLambda(
+            query: YawnCriteriaQuery<SOURCE, T>,
+            tableDef: DEF,
+            lambda: JoinTypeSafeCriteriaQuery<SOURCE, T, DEF>.(tableDef: DEF) -> Unit,
+        ): JoinTypeSafeCriteriaQuery<SOURCE, T, DEF> {
+            return JoinTypeSafeCriteriaQuery<SOURCE, T, DEF>(query).apply { lambda(tableDef) }
+        }
     }
-  }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/ProjectedTypeSafeCriteriaQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/ProjectedTypeSafeCriteriaQuery.kt
@@ -22,29 +22,29 @@ private constructor(
     TypeSafeCriteriaWithJoin<SOURCE, T> by TypeSafeCriteriaWithJoinDelegate(query),
     TypeSafeCriteriaWithOrder<SOURCE, T> by TypeSafeCriteriaWithOrderDelegate(query) {
 
-  private var projectionCalled: Boolean = false
+    private var projectionCalled: Boolean = false
 
-  private fun ensureUniqueProjection() {
-    if (projectionCalled) {
-      throw IllegalStateException("Projection already called")
-    } else {
-      projectionCalled = true
+    private fun ensureUniqueProjection() {
+        if (projectionCalled) {
+            throw IllegalStateException("Projection already called")
+        } else {
+            projectionCalled = true
+        }
     }
-  }
 
-  fun project(
-      projection: YawnQueryProjection<SOURCE, PROJECTION>,
-  ): YawnQueryProjection<SOURCE, PROJECTION> {
-    ensureUniqueProjection()
-    return projection
-  }
-
-  companion object {
-    internal fun <SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>, PROJECTION : Any?> applyLambda(
-        query: YawnQuery<SOURCE, T>,
-        lambda: ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION>.() -> Unit,
-    ): ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION> {
-      return ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION>(query).apply(lambda)
+    fun project(
+        projection: YawnQueryProjection<SOURCE, PROJECTION>,
+    ): YawnQueryProjection<SOURCE, PROJECTION> {
+        ensureUniqueProjection()
+        return projection
     }
-  }
+
+    companion object {
+        internal fun <SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>, PROJECTION : Any?> applyLambda(
+            query: YawnQuery<SOURCE, T>,
+            lambda: ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION>.() -> Unit,
+        ): ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION> {
+            return ProjectedTypeSafeCriteriaQuery<SOURCE, T, DEF, PROJECTION>(query).apply(lambda)
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/ProjectionTypeSafeCriteriaQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/ProjectionTypeSafeCriteriaQuery.kt
@@ -16,16 +16,16 @@ class ProjectionTypeSafeCriteriaQuery<T : Any, DEF : YawnProjectionDef<T, T>> pr
 ) : BaseTypeSafeCriteriaQuery<T, T, DEF>(query),
     TypeSafeCriteriaWithWhere<T, T> by TypeSafeCriteriaWithWhereDelegate(query),
     TypeSafeCriteriaWithOrder<T, T> by TypeSafeCriteriaWithOrderDelegate(query) {
-  companion object {
-    @Suppress("unused")
-    fun <T : Any, DEF : YawnProjectionDef<T, T>> create(
-        tableDef: DEF,
-        query: YawnQuery<T, T>,
-        lambda: ProjectionTypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit,
-    ): ProjectionTypeSafeCriteriaQuery<T, DEF> {
-      val typeSafeCriteria = ProjectionTypeSafeCriteriaQuery<T, DEF>(query)
-      typeSafeCriteria.lambda(tableDef)
-      return typeSafeCriteria
+    companion object {
+        @Suppress("unused")
+        fun <T : Any, DEF : YawnProjectionDef<T, T>> create(
+            tableDef: DEF,
+            query: YawnQuery<T, T>,
+            lambda: ProjectionTypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit,
+        ): ProjectionTypeSafeCriteriaQuery<T, DEF> {
+            val typeSafeCriteria = ProjectionTypeSafeCriteriaQuery<T, DEF>(query)
+            typeSafeCriteria.lambda(tableDef)
+            return typeSafeCriteria
+        }
     }
-  }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaQuery.kt
@@ -26,12 +26,12 @@ class TypeSafeCriteriaQuery<SOURCE : Any, DEF : YawnTableDef<SOURCE, SOURCE>> pr
     TypeSafeCriteriaWithWhere<SOURCE, SOURCE> by TypeSafeCriteriaWithWhereDelegate(query),
     TypeSafeCriteriaWithJoin<SOURCE, SOURCE> by TypeSafeCriteriaWithJoinDelegate(query),
     TypeSafeCriteriaWithOrder<SOURCE, SOURCE> by TypeSafeCriteriaWithOrderDelegate(query) {
-  companion object {
-    internal fun <T : Any, DEF : YawnTableDef<T, T>> applyLambda(
-        query: YawnQuery<T, T>,
-        lambda: TypeSafeCriteriaQuery<T, DEF>.() -> Unit,
-    ): TypeSafeCriteriaQuery<T, DEF> {
-      return TypeSafeCriteriaQuery<T, DEF>(query).apply(lambda)
+    companion object {
+        internal fun <T : Any, DEF : YawnTableDef<T, T>> applyLambda(
+            query: YawnQuery<T, T>,
+            lambda: TypeSafeCriteriaQuery<T, DEF>.() -> Unit,
+        ): TypeSafeCriteriaQuery<T, DEF> {
+            return TypeSafeCriteriaQuery<T, DEF>(query).apply(lambda)
+        }
     }
-  }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithJoin.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithJoin.kt
@@ -10,29 +10,29 @@ import org.hibernate.sql.JoinType
  * This serves for both [TypeSafeCriteriaQuery] and [ProjectionTypeSafeCriteriaQuery].
  */
 sealed interface TypeSafeCriteriaWithJoin<SOURCE : Any, T : Any> {
-  fun <F : Any, D : YawnTableDef<SOURCE, F>> join(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
-      joinType: JoinType = JoinType.INNER_JOIN,
-      lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit = {},
-  ): D
+    fun <F : Any, D : YawnTableDef<SOURCE, F>> join(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
+        joinType: JoinType = JoinType.INNER_JOIN,
+        lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit = {},
+    ): D
 }
 
 internal class TypeSafeCriteriaWithJoinDelegate<SOURCE : Any, T : Any>(
     private val query: YawnQuery<SOURCE, T>,
 ) : TypeSafeCriteriaWithJoin<SOURCE, T> {
-  override fun <F : Any, D : YawnTableDef<SOURCE, F>> join(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
-      joinType: JoinType,
-      lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit,
-  ): D {
-    val join = query.registerJoin(column, joinType, lambda)
-    return column.joinTableDef(join.parent)
-  }
+    override fun <F : Any, D : YawnTableDef<SOURCE, F>> join(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
+        joinType: JoinType,
+        lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit,
+    ): D {
+        val join = query.registerJoin(column, joinType, lambda)
+        return column.joinTableDef(join.parent)
+    }
 
-  internal fun <D : YawnTableDef<SOURCE, F>, F : Any> registerJoin(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
-      joinType: JoinType,
-  ): AssociationTableDefParent {
-    return query.registerJoin(column, joinType).parent
-  }
+    internal fun <D : YawnTableDef<SOURCE, F>, F : Any> registerJoin(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
+        joinType: JoinType,
+    ): AssociationTableDefParent {
+        return query.registerJoin(column, joinType).parent
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithOrder.kt
@@ -9,25 +9,25 @@ import com.faire.yawn.query.YawnQueryOrder
  * This serves for both [TypeSafeCriteriaQuery], [ProjectionTypeSafeCriteriaQuery] and [ProjectedTypeSafeCriteriaQuery].
  */
 sealed interface TypeSafeCriteriaWithOrder<SOURCE : Any, T : Any> {
-  fun order(vararg orders: YawnQueryOrder<SOURCE>)
-  fun orderAsc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>)
-  fun orderDesc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>)
+    fun order(vararg orders: YawnQueryOrder<SOURCE>)
+    fun orderAsc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>)
+    fun orderDesc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>)
 }
 
 internal class TypeSafeCriteriaWithOrderDelegate<SOURCE : Any, T : Any>(
     private val query: YawnQuery<SOURCE, T>,
 ) : TypeSafeCriteriaWithOrder<SOURCE, T> {
-  override fun order(vararg orders: YawnQueryOrder<SOURCE>) {
-    for (order in orders) {
-      query.orders.add(order)
+    override fun order(vararg orders: YawnQueryOrder<SOURCE>) {
+        for (order in orders) {
+            query.orders.add(order)
+        }
     }
-  }
 
-  override fun orderAsc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>) {
-    order(YawnQueryOrder.asc(property))
-  }
+    override fun orderAsc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>) {
+        order(YawnQueryOrder.asc(property))
+    }
 
-  override fun orderDesc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>) {
-    order(YawnQueryOrder.desc(property))
-  }
+    override fun orderDesc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>) {
+        order(YawnQueryOrder.desc(property))
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithWhere.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithWhere.kt
@@ -14,413 +14,413 @@ import org.hibernate.criterion.MatchMode
  * This serves for all implementations of [BaseTypeSafeCriteriaQuery] (just extracted for organization).
  */
 sealed interface TypeSafeCriteriaWithWhere<SOURCE : Any, T : Any> {
-  fun provideQuery(): YawnCriteriaQuery<SOURCE, T>
+    fun provideQuery(): YawnCriteriaQuery<SOURCE, T>
 
-  fun add(criterion: YawnQueryCriterion<SOURCE>)
+    fun add(criterion: YawnQueryCriterion<SOURCE>)
 
-  fun <F> addEq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ) {
-    add(YawnRestrictions.eq(column, value))
-  }
+    fun <F> addEq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ) {
+        add(YawnRestrictions.eq(column, value))
+    }
 
-  fun <F> addEq(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-      value: F & Any,
-  ) {
-    addEq(column.foreignKey, value)
-  }
+    fun <F> addEq(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+        value: F & Any,
+    ) {
+        addEq(column.foreignKey, value)
+    }
 
-  fun <F> addEq(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-      otherColumn: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-  ) {
-    addEq(column.foreignKey, otherColumn.foreignKey)
-  }
+    fun <F> addEq(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+        otherColumn: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+    ) {
+        addEq(column.foreignKey, otherColumn.foreignKey)
+    }
 
-  fun <F> addEq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.eq(column, otherColumn))
-  }
+    fun <F> addEq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.eq(column, otherColumn))
+    }
 
-  /**
-   * Implies that the sub query returns a single result.
-   */
-  fun <F> addEq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.eq(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    /**
+     * Implies that the sub query returns a single result.
+     */
+    fun <F> addEq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.eq(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addEq(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.eq(column.foreignKey, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addEq(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.eq(column.foreignKey, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addGt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ) {
-    add(YawnRestrictions.gt(column, value))
-  }
+    fun <F> addGt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ) {
+        add(YawnRestrictions.gt(column, value))
+    }
 
-  fun <F> addGt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.gt(column, otherColumn))
-  }
+    fun <F> addGt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.gt(column, otherColumn))
+    }
 
-  /**
-   * Implies that the sub query returns a single result.
-   */
-  fun <F> addGt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.gt(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    /**
+     * Implies that the sub query returns a single result.
+     */
+    fun <F> addGt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.gt(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addGe(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ) {
-    add(YawnRestrictions.ge(column, value))
-  }
+    fun <F> addGe(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ) {
+        add(YawnRestrictions.ge(column, value))
+    }
 
-  fun <F> addGe(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.ge(column, otherColumn))
-  }
+    fun <F> addGe(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.ge(column, otherColumn))
+    }
 
-  /**
-   * Implies that the sub query returns a single result.
-   */
-  fun <F> addGe(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.ge(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    /**
+     * Implies that the sub query returns a single result.
+     */
+    fun <F> addGe(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.ge(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addLe(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ) {
-    add(YawnRestrictions.le(column, value))
-  }
+    fun <F> addLe(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ) {
+        add(YawnRestrictions.le(column, value))
+    }
 
-  fun <F> addLe(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.le(column, otherColumn))
-  }
+    fun <F> addLe(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.le(column, otherColumn))
+    }
 
-  /**
-   * Implies that the sub query returns a single result.
-   */
-  fun <F> addLe(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.le(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    /**
+     * Implies that the sub query returns a single result.
+     */
+    fun <F> addLe(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.le(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addLt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ) {
-    add(YawnRestrictions.lt(column, value))
-  }
+    fun <F> addLt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ) {
+        add(YawnRestrictions.lt(column, value))
+    }
 
-  fun <F> addLt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.lt(column, otherColumn))
-  }
+    fun <F> addLt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.lt(column, otherColumn))
+    }
 
-  /**
-   * Implies that the sub query returns a single result.
-   */
-  fun <F> addLt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.lt(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    /**
+     * Implies that the sub query returns a single result.
+     */
+    fun <F> addLt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.lt(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addBetween(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      lo: F & Any,
-      hi: F & Any,
-  ) {
-    add(YawnRestrictions.between(column, lo, hi))
-  }
+    fun <F> addBetween(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        lo: F & Any,
+        hi: F & Any,
+    ) {
+        add(YawnRestrictions.between(column, lo, hi))
+    }
 
-  fun addOr(lhs: YawnQueryCriterion<SOURCE>, rhs: YawnQueryCriterion<SOURCE>) {
-    add(YawnRestrictions.or(lhs, rhs))
-  }
+    fun addOr(lhs: YawnQueryCriterion<SOURCE>, rhs: YawnQueryCriterion<SOURCE>) {
+        add(YawnRestrictions.or(lhs, rhs))
+    }
 
-  fun addOr(vararg predicates: YawnQueryCriterion<SOURCE>) {
-    add(YawnRestrictions.or(*predicates))
-  }
+    fun addOr(vararg predicates: YawnQueryCriterion<SOURCE>) {
+        add(YawnRestrictions.or(*predicates))
+    }
 
-  fun addAnd(vararg predicates: YawnQueryCriterion<SOURCE>) {
-    add(YawnRestrictions.and(*predicates))
-  }
+    fun addAnd(vararg predicates: YawnQueryCriterion<SOURCE>) {
+        add(YawnRestrictions.and(*predicates))
+    }
 
-  fun <F> addNotEq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ) {
-    add(YawnRestrictions.ne(column, value))
-  }
+    fun <F> addNotEq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ) {
+        add(YawnRestrictions.ne(column, value))
+    }
 
-  fun <F> addNotEq(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-      value: F & Any,
-  ) {
-    add(YawnRestrictions.ne(column.foreignKey, value))
-  }
+    fun <F> addNotEq(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+        value: F & Any,
+    ) {
+        add(YawnRestrictions.ne(column.foreignKey, value))
+    }
 
-  /**
-   * Implies that the sub query returns a single result.
-   */
-  fun <F> addNotEq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.ne(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    /**
+     * Implies that the sub query returns a single result.
+     */
+    fun <F> addNotEq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.ne(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addNotEq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.ne(column, otherColumn))
-  }
+    fun <F> addNotEq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.ne(column, otherColumn))
+    }
 
-  // TODO(yawn): addCaseInsensitiveNotEq
-  // TODO(yawn): addCaseInsensitiveEq
+    // TODO(yawn): addCaseInsensitiveNotEq
+    // TODO(yawn): addCaseInsensitiveEq
 
-  fun <F : String?> addLike(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: String,
-      matchMode: MatchMode = MatchMode.EXACT,
-  ) {
-    add(YawnRestrictions.like(column, value, matchMode))
-  }
+    fun <F : String?> addLike(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: String,
+        matchMode: MatchMode = MatchMode.EXACT,
+    ) {
+        add(YawnRestrictions.like(column, value, matchMode))
+    }
 
-  fun <F : String?> addILike(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: String,
-      matchMode: MatchMode = MatchMode.EXACT,
-  ) {
-    add(YawnRestrictions.iLike(column, value, matchMode))
-  }
+    fun <F : String?> addILike(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: String,
+        matchMode: MatchMode = MatchMode.EXACT,
+    ) {
+        add(YawnRestrictions.iLike(column, value, matchMode))
+    }
 
-  fun <F : String?> addNotLike(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: String,
-      matchMode: MatchMode = MatchMode.EXACT,
-  ) {
-    add(YawnRestrictions.not(YawnRestrictions.like(column, value, matchMode)))
-  }
+    fun <F : String?> addNotLike(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: String,
+        matchMode: MatchMode = MatchMode.EXACT,
+    ) {
+        add(YawnRestrictions.not(YawnRestrictions.like(column, value, matchMode)))
+    }
 
-  fun <F : String?> addNotILike(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: String,
-      matchMode: MatchMode = MatchMode.EXACT,
-  ) {
-    add(YawnRestrictions.not(YawnRestrictions.iLike(column, value, matchMode)))
-  }
+    fun <F : String?> addNotILike(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: String,
+        matchMode: MatchMode = MatchMode.EXACT,
+    ) {
+        add(YawnRestrictions.not(YawnRestrictions.iLike(column, value, matchMode)))
+    }
 
-  fun <F> addIsNotNull(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-  ) {
-    addIsNotNull(column.foreignKey)
-  }
+    fun <F> addIsNotNull(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+    ) {
+        addIsNotNull(column.foreignKey)
+    }
 
-  fun <F> addIsNotNull(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.isNotNull(column))
-  }
+    fun <F> addIsNotNull(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.isNotNull(column))
+    }
 
-  fun <F> addIsNull(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) {
-    add(YawnRestrictions.isNull(column))
-  }
+    fun <F> addIsNull(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) {
+        add(YawnRestrictions.isNull(column))
+    }
 
-  fun <F> addEqOrIsNull(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F,
-  ) {
-    add(YawnRestrictions.eqOrIsNull(column, value))
-  }
+    fun <F> addEqOrIsNull(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F,
+    ) {
+        add(YawnRestrictions.eqOrIsNull(column, value))
+    }
 
-  // TODO(yawn): doesn't have any of our custom stuff that checks large IN clause
-  fun <F> addIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      values: Collection<F & Any>,
-  ) {
-    add(YawnRestrictions.`in`(column, values))
-  }
+    // TODO(yawn): doesn't have any of our custom stuff that checks large IN clause
+    fun <F> addIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        values: Collection<F & Any>,
+    ) {
+        add(YawnRestrictions.`in`(column, values))
+    }
 
-  fun <F> addIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      vararg collection: F & Any,
-  ) {
-    add(YawnRestrictions.`in`(column, collection.toSet()))
-  }
+    fun <F> addIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        vararg collection: F & Any,
+    ) {
+        add(YawnRestrictions.`in`(column, collection.toSet()))
+    }
 
-  fun <F : Any> addIn(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-      values: Collection<F>,
-  ) {
-    add(YawnRestrictions.`in`(column.foreignKey, values))
-  }
+    fun <F : Any> addIn(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+        values: Collection<F>,
+    ) {
+        add(YawnRestrictions.`in`(column.foreignKey, values))
+    }
 
-  fun <F> addIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.`in`(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.`in`(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F : Any> addIn(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.`in`(column.foreignKey, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F : Any> addIn(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDefWithForeignKey<*, *, F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.`in`(column.foreignKey, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addNotIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      vararg collection: F & Any,
-  ) {
-    add(YawnRestrictions.notIn(column, collection.toSet()))
-  }
+    fun <F> addNotIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        vararg collection: F & Any,
+    ) {
+        add(YawnRestrictions.notIn(column, collection.toSet()))
+    }
 
-  fun <F> addNotIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      values: Collection<F & Any>,
-  ) {
-    add(YawnRestrictions.notIn(column, values))
-  }
+    fun <F> addNotIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        values: Collection<F & Any>,
+    ) {
+        add(YawnRestrictions.notIn(column, values))
+    }
 
-  fun <F> addNotIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.notIn(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addNotIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.notIn(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addExists(
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.exists(detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addExists(
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.exists(detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addNotExists(
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.notExists(detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addNotExists(
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.notExists(detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addEqAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.eqAll(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addEqAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.eqAll(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addGeAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.geAll(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addGeAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.geAll(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addGeSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.geSome(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addGeSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.geSome(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addGtAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.gtAll(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addGtAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.gtAll(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addGtSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.gtSome(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addGtSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.gtSome(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addLeAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.leAll(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addLeAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.leAll(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addLeSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.leSome(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addLeSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.leSome(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addLtAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.ltAll(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addLtAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.ltAll(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <F> addLtSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) {
-    add(YawnSubQueryRestrictions.ltSome(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <F> addLtSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) {
+        add(YawnSubQueryRestrictions.ltSome(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun addIsEmpty(
-      definition: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
-  ) {
-    add(YawnRestrictions.isEmpty(definition))
-  }
+    fun addIsEmpty(
+        definition: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
+    ) {
+        add(YawnRestrictions.isEmpty(definition))
+    }
 
-  fun addIsNotEmpty(
-      definition: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
-  ) {
-    add(YawnRestrictions.isNotEmpty(definition))
-  }
+    fun addIsNotEmpty(
+        definition: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
+    ) {
+        add(YawnRestrictions.isNotEmpty(definition))
+    }
 }
 
 internal class TypeSafeCriteriaWithWhereDelegate<SOURCE : Any, T : Any>(
     private val query: YawnCriteriaQuery<SOURCE, T>,
 ) : TypeSafeCriteriaWithWhere<SOURCE, T> {
-  override fun provideQuery(): YawnCriteriaQuery<SOURCE, T> = query
+    override fun provideQuery(): YawnCriteriaQuery<SOURCE, T> = query
 
-  override fun add(criterion: YawnQueryCriterion<SOURCE>) {
-    query.addCriterion(criterion)
-  }
+    override fun add(criterion: YawnQueryCriterion<SOURCE>) {
+        query.addCriterion(criterion)
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnAliasManager.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnAliasManager.kt
@@ -21,41 +21,41 @@ private val tableNamePrefixMap = ConcurrentHashMap<String, String>()
  * - `customer` (repeated) -> `c2`
  */
 internal class YawnAliasManager {
-  private val aliasCounters = mutableMapOf<String, Int>()
-  private val utilizedAliases = mutableSetOf<String>()
-  private val aliasesByParent = mutableMapOf<YawnTableDefParent, String?>()
+    private val aliasCounters = mutableMapOf<String, Int>()
+    private val utilizedAliases = mutableSetOf<String>()
+    private val aliasesByParent = mutableMapOf<YawnTableDefParent, String?>()
 
-  fun generate(parent: YawnTableDefParent, context: YawnCompilationContext): String? {
-    return aliasesByParent.getOrPut(parent) {
-      parent.getAliasBaseString(context)?.let { generate(it) }
-    }
-  }
-
-  internal fun generate(path: String): String {
-    val prefix = computePrefix(path)
-
-    var counter = aliasCounters.getOrPut(prefix) { 2 }
-    var alias = prefix
-    while (!utilizedAliases.add(alias)) {
-      alias = "${prefix}${counter++}"
+    fun generate(parent: YawnTableDefParent, context: YawnCompilationContext): String? {
+        return aliasesByParent.getOrPut(parent) {
+            parent.getAliasBaseString(context)?.let { generate(it) }
+        }
     }
 
-    aliasCounters[prefix] = counter
+    internal fun generate(path: String): String {
+        val prefix = computePrefix(path)
 
-    return alias
-  }
+        var counter = aliasCounters.getOrPut(prefix) { 2 }
+        var alias = prefix
+        while (!utilizedAliases.add(alias)) {
+            alias = "${prefix}${counter++}"
+        }
 
-  internal fun computePrefix(path: String): String {
-    val tableName = path.split('.').last()
+        aliasCounters[prefix] = counter
 
-    return tableNamePrefixMap.computeIfAbsent(tableName) { _ ->
-      (
-          sequenceOf(tableName.first()) + tableName.asSequence()
-          .drop(1)
-          .filter { it.isUpperCase() }
-          .map { it.lowercaseChar() }
-      )
-          .joinToString("")
+        return alias
     }
-  }
+
+    internal fun computePrefix(path: String): String {
+        val tableName = path.split('.').last()
+
+        return tableNamePrefixMap.computeIfAbsent(tableName) { _ ->
+            (
+                sequenceOf(tableName.first()) + tableName.asSequence()
+                    .drop(1)
+                    .filter { it.isUpperCase() }
+                    .map { it.lowercaseChar() }
+                )
+                .joinToString("")
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnCompositeQueryProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnCompositeQueryProjection.kt
@@ -13,18 +13,18 @@ class YawnCompositeQueryProjection<SOURCE : Any, TO>(
     private val mapper: (Any?) -> TO,
 ) : YawnQueryProjection<SOURCE, TO> {
 
-  constructor(vararg projections: YawnQueryProjection<SOURCE, *>, mapper: (Any?) -> TO) : this(
-      projections = projections.toList(),
-      mapper = mapper,
-  )
+    constructor(vararg projections: YawnQueryProjection<SOURCE, *>, mapper: (Any?) -> TO) : this(
+        projections = projections.toList(),
+        mapper = mapper,
+    )
 
-  override fun compile(context: YawnCompilationContext): Projection = Projections.projectionList().apply {
-    for (projection in projections) {
-      add(projection.compile(context))
+    override fun compile(context: YawnCompilationContext): Projection = Projections.projectionList().apply {
+        for (projection in projections) {
+            add(projection.compile(context))
+        }
     }
-  }
 
-  override fun project(value: Any?): TO {
-    return mapper(value)
-  }
+    override fun project(value: Any?): TO {
+        return mapper(value)
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjectionDef.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjectionDef.kt
@@ -12,13 +12,13 @@ import com.faire.yawn.query.YawnCompilationContext
  * @param SOURCE the type of the original table that the criteria is based off of.
  */
 abstract class YawnProjectionDef<SOURCE : Any, D : Any> : YawnDef<SOURCE, D>() {
-  /**
-   * A column definition for a projection.
-   * It is the equivalent of [com.faire.yawn.YawnTableDef.ColumnDef], but for projections.
-   *
-   * @param T the type of the column.
-   */
-  inner class ProjectionColumnDef<T>(private val name: String) : YawnColumnDef<T>() {
-    override fun generatePath(context: YawnCompilationContext): String = name
-  }
+    /**
+     * A column definition for a projection.
+     * It is the equivalent of [com.faire.yawn.YawnTableDef.ColumnDef], but for projections.
+     *
+     * @param T the type of the column.
+     */
+    inner class ProjectionColumnDef<T>(private val name: String) : YawnColumnDef<T>() {
+        override fun generatePath(context: YawnCompilationContext): String = name
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
@@ -11,286 +11,286 @@ import org.hibernate.type.StandardBasicTypes
  * A utility object to create type-safe [YawnQueryProjection].
  */
 object YawnProjections {
-  internal class Distinct<SOURCE : Any, TO>(
-      private val projection: YawnQueryProjection<SOURCE, TO>,
-  ) : YawnQueryProjection<SOURCE, TO> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.distinct(projection.compile(context))
+    internal class Distinct<SOURCE : Any, TO>(
+        private val projection: YawnQueryProjection<SOURCE, TO>,
+    ) : YawnQueryProjection<SOURCE, TO> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.distinct(projection.compile(context))
 
-    override fun project(value: Any?): TO = projection.project(value)
-  }
-
-  fun <SOURCE : Any, TO> distinct(
-      projection: YawnQueryProjection<SOURCE, TO>,
-  ): YawnQueryProjection<SOURCE, TO> {
-    return Distinct(projection)
-  }
-
-  internal class Count<SOURCE : Any, FROM : Any?>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, Long> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.count(columnDef.generatePath(context))
-
-    override fun project(value: Any?): Long = value as Long
-  }
-
-  fun <SOURCE : Any, FROM : Any?> count(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, Long> {
-    return Count(columnDef)
-  }
-
-  internal class CountDistinct<SOURCE : Any, FROM : Any?>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, Long> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.countDistinct(columnDef.generatePath(context))
-
-    override fun project(value: Any?): Long = value as Long
-  }
-
-  fun <SOURCE : Any, FROM : Any?> countDistinct(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, Long> {
-    return CountDistinct(columnDef)
-  }
-
-  internal class SumNullable<SOURCE : Any, FROM : Number?>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, Long?> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.sum(columnDef.generatePath(context))
-
-    override fun project(value: Any?): Long? = value as Long?
-  }
-
-  @JvmName("sumNullable")
-  fun <SOURCE : Any, FROM : Number?> sum(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, Long?> {
-    return SumNullable(columnDef)
-  }
-
-  internal class Sum<SOURCE : Any, FROM : Number>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, Long> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.sum(columnDef.generatePath(context))
-
-    override fun project(value: Any?): Long = value as Long
-  }
-
-  fun <SOURCE : Any, FROM : Number> sum(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, Long> {
-    return Sum(columnDef)
-  }
-
-  internal class AvgNullable<SOURCE : Any, FROM : Any?>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, Double?> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.avg(columnDef.generatePath(context))
-
-    override fun project(value: Any?): Double? = value as Double?
-  }
-
-  @JvmName("avgNullable")
-  fun <SOURCE : Any, FROM : Number?> avg(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, Double?> {
-    return AvgNullable(columnDef)
-  }
-
-  internal class Avg<SOURCE : Any, FROM : Number>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, Double> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.avg(columnDef.generatePath(context))
-
-    override fun project(value: Any?): Double = value as Double
-  }
-
-  fun <SOURCE : Any, FROM : Number> avg(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, Double> {
-    return Avg(columnDef)
-  }
-
-  internal class Max<SOURCE : Any, FROM : Comparable<FROM>?>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, FROM> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.max(columnDef.generatePath(context))
-
-    @Suppress("UNCHECKED_CAST")
-    override fun project(value: Any?): FROM = value as FROM
-  }
-
-  fun <SOURCE : Any, FROM : Comparable<FROM>?> max(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, FROM> {
-    return Max(columnDef)
-  }
-
-  internal class Min<SOURCE : Any, FROM : Comparable<FROM>?>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, FROM> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.min(columnDef.generatePath(context))
-
-    @Suppress("UNCHECKED_CAST")
-    override fun project(value: Any?): FROM = value as FROM
-  }
-
-  fun <SOURCE : Any, FROM : Comparable<FROM>?> min(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, FROM> {
-    return Min(columnDef)
-  }
-
-  internal class GroupBy<SOURCE : Any, FROM : Any?>(
-      private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ) : YawnQueryProjection<SOURCE, FROM> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = Projections.groupProperty(columnDef.generatePath(context))
-
-    @Suppress("UNCHECKED_CAST")
-    override fun project(value: Any?): FROM = value as FROM
-  }
-
-  fun <SOURCE : Any, FROM : Any?> groupBy(
-      columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
-  ): YawnQueryProjection<SOURCE, FROM> {
-    return GroupBy(columnDef)
-  }
-
-  internal class RowCount<SOURCE : Any> : YawnQueryProjection<SOURCE, Long> {
-    override fun compile(context: YawnCompilationContext): Projection = Projections.rowCount()
-
-    override fun project(value: Any?): Long = value as Long
-  }
-
-  fun <SOURCE : Any> rowCount(): YawnQueryProjection<SOURCE, Long> {
-    return RowCount()
-  }
-
-  internal class SelectConstant<SOURCE : Any>(
-      private val constant: String,
-  ) : YawnQueryProjection<SOURCE, String> {
-    override fun compile(context: YawnCompilationContext): Projection {
-      return Projections.sqlProjection(
-          "'$constant' as $CONSTANT_ALIAS",
-          arrayOf(CONSTANT_ALIAS),
-          arrayOf(StandardBasicTypes.STRING),
-      )
+        override fun project(value: Any?): TO = projection.project(value)
     }
 
-    override fun project(value: Any?): String = value as String
-  }
-
-  fun <SOURCE : Any> selectConstant(constant: String): YawnQueryProjection<SOURCE, String> {
-    return SelectConstant(constant)
-  }
-
-  internal class Coalesce<SOURCE : Any, FROM : Any?>(
-      private val projection: YawnQueryProjection<SOURCE, FROM?>,
-      private val defaultValue: FROM,
-  ) : YawnQueryProjection<SOURCE, FROM> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Projection = projection.compile(context)
-
-    @Suppress("UNCHECKED_CAST")
-    override fun project(value: Any?): FROM = (value as FROM?) ?: defaultValue
-  }
-
-  fun <SOURCE : Any, FROM : Any> coalesce(
-      projection: YawnQueryProjection<SOURCE, FROM?>,
-      defaultValue: FROM,
-  ): YawnQueryProjection<SOURCE, FROM> {
-    return Coalesce(projection, defaultValue)
-  }
-
-  internal class Null<SOURCE : Any, FROM : Any> : YawnQueryProjection<SOURCE, FROM?> {
-    override fun compile(context: YawnCompilationContext): Projection {
-      return Projections.sqlProjection(
-          "null as $CONSTANT_ALIAS",
-          arrayOf(CONSTANT_ALIAS),
-          arrayOf(StandardBasicTypes.STRING),
-      )
+    fun <SOURCE : Any, TO> distinct(
+        projection: YawnQueryProjection<SOURCE, TO>,
+    ): YawnQueryProjection<SOURCE, TO> {
+        return Distinct(projection)
     }
 
-    override fun project(value: Any?): FROM? = null
-  }
+    internal class Count<SOURCE : Any, FROM : Any?>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, Long> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.count(columnDef.generatePath(context))
 
-  fun <SOURCE : Any, T : Any> `null`(): YawnQueryProjection<SOURCE, T?> {
-    return Null()
-  }
-
-  internal class PairProjection<SOURCE : Any, A : Any?, B : Any?>(
-      private val firstProjection: YawnQueryProjection<SOURCE, A>,
-      private val secondProjection: YawnQueryProjection<SOURCE, B>,
-  ) : YawnQueryProjection<SOURCE, Pair<A, B>> {
-    override fun compile(context: YawnCompilationContext): Projection {
-      return Projections.projectionList()
-          .add(firstProjection.compile(context))
-          .add(secondProjection.compile(context))
+        override fun project(value: Any?): Long = value as Long
     }
 
-    override fun project(value: Any?): Pair<A, B> {
-      val queryResult = value as Array<*>
-      return Pair(firstProjection.project(queryResult[0]), secondProjection.project(queryResult[1]))
-    }
-  }
-
-  fun <SOURCE : Any, A : Any?, B : Any?> pair(
-      firstProjection: YawnQueryProjection<SOURCE, A>,
-      secondProjection: YawnQueryProjection<SOURCE, B>,
-  ): YawnQueryProjection<SOURCE, Pair<A, B>> {
-    return PairProjection(firstProjection, secondProjection)
-  }
-
-  internal class TripleProjection<SOURCE : Any, A : Any?, B : Any?, C : Any?>(
-      private val firstProjection: YawnQueryProjection<SOURCE, A>,
-      private val secondProjection: YawnQueryProjection<SOURCE, B>,
-      private val thirdProjection: YawnQueryProjection<SOURCE, C>,
-  ) : YawnQueryProjection<SOURCE, Triple<A, B, C>> {
-    override fun compile(context: YawnCompilationContext): Projection {
-      return Projections.projectionList()
-          .add(firstProjection.compile(context))
-          .add(secondProjection.compile(context))
-          .add(thirdProjection.compile(context))
+    fun <SOURCE : Any, FROM : Any?> count(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, Long> {
+        return Count(columnDef)
     }
 
-    override fun project(value: Any?): Triple<A, B, C> {
-      val queryResult = value as Array<*>
-      return Triple(
-          firstProjection.project(queryResult[0]),
-          secondProjection.project(queryResult[1]),
-          thirdProjection.project(queryResult[2]),
-      )
-    }
-  }
+    internal class CountDistinct<SOURCE : Any, FROM : Any?>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, Long> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.countDistinct(columnDef.generatePath(context))
 
-  fun <SOURCE : Any, A : Any?, B : Any?, C : Any?> triple(
-      firstProjection: YawnQueryProjection<SOURCE, A>,
-      secondProjection: YawnQueryProjection<SOURCE, B>,
-      thirdProjection: YawnQueryProjection<SOURCE, C>,
-  ): YawnQueryProjection<SOURCE, Triple<A, B, C>> {
-    return TripleProjection(firstProjection, secondProjection, thirdProjection)
-  }
+        override fun project(value: Any?): Long = value as Long
+    }
+
+    fun <SOURCE : Any, FROM : Any?> countDistinct(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, Long> {
+        return CountDistinct(columnDef)
+    }
+
+    internal class SumNullable<SOURCE : Any, FROM : Number?>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, Long?> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.sum(columnDef.generatePath(context))
+
+        override fun project(value: Any?): Long? = value as Long?
+    }
+
+    @JvmName("sumNullable")
+    fun <SOURCE : Any, FROM : Number?> sum(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, Long?> {
+        return SumNullable(columnDef)
+    }
+
+    internal class Sum<SOURCE : Any, FROM : Number>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, Long> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.sum(columnDef.generatePath(context))
+
+        override fun project(value: Any?): Long = value as Long
+    }
+
+    fun <SOURCE : Any, FROM : Number> sum(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, Long> {
+        return Sum(columnDef)
+    }
+
+    internal class AvgNullable<SOURCE : Any, FROM : Any?>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, Double?> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.avg(columnDef.generatePath(context))
+
+        override fun project(value: Any?): Double? = value as Double?
+    }
+
+    @JvmName("avgNullable")
+    fun <SOURCE : Any, FROM : Number?> avg(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, Double?> {
+        return AvgNullable(columnDef)
+    }
+
+    internal class Avg<SOURCE : Any, FROM : Number>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, Double> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.avg(columnDef.generatePath(context))
+
+        override fun project(value: Any?): Double = value as Double
+    }
+
+    fun <SOURCE : Any, FROM : Number> avg(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, Double> {
+        return Avg(columnDef)
+    }
+
+    internal class Max<SOURCE : Any, FROM : Comparable<FROM>?>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, FROM> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.max(columnDef.generatePath(context))
+
+        @Suppress("UNCHECKED_CAST")
+        override fun project(value: Any?): FROM = value as FROM
+    }
+
+    fun <SOURCE : Any, FROM : Comparable<FROM>?> max(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, FROM> {
+        return Max(columnDef)
+    }
+
+    internal class Min<SOURCE : Any, FROM : Comparable<FROM>?>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, FROM> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.min(columnDef.generatePath(context))
+
+        @Suppress("UNCHECKED_CAST")
+        override fun project(value: Any?): FROM = value as FROM
+    }
+
+    fun <SOURCE : Any, FROM : Comparable<FROM>?> min(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, FROM> {
+        return Min(columnDef)
+    }
+
+    internal class GroupBy<SOURCE : Any, FROM : Any?>(
+        private val columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ) : YawnQueryProjection<SOURCE, FROM> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = Projections.groupProperty(columnDef.generatePath(context))
+
+        @Suppress("UNCHECKED_CAST")
+        override fun project(value: Any?): FROM = value as FROM
+    }
+
+    fun <SOURCE : Any, FROM : Any?> groupBy(
+        columnDef: YawnTableDef<SOURCE, *>.ColumnDef<FROM>,
+    ): YawnQueryProjection<SOURCE, FROM> {
+        return GroupBy(columnDef)
+    }
+
+    internal class RowCount<SOURCE : Any> : YawnQueryProjection<SOURCE, Long> {
+        override fun compile(context: YawnCompilationContext): Projection = Projections.rowCount()
+
+        override fun project(value: Any?): Long = value as Long
+    }
+
+    fun <SOURCE : Any> rowCount(): YawnQueryProjection<SOURCE, Long> {
+        return RowCount()
+    }
+
+    internal class SelectConstant<SOURCE : Any>(
+        private val constant: String,
+    ) : YawnQueryProjection<SOURCE, String> {
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.sqlProjection(
+                "'$constant' as $CONSTANT_ALIAS",
+                arrayOf(CONSTANT_ALIAS),
+                arrayOf(StandardBasicTypes.STRING),
+            )
+        }
+
+        override fun project(value: Any?): String = value as String
+    }
+
+    fun <SOURCE : Any> selectConstant(constant: String): YawnQueryProjection<SOURCE, String> {
+        return SelectConstant(constant)
+    }
+
+    internal class Coalesce<SOURCE : Any, FROM : Any?>(
+        private val projection: YawnQueryProjection<SOURCE, FROM?>,
+        private val defaultValue: FROM,
+    ) : YawnQueryProjection<SOURCE, FROM> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Projection = projection.compile(context)
+
+        @Suppress("UNCHECKED_CAST")
+        override fun project(value: Any?): FROM = (value as FROM?) ?: defaultValue
+    }
+
+    fun <SOURCE : Any, FROM : Any> coalesce(
+        projection: YawnQueryProjection<SOURCE, FROM?>,
+        defaultValue: FROM,
+    ): YawnQueryProjection<SOURCE, FROM> {
+        return Coalesce(projection, defaultValue)
+    }
+
+    internal class Null<SOURCE : Any, FROM : Any> : YawnQueryProjection<SOURCE, FROM?> {
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.sqlProjection(
+                "null as $CONSTANT_ALIAS",
+                arrayOf(CONSTANT_ALIAS),
+                arrayOf(StandardBasicTypes.STRING),
+            )
+        }
+
+        override fun project(value: Any?): FROM? = null
+    }
+
+    fun <SOURCE : Any, T : Any> `null`(): YawnQueryProjection<SOURCE, T?> {
+        return Null()
+    }
+
+    internal class PairProjection<SOURCE : Any, A : Any?, B : Any?>(
+        private val firstProjection: YawnQueryProjection<SOURCE, A>,
+        private val secondProjection: YawnQueryProjection<SOURCE, B>,
+    ) : YawnQueryProjection<SOURCE, Pair<A, B>> {
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.projectionList()
+                .add(firstProjection.compile(context))
+                .add(secondProjection.compile(context))
+        }
+
+        override fun project(value: Any?): Pair<A, B> {
+            val queryResult = value as Array<*>
+            return Pair(firstProjection.project(queryResult[0]), secondProjection.project(queryResult[1]))
+        }
+    }
+
+    fun <SOURCE : Any, A : Any?, B : Any?> pair(
+        firstProjection: YawnQueryProjection<SOURCE, A>,
+        secondProjection: YawnQueryProjection<SOURCE, B>,
+    ): YawnQueryProjection<SOURCE, Pair<A, B>> {
+        return PairProjection(firstProjection, secondProjection)
+    }
+
+    internal class TripleProjection<SOURCE : Any, A : Any?, B : Any?, C : Any?>(
+        private val firstProjection: YawnQueryProjection<SOURCE, A>,
+        private val secondProjection: YawnQueryProjection<SOURCE, B>,
+        private val thirdProjection: YawnQueryProjection<SOURCE, C>,
+    ) : YawnQueryProjection<SOURCE, Triple<A, B, C>> {
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.projectionList()
+                .add(firstProjection.compile(context))
+                .add(secondProjection.compile(context))
+                .add(thirdProjection.compile(context))
+        }
+
+        override fun project(value: Any?): Triple<A, B, C> {
+            val queryResult = value as Array<*>
+            return Triple(
+                firstProjection.project(queryResult[0]),
+                secondProjection.project(queryResult[1]),
+                thirdProjection.project(queryResult[2]),
+            )
+        }
+    }
+
+    fun <SOURCE : Any, A : Any?, B : Any?, C : Any?> triple(
+        firstProjection: YawnQueryProjection<SOURCE, A>,
+        secondProjection: YawnQueryProjection<SOURCE, B>,
+        thirdProjection: YawnQueryProjection<SOURCE, C>,
+    ): YawnQueryProjection<SOURCE, Triple<A, B, C>> {
+        return TripleProjection(firstProjection, secondProjection, thirdProjection)
+    }
 }
 
 private const val CONSTANT_ALIAS = "_yawn_ct"

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnQueryProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnQueryProjection.kt
@@ -12,11 +12,11 @@ import org.hibernate.criterion.Projection
  * @param TO the type being projected to
  */
 interface YawnQueryProjection<SOURCE : Any, TO> {
-  fun compile(context: YawnCompilationContext): Projection
+    fun compile(context: YawnCompilationContext): Projection
 
-  fun project(value: Any?): TO
+    fun project(value: Any?): TO
 
-  fun apply(context: YawnCompilationContext, criteria: Criteria) {
-    criteria.setProjection(compile(context))
-  }
+    fun apply(context: YawnCompilationContext, criteria: Criteria) {
+        criteria.setProjection(compile(context))
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/CompiledYawnQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/CompiledYawnQuery.kt
@@ -4,6 +4,6 @@ package com.faire.yawn.query
  * A compiled query that can be executed to retrieve results.
  */
 interface CompiledYawnQuery<T> {
-  fun list(): List<T>
-  fun uniqueResult(): T?
+    fun list(): List<T>
+    fun uniqueResult(): T?
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnCompilationContext.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnCompilationContext.kt
@@ -10,19 +10,19 @@ import com.faire.yawn.criteria.query.YawnAliasManager
 data class YawnCompilationContext(
     val withSubQuery: Boolean = false,
 ) {
-  private val aliasManager: YawnAliasManager = YawnAliasManager()
+    private val aliasManager: YawnAliasManager = YawnAliasManager()
 
-  fun generateAlias(tableDef: YawnTableDef<*, *>): String? {
-    return generateAlias(tableDef.parent)
-  }
-
-  fun generateAlias(parent: YawnTableDefParent): String? {
-    return aliasManager.generate(parent, this)
-  }
-
-  companion object {
-    fun fromQuery(query: YawnQuery<*, *>): YawnCompilationContext {
-      return YawnCompilationContext(withSubQuery = query.hasSubQuery())
+    fun generateAlias(tableDef: YawnTableDef<*, *>): String? {
+        return generateAlias(tableDef.parent)
     }
-  }
+
+    fun generateAlias(parent: YawnTableDefParent): String? {
+        return aliasManager.generate(parent, this)
+    }
+
+    companion object {
+        fun fromQuery(query: YawnQuery<*, *>): YawnCompilationContext {
+            return YawnCompilationContext(withSubQuery = query.hasSubQuery())
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnCriteriaQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnCriteriaQuery.kt
@@ -4,5 +4,5 @@ package com.faire.yawn.query
  * Defines a Yawn query that can support criteria
  */
 interface YawnCriteriaQuery<SOURCE : Any, T : Any> {
-  fun addCriterion(criterion: YawnQueryCriterion<SOURCE>)
+    fun addCriterion(criterion: YawnQueryCriterion<SOURCE>)
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnDetachedQueryRestriction.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnDetachedQueryRestriction.kt
@@ -12,205 +12,205 @@ import org.hibernate.criterion.Subqueries
  * @param F the type being projected to by the detached criteria.
  */
 interface YawnDetachedQueryRestriction<SOURCE : Any, F : Any?> : YawnQueryRestriction<SOURCE> {
-  val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>
+    val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>
 
-  class EqualsDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion {
-      return Subqueries.propertyEq(
-          property.generatePath(context),
-          detachedCriteriaBuilder.compile(context),
-      )
+    class EqualsDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion {
+            return Subqueries.propertyEq(
+                property.generatePath(context),
+                detachedCriteriaBuilder.compile(context),
+            )
+        }
     }
-  }
 
-  class EqualsAllDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyEqAll(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class EqualsAllDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyEqAll(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class NotEqualsDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.propertyNe(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class NotEqualsDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.propertyNe(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class GreaterThanDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.propertyGt(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class GreaterThanDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.propertyGt(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class GreaterThanAllDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGtAll(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class GreaterThanAllDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGtAll(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class GreaterThanSomeDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGtSome(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class GreaterThanSomeDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGtSome(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class GreaterThanOrEqualToDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.propertyGe(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class GreaterThanOrEqualToDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.propertyGe(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class GreaterThanOrEqualToAllDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGeAll(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class GreaterThanOrEqualToAllDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGeAll(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class GreaterThanOrEqualToSomeDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGeSome(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class GreaterThanOrEqualToSomeDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyGeSome(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class LessThanDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.propertyLt(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class LessThanDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.propertyLt(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class LessThanAllDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLtAll(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class LessThanAllDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLtAll(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class LessThanSomeDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLtSome(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class LessThanSomeDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLtSome(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class LessThanOrEqualToDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.propertyLe(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class LessThanOrEqualToDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.propertyLe(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class LessThanOrEqualToAllDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLeAll(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class LessThanOrEqualToAllDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLeAll(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class LessThanOrEqualToSomeDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLeSome(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class LessThanOrEqualToSomeDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyLeSome(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class InDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.propertyIn(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class InDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.propertyIn(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class NotInDetached<SOURCE : Any, F : Any?>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyNotIn(
-        property.generatePath(context),
-        detachedCriteriaBuilder.compile(context),
-    )
-  }
+    class NotInDetached<SOURCE : Any, F : Any?>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(context: YawnCompilationContext): Criterion = Subqueries.propertyNotIn(
+            property.generatePath(context),
+            detachedCriteriaBuilder.compile(context),
+        )
+    }
 
-  class ExistsDetached<SOURCE : Any, F : Any?>(
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.exists(detachedCriteriaBuilder.compile(context))
-  }
+    class ExistsDetached<SOURCE : Any, F : Any?>(
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.exists(detachedCriteriaBuilder.compile(context))
+    }
 
-  class NotExistsDetached<SOURCE : Any, F : Any?>(
-      override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ) : YawnDetachedQueryRestriction<SOURCE, F> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Subqueries.notExists(detachedCriteriaBuilder.compile(context))
-  }
+    class NotExistsDetached<SOURCE : Any, F : Any?>(
+        override val detachedCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ) : YawnDetachedQueryRestriction<SOURCE, F> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Subqueries.notExists(detachedCriteriaBuilder.compile(context))
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQuery.kt
@@ -22,58 +22,58 @@ data class YawnQuery<SOURCE : Any, T : Any>(
     var maxResults: Int? = null,
 ) : YawnCriteriaQuery<SOURCE, T> {
 
-  override fun addCriterion(criterion: YawnQueryCriterion<SOURCE>) {
-    criteria.add(criterion)
-  }
-
-  internal fun <D : YawnTableDef<SOURCE, F>, F : Any> registerJoin(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
-      joinType: JoinType,
-      lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit = {},
-  ): YawnQueryJoin<SOURCE> {
-    val parent = AssociationTableDefParent(column)
-    val join = YawnQueryJoin<SOURCE>(
-        columnDef = column,
-        parent = parent,
-        joinType = joinType,
-    )
-    join.joinCriteria.addAll(
-        createJoinCriteria(column, join, lambda),
-    )
-
-    joins.add(join)
-    return join
-  }
-
-  private fun <F : Any, D : YawnTableDef<SOURCE, F>> createJoinCriteria(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
-      join: YawnQueryJoin<SOURCE>,
-      lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit,
-  ): List<YawnQueryCriterion<SOURCE>> {
-    val def = column.joinTableDef(join.parent)
-
-    val criteria = mutableListOf<YawnQueryCriterion<SOURCE>>()
-    val subQuery = object : YawnCriteriaQuery<SOURCE, F> {
-      override fun addCriterion(criterion: YawnQueryCriterion<SOURCE>) {
+    override fun addCriterion(criterion: YawnQueryCriterion<SOURCE>) {
         criteria.add(criterion)
-      }
     }
 
-    JoinTypeSafeCriteriaQuery.applyLambda<SOURCE, F, D>(subQuery, def, lambda)
+    internal fun <D : YawnTableDef<SOURCE, F>, F : Any> registerJoin(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
+        joinType: JoinType,
+        lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit = {},
+    ): YawnQueryJoin<SOURCE> {
+        val parent = AssociationTableDefParent(column)
+        val join = YawnQueryJoin<SOURCE>(
+            columnDef = column,
+            parent = parent,
+            joinType = joinType,
+        )
+        join.joinCriteria.addAll(
+            createJoinCriteria(column, join, lambda),
+        )
 
-    return criteria
-  }
+        joins.add(join)
+        return join
+    }
 
-  fun clone(): YawnQuery<SOURCE, T> {
-    return copy(
-        criteria = MutableList(criteria.size) { criteria[it].copy() },
-        joins = MutableList(joins.size) { joins[it].copy() },
-        orders = MutableList(orders.size) { orders[it].copy() },
-        queryHints = MutableList(queryHints.size) { queryHints[it] },
-    )
-  }
+    private fun <F : Any, D : YawnTableDef<SOURCE, F>> createJoinCriteria(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDef<F, D>,
+        join: YawnQueryJoin<SOURCE>,
+        lambda: JoinTypeSafeCriteriaQuery<SOURCE, F, D>.(tableDef: D) -> Unit,
+    ): List<YawnQueryCriterion<SOURCE>> {
+        val def = column.joinTableDef(join.parent)
 
-  fun hasSubQuery(): Boolean {
-    return criteria.any { it.yawnRestriction is YawnDetachedQueryRestriction<*, *> }
-  }
+        val criteria = mutableListOf<YawnQueryCriterion<SOURCE>>()
+        val subQuery = object : YawnCriteriaQuery<SOURCE, F> {
+            override fun addCriterion(criterion: YawnQueryCriterion<SOURCE>) {
+                criteria.add(criterion)
+            }
+        }
+
+        JoinTypeSafeCriteriaQuery.applyLambda<SOURCE, F, D>(subQuery, def, lambda)
+
+        return criteria
+    }
+
+    fun clone(): YawnQuery<SOURCE, T> {
+        return copy(
+            criteria = MutableList(criteria.size) { criteria[it].copy() },
+            joins = MutableList(joins.size) { joins[it].copy() },
+            orders = MutableList(orders.size) { orders[it].copy() },
+            queryHints = MutableList(queryHints.size) { queryHints[it] },
+        )
+    }
+
+    fun hasSubQuery(): Boolean {
+        return criteria.any { it.yawnRestriction is YawnDetachedQueryRestriction<*, *> }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryFactory.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryFactory.kt
@@ -6,5 +6,5 @@ import com.faire.yawn.YawnTableDef
  * A factory to abstract Yawn over an underlying ORM of choice.
  */
 interface YawnQueryFactory {
-  fun <T : Any> compile(query: YawnQuery<*, T>, tableDef: YawnTableDef<*, *>): CompiledYawnQuery<T>
+    fun <T : Any> compile(query: YawnQuery<*, T>, tableDef: YawnTableDef<*, *>): CompiledYawnQuery<T>
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryJoin.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryJoin.kt
@@ -13,5 +13,5 @@ data class YawnQueryJoin<SOURCE : Any>(
     val joinType: JoinType,
     val joinCriteria: MutableList<YawnQueryCriterion<SOURCE>> = mutableListOf(),
 ) {
-  fun path(context: YawnCompilationContext): String = columnDef.path(context)
+    fun path(context: YawnCompilationContext): String = columnDef.path(context)
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
@@ -15,35 +15,35 @@ data class YawnQueryOrder<SOURCE : Any>(
     val direction: Direction,
     val nullPrecedence: NullPrecedence,
 ) {
-  /**
-   * Sort direction, either ascending or descending.
-   */
-  enum class Direction {
-    ASC,
-    DESC,
-  }
-
-  fun compile(context: YawnCompilationContext): Order {
-    val path = property.generatePath(context)
-    return when (direction) {
-      Direction.ASC -> Order.asc(path).nulls(nullPrecedence)
-      Direction.DESC -> Order.desc(path).nulls(nullPrecedence)
-    }
-  }
-
-  companion object {
-    fun <SOURCE : Any> asc(
-        property: YawnTableDef<SOURCE, *>.ColumnDef<*>,
-        nullPrecedence: NullPrecedence = NONE,
-    ): YawnQueryOrder<SOURCE> {
-      return YawnQueryOrder(property, Direction.ASC, nullPrecedence)
+    /**
+     * Sort direction, either ascending or descending.
+     */
+    enum class Direction {
+        ASC,
+        DESC,
     }
 
-    fun <SOURCE : Any> desc(
-        property: YawnTableDef<SOURCE, *>.ColumnDef<*>,
-        nullPrecedence: NullPrecedence = NONE,
-    ): YawnQueryOrder<SOURCE> {
-      return YawnQueryOrder(property, Direction.DESC, nullPrecedence)
+    fun compile(context: YawnCompilationContext): Order {
+        val path = property.generatePath(context)
+        return when (direction) {
+            Direction.ASC -> Order.asc(path).nulls(nullPrecedence)
+            Direction.DESC -> Order.desc(path).nulls(nullPrecedence)
+        }
     }
-  }
+
+    companion object {
+        fun <SOURCE : Any> asc(
+            property: YawnTableDef<SOURCE, *>.ColumnDef<*>,
+            nullPrecedence: NullPrecedence = NONE,
+        ): YawnQueryOrder<SOURCE> {
+            return YawnQueryOrder(property, Direction.ASC, nullPrecedence)
+        }
+
+        fun <SOURCE : Any> desc(
+            property: YawnTableDef<SOURCE, *>.ColumnDef<*>,
+            nullPrecedence: NullPrecedence = NONE,
+        ): YawnQueryOrder<SOURCE> {
+            return YawnQueryOrder(property, Direction.DESC, nullPrecedence)
+        }
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
@@ -7,242 +7,242 @@ import org.hibernate.criterion.MatchMode
 import org.hibernate.criterion.Restrictions
 
 interface YawnQueryRestriction<SOURCE : Any> {
-  fun compile(context: YawnCompilationContext): Criterion
+    fun compile(context: YawnCompilationContext): Criterion
 
-  class Equals<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: F & Any,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.eq(property.generatePath(context), value)
-  }
-
-  class EqualsProperty<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.eqProperty(property.generatePath(context), otherProperty.generatePath(context))
-  }
-
-  class NotEquals<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: F & Any,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.ne(property.generatePath(context), value)
-  }
-
-  class NotEqualsProperty<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.neProperty(property.generatePath(context), otherProperty.generatePath(context))
-  }
-
-  class GreaterThan<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: F & Any,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.gt(property.generatePath(context), value)
-  }
-
-  class GreaterThanProperty<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.gtProperty(property.generatePath(context), otherProperty.generatePath(context))
-  }
-
-  class GreaterThanOrEqualTo<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: F & Any,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.ge(property.generatePath(context), value)
-  }
-
-  class GreaterThanOrEqualToProperty<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.geProperty(property.generatePath(context), otherProperty.generatePath(context))
-  }
-
-  class LessThan<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: F & Any,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.lt(property.generatePath(context), value)
-  }
-
-  class LessThanProperty<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.ltProperty(property.generatePath(context), otherProperty.generatePath(context))
-  }
-
-  class LessThanOrEqualTo<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: F & Any,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.le(property.generatePath(context), value)
-  }
-
-  class LessThanOrEqualToProperty<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.leProperty(property.generatePath(context), otherProperty.generatePath(context))
-  }
-
-  class Between<SOURCE : Any, F>(
-      private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val lo: F & Any,
-      private val hi: F & Any,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.between(property.generatePath(context), lo, hi)
-  }
-
-  class Not<SOURCE : Any>(
-      private val criterion: YawnQueryCriterion<SOURCE>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.not(criterion.yawnRestriction.compile(context))
-  }
-
-  class Or<SOURCE : Any>(
-      private val criteria: List<YawnQueryCriterion<SOURCE>>,
-  ) : YawnQueryRestriction<SOURCE> {
-    internal constructor(vararg criteria: YawnQueryCriterion<SOURCE>) : this(criteria.toList())
-
-    override fun compile(context: YawnCompilationContext): Criterion = Restrictions.or(
-        *criteria.map {
-        it.yawnRestriction.compile(context)
-    }.toTypedArray(),
-    )
-  }
-
-  class And<SOURCE : Any>(
-      private val criteria: List<YawnQueryCriterion<SOURCE>>,
-  ) : YawnQueryRestriction<SOURCE> {
-    constructor(vararg criteria: YawnQueryCriterion<SOURCE>) : this(criteria.toList())
-
-    override fun compile(context: YawnCompilationContext): Criterion = Restrictions.and(
-        *criteria.map {
-        it.yawnRestriction.compile(context)
-    }.toTypedArray(),
-    )
-  }
-
-  class Like<SOURCE : Any, F : String?>(
-      private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: String,
-      private val matchMode: MatchMode,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.like(column.generatePath(context), value, matchMode)
-  }
-
-  class ILike<SOURCE : Any, F : String?>(
-      private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: String,
-      private val matchMode: MatchMode,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.ilike(column.generatePath(context), value, matchMode)
-  }
-
-  class IsNotNull<SOURCE : Any, F>(
-      private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.isNotNull(column.generatePath(context))
-  }
-
-  class IsNull<SOURCE : Any, F>(
-      private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.isNull(column.generatePath(context))
-  }
-
-  class EqualsOrIsNull<SOURCE : Any, F>(
-      private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val value: F,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.eqOrIsNull(column.generatePath(context), value)
-  }
-
-  class In<SOURCE : Any, F>(
-      private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val values: Collection<F & Any>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(context: YawnCompilationContext): Criterion {
-      return if (values.isEmpty()) {
-        Restrictions.sqlRestriction("0=1")
-      } else {
-        Restrictions.`in`(column.generatePath(context), values)
-      }
+    class Equals<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: F & Any,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.eq(property.generatePath(context), value)
     }
-  }
 
-  class NotIn<SOURCE : Any, F>(
-      private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      private val values: Collection<F & Any>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(context: YawnCompilationContext): Criterion {
-      return if (values.isEmpty()) {
-        Restrictions.sqlRestriction("1=1")
-      } else {
-        Restrictions.not(Restrictions.`in`(column.generatePath(context), values))
-      }
+    class EqualsProperty<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.eqProperty(property.generatePath(context), otherProperty.generatePath(context))
     }
-  }
 
-  class IsEmpty<SOURCE : Any>(
-      private val joinColumn: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.isEmpty(joinColumn.path(context))
-  }
+    class NotEquals<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: F & Any,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.ne(property.generatePath(context), value)
+    }
 
-  class IsNotEmpty<SOURCE : Any>(
-      private val joinColumn: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
-  ) : YawnQueryRestriction<SOURCE> {
-    override fun compile(
-        context: YawnCompilationContext,
-    ): Criterion = Restrictions.isNotEmpty(joinColumn.path(context))
-  }
+    class NotEqualsProperty<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.neProperty(property.generatePath(context), otherProperty.generatePath(context))
+    }
+
+    class GreaterThan<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: F & Any,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.gt(property.generatePath(context), value)
+    }
+
+    class GreaterThanProperty<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.gtProperty(property.generatePath(context), otherProperty.generatePath(context))
+    }
+
+    class GreaterThanOrEqualTo<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: F & Any,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.ge(property.generatePath(context), value)
+    }
+
+    class GreaterThanOrEqualToProperty<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.geProperty(property.generatePath(context), otherProperty.generatePath(context))
+    }
+
+    class LessThan<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: F & Any,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.lt(property.generatePath(context), value)
+    }
+
+    class LessThanProperty<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.ltProperty(property.generatePath(context), otherProperty.generatePath(context))
+    }
+
+    class LessThanOrEqualTo<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: F & Any,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.le(property.generatePath(context), value)
+    }
+
+    class LessThanOrEqualToProperty<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.leProperty(property.generatePath(context), otherProperty.generatePath(context))
+    }
+
+    class Between<SOURCE : Any, F>(
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val lo: F & Any,
+        private val hi: F & Any,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.between(property.generatePath(context), lo, hi)
+    }
+
+    class Not<SOURCE : Any>(
+        private val criterion: YawnQueryCriterion<SOURCE>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.not(criterion.yawnRestriction.compile(context))
+    }
+
+    class Or<SOURCE : Any>(
+        private val criteria: List<YawnQueryCriterion<SOURCE>>,
+    ) : YawnQueryRestriction<SOURCE> {
+        internal constructor(vararg criteria: YawnQueryCriterion<SOURCE>) : this(criteria.toList())
+
+        override fun compile(context: YawnCompilationContext): Criterion = Restrictions.or(
+            *criteria.map {
+                it.yawnRestriction.compile(context)
+            }.toTypedArray(),
+        )
+    }
+
+    class And<SOURCE : Any>(
+        private val criteria: List<YawnQueryCriterion<SOURCE>>,
+    ) : YawnQueryRestriction<SOURCE> {
+        constructor(vararg criteria: YawnQueryCriterion<SOURCE>) : this(criteria.toList())
+
+        override fun compile(context: YawnCompilationContext): Criterion = Restrictions.and(
+            *criteria.map {
+                it.yawnRestriction.compile(context)
+            }.toTypedArray(),
+        )
+    }
+
+    class Like<SOURCE : Any, F : String?>(
+        private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: String,
+        private val matchMode: MatchMode,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.like(column.generatePath(context), value, matchMode)
+    }
+
+    class ILike<SOURCE : Any, F : String?>(
+        private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: String,
+        private val matchMode: MatchMode,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.ilike(column.generatePath(context), value, matchMode)
+    }
+
+    class IsNotNull<SOURCE : Any, F>(
+        private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.isNotNull(column.generatePath(context))
+    }
+
+    class IsNull<SOURCE : Any, F>(
+        private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.isNull(column.generatePath(context))
+    }
+
+    class EqualsOrIsNull<SOURCE : Any, F>(
+        private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val value: F,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.eqOrIsNull(column.generatePath(context), value)
+    }
+
+    class In<SOURCE : Any, F>(
+        private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val values: Collection<F & Any>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(context: YawnCompilationContext): Criterion {
+            return if (values.isEmpty()) {
+                Restrictions.sqlRestriction("0=1")
+            } else {
+                Restrictions.`in`(column.generatePath(context), values)
+            }
+        }
+    }
+
+    class NotIn<SOURCE : Any, F>(
+        private val column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val values: Collection<F & Any>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(context: YawnCompilationContext): Criterion {
+            return if (values.isEmpty()) {
+                Restrictions.sqlRestriction("1=1")
+            } else {
+                Restrictions.not(Restrictions.`in`(column.generatePath(context), values))
+            }
+        }
+    }
+
+    class IsEmpty<SOURCE : Any>(
+        private val joinColumn: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.isEmpty(joinColumn.path(context))
+    }
+
+    class IsNotEmpty<SOURCE : Any>(
+        private val joinColumn: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
+    ) : YawnQueryRestriction<SOURCE> {
+        override fun compile(
+            context: YawnCompilationContext,
+        ): Criterion = Restrictions.isNotEmpty(joinColumn.path(context))
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnRestrictions.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnRestrictions.kt
@@ -35,174 +35,174 @@ import org.hibernate.criterion.Restrictions
  * Yawn's equivalent to Hibernate's [Restrictions].
  */
 object YawnRestrictions {
-  fun <SOURCE : Any, F> eq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(Equals(column, value))
-  }
+    fun <SOURCE : Any, F> eq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(Equals(column, value))
+    }
 
-  fun <SOURCE : Any, F> eq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(EqualsProperty(column, otherColumn))
-  }
+    fun <SOURCE : Any, F> eq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(EqualsProperty(column, otherColumn))
+    }
 
-  fun <SOURCE : Any, F> ne(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(NotEquals(column, value))
-  }
+    fun <SOURCE : Any, F> ne(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(NotEquals(column, value))
+    }
 
-  fun <SOURCE : Any, F> ne(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(NotEqualsProperty(column, otherColumn))
-  }
+    fun <SOURCE : Any, F> ne(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(NotEqualsProperty(column, otherColumn))
+    }
 
-  fun <SOURCE : Any, F> gt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThan(column, value))
-  }
+    fun <SOURCE : Any, F> gt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThan(column, value))
+    }
 
-  fun <SOURCE : Any, F> gt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanProperty(column, otherColumn))
-  }
+    fun <SOURCE : Any, F> gt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanProperty(column, otherColumn))
+    }
 
-  fun <SOURCE : Any, F> ge(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanOrEqualTo(column, value))
-  }
+    fun <SOURCE : Any, F> ge(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanOrEqualTo(column, value))
+    }
 
-  fun <SOURCE : Any, F> ge(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanOrEqualToProperty(column, otherColumn))
-  }
+    fun <SOURCE : Any, F> ge(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanOrEqualToProperty(column, otherColumn))
+    }
 
-  fun <SOURCE : Any, F> lt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThan(column, value))
-  }
+    fun <SOURCE : Any, F> lt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThan(column, value))
+    }
 
-  fun <SOURCE : Any, F> lt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanProperty(column, otherColumn))
-  }
+    fun <SOURCE : Any, F> lt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanProperty(column, otherColumn))
+    }
 
-  fun <SOURCE : Any, F> le(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F & Any,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanOrEqualTo(column, value))
-  }
+    fun <SOURCE : Any, F> le(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F & Any,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanOrEqualTo(column, value))
+    }
 
-  fun <SOURCE : Any, F> le(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanOrEqualToProperty(column, otherColumn))
-  }
+    fun <SOURCE : Any, F> le(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanOrEqualToProperty(column, otherColumn))
+    }
 
-  fun <SOURCE : Any, F> between(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      lo: F & Any,
-      hi: F & Any,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(Between(column, lo, hi))
-  }
+    fun <SOURCE : Any, F> between(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        lo: F & Any,
+        hi: F & Any,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(Between(column, lo, hi))
+    }
 
-  fun <SOURCE : Any> not(
-      yawnQueryCriterion: YawnQueryCriterion<SOURCE>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(Not(yawnQueryCriterion))
-  }
+    fun <SOURCE : Any> not(
+        yawnQueryCriterion: YawnQueryCriterion<SOURCE>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(Not(yawnQueryCriterion))
+    }
 
-  fun <SOURCE : Any> or(lhs: YawnQueryCriterion<SOURCE>, rhs: YawnQueryCriterion<SOURCE>): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(Or(lhs, rhs))
-  }
+    fun <SOURCE : Any> or(lhs: YawnQueryCriterion<SOURCE>, rhs: YawnQueryCriterion<SOURCE>): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(Or(lhs, rhs))
+    }
 
-  fun <SOURCE : Any> or(vararg criterion: YawnQueryCriterion<SOURCE>): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(Or(*criterion))
-  }
+    fun <SOURCE : Any> or(vararg criterion: YawnQueryCriterion<SOURCE>): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(Or(*criterion))
+    }
 
-  fun <SOURCE : Any> and(vararg criterion: YawnQueryCriterion<SOURCE>): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(And(*criterion))
-  }
+    fun <SOURCE : Any> and(vararg criterion: YawnQueryCriterion<SOURCE>): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(And(*criterion))
+    }
 
-  fun <SOURCE : Any, F : String?> like(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: String,
-      matchMode: MatchMode = MatchMode.EXACT,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(Like(column, value, matchMode))
-  }
+    fun <SOURCE : Any, F : String?> like(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: String,
+        matchMode: MatchMode = MatchMode.EXACT,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(Like(column, value, matchMode))
+    }
 
-  fun <SOURCE : Any, F : String?> iLike(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: String,
-      matchMode: MatchMode = MatchMode.EXACT,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(ILike(column, value, matchMode))
-  }
+    fun <SOURCE : Any, F : String?> iLike(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: String,
+        matchMode: MatchMode = MatchMode.EXACT,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(ILike(column, value, matchMode))
+    }
 
-  fun <SOURCE : Any, F> isNotNull(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(IsNotNull(column))
-  }
+    fun <SOURCE : Any, F> isNotNull(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(IsNotNull(column))
+    }
 
-  fun <SOURCE : Any, F> isNull(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(IsNull(column))
-  }
+    fun <SOURCE : Any, F> isNull(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(IsNull(column))
+    }
 
-  fun <SOURCE : Any, F> eqOrIsNull(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      value: F,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(EqualsOrIsNull(column, value))
-  }
+    fun <SOURCE : Any, F> eqOrIsNull(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(EqualsOrIsNull(column, value))
+    }
 
-  fun <SOURCE : Any, F> `in`(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      values: Collection<F & Any>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(In(column, values))
-  }
+    fun <SOURCE : Any, F> `in`(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        values: Collection<F & Any>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(In(column, values))
+    }
 
-  fun <SOURCE : Any, F> notIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      values: Collection<F & Any>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(NotIn(column, values))
-  }
+    fun <SOURCE : Any, F> notIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        values: Collection<F & Any>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(NotIn(column, values))
+    }
 
-  fun <SOURCE : Any> isEmpty(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(IsEmpty(column))
-  }
+    fun <SOURCE : Any> isEmpty(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(IsEmpty(column))
+    }
 
-  fun <SOURCE : Any> isNotEmpty(
-      column: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(IsNotEmpty(column))
-  }
+    fun <SOURCE : Any> isNotEmpty(
+        column: YawnTableDef<SOURCE, *>.JoinColumnDef<*, *>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(IsNotEmpty(column))
+    }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnSubQueryRestrictions.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnSubQueryRestrictions.kt
@@ -28,138 +28,138 @@ import org.hibernate.criterion.Subqueries
  * Equivalent to Hibernate's [Subqueries].
  */
 object YawnSubQueryRestrictions {
-  // TODO(yawn): Decouple these from Hibernate
+    // TODO(yawn): Decouple these from Hibernate
 
-  fun <SOURCE : Any, F : Any?> eq(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(EqualsDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> eq(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(EqualsDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> ne(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(NotEqualsDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> ne(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(NotEqualsDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> gt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> gt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> ge(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanOrEqualToDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> ge(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanOrEqualToDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> le(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanOrEqualToDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> le(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanOrEqualToDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> lt(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> lt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> `in`(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(InDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> `in`(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(InDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> notIn(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(NotInDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> notIn(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(NotInDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> exists(
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(ExistsDetached(detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> exists(
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(ExistsDetached(detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> notExists(
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(NotExistsDetached(detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> notExists(
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(NotExistsDetached(detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> eqAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(EqualsAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> eqAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(EqualsAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> geAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanOrEqualToAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> geAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanOrEqualToAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> geSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanOrEqualToSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> geSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanOrEqualToSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> gtAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> gtAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> gtSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(GreaterThanSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> gtSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> leAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanOrEqualToAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> leAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanOrEqualToAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> leSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanOrEqualToSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> leSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanOrEqualToSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> ltAll(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> ltAll(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanAllDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  fun <SOURCE : Any, F : Any?> ltSome(
-      column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-      detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
-  ): YawnQueryCriterion<SOURCE> {
-    return YawnQueryCriterion(LessThanSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
-  }
+    fun <SOURCE : Any, F : Any?> ltSome(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        detachedProjectedTypeSafeCriteriaBuilder: DetachedProjectedTypeSafeCriteriaBuilder<*, *, *, F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanSomeDetached(column, detachedProjectedTypeSafeCriteriaBuilder))
+    }
 
-  // TODO(yawn): Support properties... functions using a data class projection
+    // TODO(yawn): Support properties... functions using a data class projection
 }

--- a/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnAliasManagerTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnAliasManagerTest.kt
@@ -5,57 +5,57 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class YawnAliasManagerTest {
-  val aliasManager = YawnAliasManager()
+    val aliasManager = YawnAliasManager()
 
-  @Test
-  fun `verify correct prefix for table`() {
-    val tablePrefix = aliasManager.computePrefix("table")
-    assertThat(tablePrefix).isEqualTo("t")
-  }
+    @Test
+    fun `verify correct prefix for table`() {
+        val tablePrefix = aliasManager.computePrefix("table")
+        assertThat(tablePrefix).isEqualTo("t")
+    }
 
-  @Test
-  fun `verify correct prefix for camelCase table`() {
-    val tablePrefix = aliasManager.computePrefix("camelCaseTable")
-    assertThat(tablePrefix).isEqualTo("cct")
-  }
+    @Test
+    fun `verify correct prefix for camelCase table`() {
+        val tablePrefix = aliasManager.computePrefix("camelCaseTable")
+        assertThat(tablePrefix).isEqualTo("cct")
+    }
 
-  @Test
-  fun `verify correct prefix for association path`() {
-    val tablePrefix = aliasManager.computePrefix("book.author")
-    assertThat(tablePrefix).isEqualTo("a")
-  }
+    @Test
+    fun `verify correct prefix for association path`() {
+        val tablePrefix = aliasManager.computePrefix("book.author")
+        assertThat(tablePrefix).isEqualTo("a")
+    }
 
-  @Test
-  fun `verify alias generation for repeated paths`() {
-    val alias1 = aliasManager.generate("table")
-    val alias2 = aliasManager.generate("table")
-    assertThat(alias1).isEqualTo("t")
-    assertThat(alias2).isEqualTo("t2")
-  }
+    @Test
+    fun `verify alias generation for repeated paths`() {
+        val alias1 = aliasManager.generate("table")
+        val alias2 = aliasManager.generate("table")
+        assertThat(alias1).isEqualTo("t")
+        assertThat(alias2).isEqualTo("t2")
+    }
 
-  @Test
-  fun `nested paths use the last part to generate a prefix`() {
-    val barAlias = aliasManager.generate("foo.clyde.bar")
-    val bazAlias = aliasManager.generate("foo.clyde.baz")
-    assertThat(barAlias).isEqualTo("b")
-    assertThat(bazAlias).isEqualTo("b2")
-  }
+    @Test
+    fun `nested paths use the last part to generate a prefix`() {
+        val barAlias = aliasManager.generate("foo.clyde.bar")
+        val bazAlias = aliasManager.generate("foo.clyde.baz")
+        assertThat(barAlias).isEqualTo("b")
+        assertThat(bazAlias).isEqualTo("b2")
+    }
 
-  @Test
-  fun `verify alias generation for different paths does not use numbers until necessary`() {
-    val appleAlias = aliasManager.generate("apples")
-    val bananaAlias = aliasManager.generate("bananas")
-    val cherryAlias = aliasManager.generate("cherries")
+    @Test
+    fun `verify alias generation for different paths does not use numbers until necessary`() {
+        val appleAlias = aliasManager.generate("apples")
+        val bananaAlias = aliasManager.generate("bananas")
+        val cherryAlias = aliasManager.generate("cherries")
 
-    val appleAlias2 = aliasManager.generate("apples")
-    val bananaAlias2 = aliasManager.generate("bananas")
-    val cherryAlias2 = aliasManager.generate("cherries")
+        val appleAlias2 = aliasManager.generate("apples")
+        val bananaAlias2 = aliasManager.generate("bananas")
+        val cherryAlias2 = aliasManager.generate("cherries")
 
-    assertThat(appleAlias).isEqualTo("a")
-    assertThat(appleAlias2).isEqualTo("a2")
-    assertThat(bananaAlias).isEqualTo("b")
-    assertThat(bananaAlias2).isEqualTo("b2")
-    assertThat(cherryAlias).isEqualTo("c")
-    assertThat(cherryAlias2).isEqualTo("c2")
-  }
+        assertThat(appleAlias).isEqualTo("a")
+        assertThat(appleAlias2).isEqualTo("a2")
+        assertThat(bananaAlias).isEqualTo("b")
+        assertThat(bananaAlias2).isEqualTo("b2")
+        assertThat(cherryAlias).isEqualTo("c")
+        assertThat(cherryAlias2).isEqualTo("c2")
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/CustomHibernateConfigurer.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/CustomHibernateConfigurer.kt
@@ -9,116 +9,115 @@ import org.hibernate.SessionFactory
 import org.hibernate.cfg.Configuration
 import org.hibernate.dialect.H2Dialect
 import org.hibernate.internal.SessionFactoryImpl
-import java.util.Properties
-import kotlin.jvm.java
+import java.util.*
 import kotlin.reflect.KClass
 
 internal object CustomHibernateConfigurer {
-  private val gson by lazy { GsonBuilder().create() }
+    private val gson by lazy { GsonBuilder().create() }
 
-  fun createSessionFactory(
-      entities: Set<KClass<out BaseEntity<*>>>,
-  ): SessionFactory {
-    val properties = buildProperties()
-    val configuration = Configuration().addProperties(properties)
+    fun createSessionFactory(
+        entities: Set<KClass<out BaseEntity<*>>>,
+    ): SessionFactory {
+        val properties = buildProperties()
+        val configuration = Configuration().addProperties(properties)
 
-    bindEntities(configuration, entities)
-    registerCustomAdapters(configuration)
-    registerCustomJsonAdapter(configuration, entities)
+        bindEntities(configuration, entities)
+        registerCustomAdapters(configuration)
+        registerCustomJsonAdapter(configuration, entities)
 
-    val sessionFactory = configuration.buildSessionFactory()
-    fixJsonBindingsHack(sessionFactory)
+        val sessionFactory = configuration.buildSessionFactory()
+        fixJsonBindingsHack(sessionFactory)
 
-    return sessionFactory
-  }
-
-  private fun buildProperties(): Properties {
-    val properties = Properties()
-
-    // Switch to H2 Dialect for in-memory DB
-    properties["hibernate.dialect"] = H2Dialect::class.qualifiedName
-
-    // In-memory H2 database URL
-    properties["hibernate.connection.driver_class"] = "org.h2.Driver"
-    properties["hibernate.connection.url"] = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false"
-    properties["hibernate.connection.username"] = "sa"
-    properties["hibernate.connection.password"] = ""
-
-    // Automatically create and drop schema
-    properties["hibernate.hbm2ddl.auto"] = "create-drop"
-
-    // Optional optimizations / settings
-    properties["hibernate.show_sql"] = false
-    properties["hibernate.format_sql"] = false
-    properties["hibernate.use_sql_comments"] = false
-    properties["hibernate.generate_statistics"] = false
-    properties["hibernate.jdbc.time_zone"] = "UTC"
-    properties["hibernate.default_batch_fetch_size"] = 50
-    properties["hibernate.max_fetch_depth"] = 2
-    properties["hibernate.jdbc.batch_size"] = 50
-
-    return properties
-  }
-
-  private fun fixJsonBindingsHack(sessionFactory: SessionFactory) {
-    // Hibernate populates this map to provide types for SQL queries, but this breaks our code all
-    // over the place. JsonMessageType is not possible to initialize from the SQL context since
-    // it can't provide the constructor arguments.
-    // Clearing this out stops Hibernate from trying to load custom types in SQL queries.
-    (sessionFactory as SessionFactoryImpl).metamodel
-        .typeConfiguration
-        .jdbcToHibernateTypeContributionMap
-        .clear()
-  }
-
-  private fun bindEntities(
-      configuration: Configuration,
-      entities: Set<KClass<out BaseEntity<*>>>,
-  ) {
-    for (entity in entities) {
-      configuration.addAnnotatedClass(entity.java)
+        return sessionFactory
     }
-  }
 
-  private fun registerCustomJsonAdapter(
-      configuration: Configuration,
-      entities: Set<KClass<out BaseEntity<*>>>,
-  ) {
-    val existingJsonKeys = mutableMapOf<String, TypeLiteral<*>>()
-    for (entity in entities) {
-      addCustomFieldTypeConverters(configuration, entity, existingJsonKeys)
+    private fun buildProperties(): Properties {
+        val properties = Properties()
+
+        // Switch to H2 Dialect for in-memory DB
+        properties["hibernate.dialect"] = H2Dialect::class.qualifiedName
+
+        // In-memory H2 database URL
+        properties["hibernate.connection.driver_class"] = "org.h2.Driver"
+        properties["hibernate.connection.url"] = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false"
+        properties["hibernate.connection.username"] = "sa"
+        properties["hibernate.connection.password"] = ""
+
+        // Automatically create and drop schema
+        properties["hibernate.hbm2ddl.auto"] = "create-drop"
+
+        // Optional optimizations / settings
+        properties["hibernate.show_sql"] = false
+        properties["hibernate.format_sql"] = false
+        properties["hibernate.use_sql_comments"] = false
+        properties["hibernate.generate_statistics"] = false
+        properties["hibernate.jdbc.time_zone"] = "UTC"
+        properties["hibernate.default_batch_fetch_size"] = 50
+        properties["hibernate.max_fetch_depth"] = 2
+        properties["hibernate.jdbc.batch_size"] = 50
+
+        return properties
     }
-  }
 
-  private fun addCustomFieldTypeConverters(
-      configuration: Configuration,
-      entityClass: KClass<out BaseEntity<*>>,
-      existingJsonKeys: MutableMap<String, TypeLiteral<*>>,
-  ) {
-    val entityType = TypeLiteral.get(entityClass.java)
+    private fun fixJsonBindingsHack(sessionFactory: SessionFactory) {
+        // Hibernate populates this map to provide types for SQL queries, but this breaks our code all
+        // over the place. JsonMessageType is not possible to initialize from the SQL context since
+        // it can't provide the constructor arguments.
+        // Clearing this out stops Hibernate from trying to load custom types in SQL queries.
+        (sessionFactory as SessionFactoryImpl).metamodel
+            .typeConfiguration
+            .jdbcToHibernateTypeContributionMap
+            .clear()
+    }
 
-    for (field in entityClass.java.declaredFields) {
-      if (field.isAnnotationPresent(SerializeAsJson::class.java)) {
-        val fieldTypeLiteral = entityType.getFieldType(field)
-        val jsonMessageType = JsonMessageType(gson, fieldTypeLiteral)
-        val existingField = existingJsonKeys.put(field.type.name, fieldTypeLiteral)
-        require(existingField == null || existingField == fieldTypeLiteral) {
-          // If one entity has a field List<Country> and another has List<State>, hibernate won't be able to
-          // deserialize one of them, since the key is just "java.util.List" for both.
-          "@SerializeAsJson collision: ${field.type.name} for $field"
+    private fun bindEntities(
+        configuration: Configuration,
+        entities: Set<KClass<out BaseEntity<*>>>,
+    ) {
+        for (entity in entities) {
+            configuration.addAnnotatedClass(entity.java)
         }
-        val keys = arrayOf(field.type.name)
-        configuration.registerTypeOverride(jsonMessageType, keys)
-      }
     }
-  }
 
-  private fun registerCustomAdapters(
-      configuration: Configuration,
-  ) {
-    val idKeys = arrayOf(YawnId::class.java.name, YawnIdType::class.java.name)
-    configuration.registerTypeOverride(YawnIdType(), idKeys)
+    private fun registerCustomJsonAdapter(
+        configuration: Configuration,
+        entities: Set<KClass<out BaseEntity<*>>>,
+    ) {
+        val existingJsonKeys = mutableMapOf<String, TypeLiteral<*>>()
+        for (entity in entities) {
+            addCustomFieldTypeConverters(configuration, entity, existingJsonKeys)
+        }
+    }
 
-    configuration.addAttributeConverter(EmailAddressConverter::class.java, true)
-  }
+    private fun addCustomFieldTypeConverters(
+        configuration: Configuration,
+        entityClass: KClass<out BaseEntity<*>>,
+        existingJsonKeys: MutableMap<String, TypeLiteral<*>>,
+    ) {
+        val entityType = TypeLiteral.get(entityClass.java)
+
+        for (field in entityClass.java.declaredFields) {
+            if (field.isAnnotationPresent(SerializeAsJson::class.java)) {
+                val fieldTypeLiteral = entityType.getFieldType(field)
+                val jsonMessageType = JsonMessageType(gson, fieldTypeLiteral)
+                val existingField = existingJsonKeys.put(field.type.name, fieldTypeLiteral)
+                require(existingField == null || existingField == fieldTypeLiteral) {
+                    // If one entity has a field List<Country> and another has List<State>, hibernate won't be able to
+                    // deserialize one of them, since the key is just "java.util.List" for both.
+                    "@SerializeAsJson collision: ${field.type.name} for $field"
+                }
+                val keys = arrayOf(field.type.name)
+                configuration.registerTypeOverride(jsonMessageType, keys)
+            }
+        }
+    }
+
+    private fun registerCustomAdapters(
+        configuration: Configuration,
+    ) {
+        val idKeys = arrayOf(YawnId::class.java.name, YawnIdType::class.java.name)
+        configuration.registerTypeOverride(YawnIdType(), idKeys)
+
+        configuration.addAttributeConverter(EmailAddressConverter::class.java, true)
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/EmailAddressConverter.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/EmailAddressConverter.kt
@@ -3,11 +3,11 @@ package com.faire.yawn.setup.custom
 import javax.persistence.AttributeConverter
 
 internal class EmailAddressConverter : AttributeConverter<EmailAddress, String> {
-  override fun convertToDatabaseColumn(attribute: EmailAddress?): String? {
-    return attribute?.emailAddress
-  }
+    override fun convertToDatabaseColumn(attribute: EmailAddress?): String? {
+        return attribute?.emailAddress
+    }
 
-  override fun convertToEntityAttribute(string: String?): EmailAddress? {
-    return string?.let { EmailAddress(it) }
-  }
+    override fun convertToEntityAttribute(string: String?): EmailAddress? {
+        return string?.let { EmailAddress(it) }
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/JsonMessageType.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/JsonMessageType.kt
@@ -16,83 +16,83 @@ internal class JsonMessageType(
     private val gson: Gson,
     private val columnTypeLiteral: TypeLiteral<*>,
 ) : UserType {
-  override fun sqlTypes(): IntArray {
-    return SQL_TYPES
-  }
-
-  override fun returnedClass(): Class<*> {
-    return columnTypeLiteral.rawType
-  }
-
-  @Throws(HibernateException::class)
-  override fun equals(x: Any?, y: Any?): Boolean {
-    val xJson = gson.toJson(x, columnTypeLiteral.type)
-    val yJson = gson.toJson(y, columnTypeLiteral.type)
-    return if (xJson == null) yJson == null else yJson != null && xJson == yJson
-  }
-
-  @Throws(HibernateException::class)
-  override fun hashCode(value: Any): Int {
-    val json = gson.toJson(value, columnTypeLiteral.type)
-    return json.hashCode()
-  }
-
-  @Throws(HibernateException::class, SQLException::class)
-  override fun nullSafeGet(
-      rs: ResultSet,
-      names: Array<String>,
-      session: SharedSessionContractImplementor,
-      owner: Any?,
-  ): Any? {
-    val jsonData = rs.getString(names[0])
-    return if (rs.wasNull() || jsonData == null) {
-      null
-    } else {
-      gson.fromJson<Any>(jsonData, columnTypeLiteral.type)
-    }
-  }
-
-  @Throws(HibernateException::class, SQLException::class)
-  override fun nullSafeSet(
-      st: PreparedStatement,
-      value: Any?,
-      index: Int,
-      session: SharedSessionContractImplementor,
-  ) {
-    if (value == null) {
-      st.setNull(index, VARCHAR)
-      return
+    override fun sqlTypes(): IntArray {
+        return SQL_TYPES
     }
 
-    st.setString(index, gson.toJson(value, columnTypeLiteral.type))
-  }
+    override fun returnedClass(): Class<*> {
+        return columnTypeLiteral.rawType
+    }
 
-  @Throws(HibernateException::class)
-  override fun deepCopy(value: Any?): Any? {
-    val json = gson.toJson(value, columnTypeLiteral.type)
-    return gson.fromJson<Any>(json, columnTypeLiteral.type)
-  }
+    @Throws(HibernateException::class)
+    override fun equals(x: Any?, y: Any?): Boolean {
+        val xJson = gson.toJson(x, columnTypeLiteral.type)
+        val yJson = gson.toJson(y, columnTypeLiteral.type)
+        return if (xJson == null) yJson == null else yJson != null && xJson == yJson
+    }
 
-  override fun isMutable(): Boolean {
-    return true
-  }
+    @Throws(HibernateException::class)
+    override fun hashCode(value: Any): Int {
+        val json = gson.toJson(value, columnTypeLiteral.type)
+        return json.hashCode()
+    }
 
-  @Throws(HibernateException::class)
-  override fun disassemble(value: Any?): Serializable? {
-    return if (value == null) null else deepCopy(value) as Serializable?
-  }
+    @Throws(HibernateException::class, SQLException::class)
+    override fun nullSafeGet(
+        rs: ResultSet,
+        names: Array<String>,
+        session: SharedSessionContractImplementor,
+        owner: Any?,
+    ): Any? {
+        val jsonData = rs.getString(names[0])
+        return if (rs.wasNull() || jsonData == null) {
+            null
+        } else {
+            gson.fromJson<Any>(jsonData, columnTypeLiteral.type)
+        }
+    }
 
-  @Throws(HibernateException::class)
-  override fun assemble(cached: Serializable, owner: Any): Any? {
-    return gson.fromJson<Any>(cached as String, columnTypeLiteral.type)
-  }
+    @Throws(HibernateException::class, SQLException::class)
+    override fun nullSafeSet(
+        st: PreparedStatement,
+        value: Any?,
+        index: Int,
+        session: SharedSessionContractImplementor,
+    ) {
+        if (value == null) {
+            st.setNull(index, VARCHAR)
+            return
+        }
 
-  @Throws(HibernateException::class)
-  override fun replace(original: Any, target: Any, owner: Any): Any? {
-    return deepCopy(original)
-  }
+        st.setString(index, gson.toJson(value, columnTypeLiteral.type))
+    }
 
-  companion object {
-    private val SQL_TYPES = intArrayOf(VARCHAR)
-  }
+    @Throws(HibernateException::class)
+    override fun deepCopy(value: Any?): Any? {
+        val json = gson.toJson(value, columnTypeLiteral.type)
+        return gson.fromJson<Any>(json, columnTypeLiteral.type)
+    }
+
+    override fun isMutable(): Boolean {
+        return true
+    }
+
+    @Throws(HibernateException::class)
+    override fun disassemble(value: Any?): Serializable? {
+        return if (value == null) null else deepCopy(value) as Serializable?
+    }
+
+    @Throws(HibernateException::class)
+    override fun assemble(cached: Serializable, owner: Any): Any? {
+        return gson.fromJson<Any>(cached as String, columnTypeLiteral.type)
+    }
+
+    @Throws(HibernateException::class)
+    override fun replace(original: Any, target: Any, owner: Any): Any? {
+        return deepCopy(original)
+    }
+
+    companion object {
+        private val SQL_TYPES = intArrayOf(VARCHAR)
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/ReadOnlyEntity.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/custom/ReadOnlyEntity.kt
@@ -10,18 +10,18 @@ import javax.persistence.PreUpdate
  * any attempt to update or delete.
  */
 internal class ReadOnlyEntity {
-  @PrePersist
-  fun onPrePersist(entity: Any?) {
-    throw IllegalStateException("Attempting to persist a read-only entity of type ${entity?.javaClass}.")
-  }
+    @PrePersist
+    fun onPrePersist(entity: Any?) {
+        throw IllegalStateException("Attempting to persist a read-only entity of type ${entity?.javaClass}.")
+    }
 
-  @PreUpdate
-  fun onPreUpdate(entity: Any?) {
-    throw IllegalStateException("Attempting to update a read-only entity of type ${entity?.javaClass}.")
-  }
+    @PreUpdate
+    fun onPreUpdate(entity: Any?) {
+        throw IllegalStateException("Attempting to update a read-only entity of type ${entity?.javaClass}.")
+    }
 
-  @PreRemove
-  fun onPreRemove(entity: Any?) {
-    throw IllegalStateException("Attempting to remove a read-only entity of type ${entity?.javaClass}.")
-  }
+    @PreRemove
+    fun onPreRemove(entity: Any?) {
+        throw IllegalStateException("Attempting to remove a read-only entity of type ${entity?.javaClass}.")
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BaseEntity.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BaseEntity.kt
@@ -1,5 +1,5 @@
 package com.faire.yawn.setup.entities
 
 internal interface BaseEntity<T : Any> {
-  val id: YawnId<T>
+    val id: YawnId<T>
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/Book.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/Book.kt
@@ -24,72 +24,72 @@ import javax.persistence.Version
 @Table(
     name = "books",
     indexes = [
-    Index(name = "idx_name", columnList = "name"),
-],
+        Index(name = "idx_name", columnList = "name"),
+    ],
 )
 @YawnEntity
 internal class Book : TimestampedEntity<Book>() {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  override lateinit var id: YawnId<Book>
-    protected set
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    override lateinit var id: YawnId<Book>
+        protected set
 
-  @Column
-  @Version
-  var version: Long = 0
+    @Column
+    @Version
+    var version: Long = 0
 
-  @Column
-  lateinit var name: String
+    @Column
+    lateinit var name: String
 
-  @ElementCollection(targetClass = Genre::class)
-  @CollectionTable(name = "book_genres", joinColumns = [JoinColumn(name = "book_id")])
-  @Column(name = "genre")
-  @Enumerated(EnumType.STRING)
-  var genres = setOf<Genre>()
+    @ElementCollection(targetClass = Genre::class)
+    @CollectionTable(name = "book_genres", joinColumns = [JoinColumn(name = "book_id")])
+    @Column(name = "genre")
+    @Enumerated(EnumType.STRING)
+    var genres = setOf<Genre>()
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  lateinit var author: Person
+    @ManyToOne(fetch = FetchType.LAZY)
+    lateinit var author: Person
 
-  @Column
-  lateinit var originalLanguage: Language
+    @Column
+    lateinit var originalLanguage: Language
 
-  @Column
-  var numberOfPages: Long = 0
+    @Column
+    var numberOfPages: Long = 0
 
-  @Column
-  var rating: Int? = null
+    @Column
+    var rating: Int? = null
 
-  @Column
-  var notes: String? = null
+    @Column
+    var notes: String? = null
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "publisher_id")
-  var publisher: Publisher? = null
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id")
+    var publisher: Publisher? = null
 
-  @Formula("publisher_id IS NOT NULL")
-  var hasPublisher: Boolean = false
-    protected set
+    @Formula("publisher_id IS NOT NULL")
+    var hasPublisher: Boolean = false
+        protected set
 
-  @Embedded
-  lateinit var sales: BookSales
+    @Embedded
+    lateinit var sales: BookSales
 
-  @Column
-  @SerializeAsJson
-  var bookMetadata: BookMetadata? = null
+    @Column
+    @SerializeAsJson
+    var bookMetadata: BookMetadata? = null
 
-  data class BookMetadata(
-      val publicationYear: Int,
-      val isbn: String,
-  )
+    data class BookMetadata(
+        val publicationYear: Int,
+        val isbn: String,
+    )
 
-  enum class Language {
-    DANISH,
-    ENGLISH,
-  }
+    enum class Language {
+        DANISH,
+        ENGLISH,
+    }
 
-  enum class Genre {
-    FANTASY,
-    FAIRY_TALE,
-    ADVENTURE,
-  }
+    enum class Genre {
+        FANTASY,
+        FAIRY_TALE,
+        ADVENTURE,
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookFixtures.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookFixtures.kt
@@ -14,233 +14,233 @@ import kotlin.reflect.KClass
 internal class BookFixtures(
     private val transactor: YawnTestTransactor,
 ) {
-  fun setup() {
-    fixtures {
-      val tolkien = createPerson {
-        name = "J.R.R. Tolkien"
-        email = EmailAddress("tolkien@faire.com")
-      }
-      val rowling = createPerson {
-        name = "J.K. Rowling"
-        email = EmailAddress("rowling@faire.com")
-      }
-      val andersen = createPerson {
-        name = "Hans Christian Andersen"
-        email = EmailAddress("andersen@faire.com")
-      }
+    fun setup() {
+        fixtures {
+            val tolkien = createPerson {
+                name = "J.R.R. Tolkien"
+                email = EmailAddress("tolkien@faire.com")
+            }
+            val rowling = createPerson {
+                name = "J.K. Rowling"
+                email = EmailAddress("rowling@faire.com")
+            }
+            val andersen = createPerson {
+                name = "Hans Christian Andersen"
+                email = EmailAddress("andersen@faire.com")
+            }
 
-      val penguin = createPublisher { name = "Penguin" }
-      val harperCollins = createPublisher { name = "HarperCollins" }
-      val randomHouse = createPublisher { name = "Random House" }
-      val coOwned = createPublisher { name = "Co-Owned" }
+            val penguin = createPublisher { name = "Penguin" }
+            val harperCollins = createPublisher { name = "HarperCollins" }
+            val randomHouse = createPublisher { name = "Random House" }
+            val coOwned = createPublisher { name = "Co-Owned" }
 
-      val lotr = createBook(tolkien) {
-        name = "Lord of the Rings"
-        genres = setOf(FANTASY, ADVENTURE)
-        originalLanguage = ENGLISH
+            val lotr = createBook(tolkien) {
+                name = "Lord of the Rings"
+                genres = setOf(FANTASY, ADVENTURE)
+                originalLanguage = ENGLISH
 
-        publisher = harperCollins
-        numberOfPages = 1_000
-        rating = 10
-        sales = BookSales(
-            paperBacksSold = 1_500_000,
-            hardBacksSold = 1_499_999,
-            eBooksSold = 700_000,
-            countryWithMostCopiesSold = "UK",
-        )
-        bookMetadata = BookMetadata(
-            publicationYear = 1954,
-            isbn = "978-3-16-148410-0",
-        )
+                publisher = harperCollins
+                numberOfPages = 1_000
+                rating = 10
+                sales = BookSales(
+                    paperBacksSold = 1_500_000,
+                    hardBacksSold = 1_499_999,
+                    eBooksSold = 700_000,
+                    countryWithMostCopiesSold = "UK",
+                )
+                bookMetadata = BookMetadata(
+                    publicationYear = 1954,
+                    isbn = "978-3-16-148410-0",
+                )
 
-        notes = "Note for LoTR"
-      }
-      createBook(tolkien) {
-        name = "The Hobbit"
-        genres = setOf(FANTASY, ADVENTURE)
-        originalLanguage = ENGLISH
+                notes = "Note for LoTR"
+            }
+            createBook(tolkien) {
+                name = "The Hobbit"
+                genres = setOf(FANTASY, ADVENTURE)
+                originalLanguage = ENGLISH
 
-        publisher = randomHouse
-        numberOfPages = 300
-        rating = 9
-        sales = BookSales(
-            paperBacksSold = 2_000_000,
-            hardBacksSold = 1_999_999,
-            eBooksSold = 900_000,
-            countryWithMostCopiesSold = "UK",
-        )
-        bookMetadata = BookMetadata(
-            publicationYear = 1937,
-            isbn = "978-0-261-10221-7",
-        )
+                publisher = randomHouse
+                numberOfPages = 300
+                rating = 9
+                sales = BookSales(
+                    paperBacksSold = 2_000_000,
+                    hardBacksSold = 1_999_999,
+                    eBooksSold = 900_000,
+                    countryWithMostCopiesSold = "UK",
+                )
+                bookMetadata = BookMetadata(
+                    publicationYear = 1937,
+                    isbn = "978-0-261-10221-7",
+                )
 
-        notes = "Note for The Hobbit and Harry Potter"
-      }
+                notes = "Note for The Hobbit and Harry Potter"
+            }
 
-      val hp = createBook(rowling) {
-        name = "Harry Potter"
-        genres = setOf(FANTASY)
-        originalLanguage = ENGLISH
+            val hp = createBook(rowling) {
+                name = "Harry Potter"
+                genres = setOf(FANTASY)
+                originalLanguage = ENGLISH
 
-        publisher = penguin
-        numberOfPages = 500
-        sales = BookSales(
-            paperBacksSold = 1_000_000,
-            hardBacksSold = 999_999,
-            eBooksSold = 500_000,
-            countryWithMostCopiesSold = "UK",
-        )
+                publisher = penguin
+                numberOfPages = 500
+                sales = BookSales(
+                    paperBacksSold = 1_000_000,
+                    hardBacksSold = 999_999,
+                    eBooksSold = 500_000,
+                    countryWithMostCopiesSold = "UK",
+                )
 
-        notes = "Note for The Hobbit and Harry Potter"
-      }
+                notes = "Note for The Hobbit and Harry Potter"
+            }
 
-      val littleMermaid = createBook(andersen) {
-        name = "The Little Mermaid"
-        genres = setOf(FAIRY_TALE)
-        originalLanguage = DANISH
+            val littleMermaid = createBook(andersen) {
+                name = "The Little Mermaid"
+                genres = setOf(FAIRY_TALE)
+                originalLanguage = DANISH
 
-        numberOfPages = 100
-        sales = BookSales(
-            paperBacksSold = 600,
-            hardBacksSold = 300,
-            eBooksSold = 100,
-            countryWithMostCopiesSold = "NL",
-        )
-      }
-      createBook(andersen) {
-        name = "The Ugly Duckling"
-        genres = setOf(FAIRY_TALE)
-        originalLanguage = DANISH
+                numberOfPages = 100
+                sales = BookSales(
+                    paperBacksSold = 600,
+                    hardBacksSold = 300,
+                    eBooksSold = 100,
+                    countryWithMostCopiesSold = "NL",
+                )
+            }
+            createBook(andersen) {
+                name = "The Ugly Duckling"
+                genres = setOf(FAIRY_TALE)
+                originalLanguage = DANISH
 
-        numberOfPages = 110
-        sales = BookSales(
-            paperBacksSold = 600_000,
-            hardBacksSold = 300_000,
-            eBooksSold = 200_000,
-            countryWithMostCopiesSold = "US",
-        )
-      }
-      val emperorsNewClothes = createBook(andersen) {
-        name = "The Emperor's New Clothes"
-        genres = setOf(FAIRY_TALE)
-        originalLanguage = DANISH
+                numberOfPages = 110
+                sales = BookSales(
+                    paperBacksSold = 600_000,
+                    hardBacksSold = 300_000,
+                    eBooksSold = 200_000,
+                    countryWithMostCopiesSold = "US",
+                )
+            }
+            val emperorsNewClothes = createBook(andersen) {
+                name = "The Emperor's New Clothes"
+                genres = setOf(FAIRY_TALE)
+                originalLanguage = DANISH
 
-        publisher = penguin
-        numberOfPages = 120
-        sales = BookSales(
-            paperBacksSold = 600_000,
-            hardBacksSold = 300_000,
-            eBooksSold = 200_000,
-            countryWithMostCopiesSold = "CA",
-        )
-      }
+                publisher = penguin
+                numberOfPages = 120
+                sales = BookSales(
+                    paperBacksSold = 600_000,
+                    hardBacksSold = 300_000,
+                    eBooksSold = 200_000,
+                    countryWithMostCopiesSold = "CA",
+                )
+            }
 
-      createPerson {
-        name = "Paul Duchesne"
-        email = EmailAddress("paul.duchesne@faire.com")
-        favoriteBook = lotr
-        favoriteAuthor = andersen
-      }
-      createPerson {
-        name = "Luan Nico"
-        email = EmailAddress("luan@faire.com")
-        favoriteBook = hp
-        favoriteAuthor = tolkien
-      }
-      update(rowling) {
-        favoriteBook = lotr
-        favoriteAuthor = tolkien
-      }
-      update(tolkien) {
-        favoriteBook = littleMermaid
-        favoriteAuthor = andersen
-      }
+            createPerson {
+                name = "Paul Duchesne"
+                email = EmailAddress("paul.duchesne@faire.com")
+                favoriteBook = lotr
+                favoriteAuthor = andersen
+            }
+            createPerson {
+                name = "Luan Nico"
+                email = EmailAddress("luan@faire.com")
+                favoriteBook = hp
+                favoriteAuthor = tolkien
+            }
+            update(rowling) {
+                favoriteBook = lotr
+                favoriteAuthor = tolkien
+            }
+            update(tolkien) {
+                favoriteBook = littleMermaid
+                favoriteAuthor = andersen
+            }
 
-      val john = createOwner(penguin, randomHouse) {
-        name = "John Doe"
-        favoriteAuthor = rowling
-      }
-      val jane = createOwner(harperCollins) {
-        name = "Jane Doe"
-        favoriteBook = emperorsNewClothes
-      }
-      update(coOwned) {
-        owners = listOf(john, jane)
-      }
+            val john = createOwner(penguin, randomHouse) {
+                name = "John Doe"
+                favoriteAuthor = rowling
+            }
+            val jane = createOwner(harperCollins) {
+                name = "Jane Doe"
+                favoriteBook = emperorsNewClothes
+            }
+            update(coOwned) {
+                owners = listOf(john, jane)
+            }
 
-      createBookRanking {
-        ratingYear = 2007
-        ratingMonth = 1
-        bestSeller = hp
-      }
-    }
-  }
-
-  private fun fixtures(setup: Context.() -> Unit) {
-    transactor.open { session -> Context(session).setup() }
-  }
-
-  private inner class Context(
-      private val session: YawnTestSession,
-  ) {
-    fun createPerson(setup: Person.() -> Unit): Person {
-      return update(Person(), setup)
-    }
-
-    fun createPublisher(setup: Publisher.() -> Unit): Publisher {
-      return update(Publisher(), setup)
-    }
-
-    fun createBookRanking(setup: BookRanking.() -> Unit): BookRanking {
-      return update(BookRanking(), setup)
-    }
-
-    fun createBook(
-        author: Person,
-        setup: Book.() -> Unit,
-    ): Book {
-      val book = update(Book()) {
-        this.author = author
-        setup()
-      }
-
-      val publisher = book.publisher
-      if (publisher != null) {
-        publisher.publishedBookIds.add(book.id)
-        session.save(publisher)
-      }
-
-      return book
-    }
-
-    fun createOwner(vararg publishers: Publisher, setup: Person.() -> Unit): Person {
-      val owner = createPerson {
-        ownedPublishers = publishers.toList()
-        setup()
-      }
-      for (publisher in publishers) {
-        update(publisher) {
-          owners += owner
+            createBookRanking {
+                ratingYear = 2007
+                ratingMonth = 1
+                bestSeller = hp
+            }
         }
-      }
-      return owner
     }
 
-    fun <T : BaseEntity<T>> update(
-        entity: T,
-        setup: T.() -> Unit,
-    ): T {
-      return session.save(entity.apply(setup))
+    private fun fixtures(setup: Context.() -> Unit) {
+        transactor.open { session -> Context(session).setup() }
     }
-  }
 
-  companion object {
-    val entities = setOf<KClass<out BaseEntity<*>>>(
-        Book::class,
-        BookRanking::class,
-        BookView::class,
-        Person::class,
-        Publisher::class,
-    )
-  }
+    private inner class Context(
+        private val session: YawnTestSession,
+    ) {
+        fun createPerson(setup: Person.() -> Unit): Person {
+            return update(Person(), setup)
+        }
+
+        fun createPublisher(setup: Publisher.() -> Unit): Publisher {
+            return update(Publisher(), setup)
+        }
+
+        fun createBookRanking(setup: BookRanking.() -> Unit): BookRanking {
+            return update(BookRanking(), setup)
+        }
+
+        fun createBook(
+            author: Person,
+            setup: Book.() -> Unit,
+        ): Book {
+            val book = update(Book()) {
+                this.author = author
+                setup()
+            }
+
+            val publisher = book.publisher
+            if (publisher != null) {
+                publisher.publishedBookIds.add(book.id)
+                session.save(publisher)
+            }
+
+            return book
+        }
+
+        fun createOwner(vararg publishers: Publisher, setup: Person.() -> Unit): Person {
+            val owner = createPerson {
+                ownedPublishers = publishers.toList()
+                setup()
+            }
+            for (publisher in publishers) {
+                update(publisher) {
+                    owners += owner
+                }
+            }
+            return owner
+        }
+
+        fun <T : BaseEntity<T>> update(
+            entity: T,
+            setup: T.() -> Unit,
+        ): T {
+            return session.save(entity.apply(setup))
+        }
+    }
+
+    companion object {
+        val entities = setOf<KClass<out BaseEntity<*>>>(
+            Book::class,
+            BookRanking::class,
+            BookView::class,
+            Person::class,
+            Publisher::class,
+        )
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookRanking.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookRanking.kt
@@ -16,22 +16,22 @@ import javax.persistence.Version
 @Table(name = "book_rankings")
 @YawnEntity
 internal class BookRanking : TimestampedEntity<BookRanking>() {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  override lateinit var id: YawnId<BookRanking>
-    protected set
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    override lateinit var id: YawnId<BookRanking>
+        protected set
 
-  @Column
-  @Version
-  var version: Long = 0
+    @Column
+    @Version
+    var version: Long = 0
 
-  @Column
-  var ratingYear: Int = 0
+    @Column
+    var ratingYear: Int = 0
 
-  @Column
-  var ratingMonth: Int = 0
+    @Column
+    var ratingMonth: Int = 0
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn
-  lateinit var bestSeller: Book
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    lateinit var bestSeller: Book
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookSales.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookSales.kt
@@ -5,30 +5,30 @@ import javax.persistence.Embeddable
 
 @Embeddable
 internal class BookSales {
-  @Column
-  var paperBacksSold: Long = 0
+    @Column
+    var paperBacksSold: Long = 0
 
-  @Column
-  var hardBacksSold: Long = 0
+    @Column
+    var hardBacksSold: Long = 0
 
-  @Column
-  var eBooksSold: Long = 0
+    @Column
+    var eBooksSold: Long = 0
 
-  @Column
-  var countryWithMostCopiesSold: String = ""
+    @Column
+    var countryWithMostCopiesSold: String = ""
 
-  // Default no-argument constructor required by Hibernate
-  constructor()
+    // Default no-argument constructor required by Hibernate
+    constructor()
 
-  constructor(
-      paperBacksSold: Long = 0,
-      hardBacksSold: Long = 0,
-      eBooksSold: Long = 0,
-      countryWithMostCopiesSold: String = "",
-  ) {
-    this.paperBacksSold = paperBacksSold
-    this.hardBacksSold = hardBacksSold
-    this.eBooksSold = eBooksSold
-    this.countryWithMostCopiesSold = countryWithMostCopiesSold
-  }
+    constructor(
+        paperBacksSold: Long = 0,
+        hardBacksSold: Long = 0,
+        eBooksSold: Long = 0,
+        countryWithMostCopiesSold: String = "",
+    ) {
+        this.paperBacksSold = paperBacksSold
+        this.hardBacksSold = hardBacksSold
+        this.eBooksSold = eBooksSold
+        this.countryWithMostCopiesSold = countryWithMostCopiesSold
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookView.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/BookView.kt
@@ -17,12 +17,12 @@ import javax.persistence.Table
 @YawnEntity
 @Immutable
 internal class BookView : BaseEntity<BookView> {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  final override lateinit var id: YawnId<BookView>
-    private set
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    final override lateinit var id: YawnId<BookView>
+        private set
 
-  @Column
-  final lateinit var name: String
-    private set
+    @Column
+    final lateinit var name: String
+        private set
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/Person.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/Person.kt
@@ -18,31 +18,31 @@ import javax.persistence.Version
 @Table(name = "people")
 @YawnEntity
 internal class Person : TimestampedEntity<Person>(), PersonInterface {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  override lateinit var id: YawnId<Person>
-    protected set
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    override lateinit var id: YawnId<Person>
+        protected set
 
-  @Column
-  @Version
-  var version: Long = 0
+    @Column
+    @Version
+    var version: Long = 0
 
-  @Column
-  override lateinit var name: String
+    @Column
+    override lateinit var name: String
 
-  /**
-   * Test for custom adapter via [com.faire.yawn.setup.custom.EmailAddressConverter]
-   */
-  @Column
-  lateinit var email: EmailAddress
+    /**
+     * Test for custom adapter via [com.faire.yawn.setup.custom.EmailAddressConverter]
+     */
+    @Column
+    lateinit var email: EmailAddress
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  var favoriteBook: Book? = null
+    @ManyToOne(fetch = FetchType.LAZY)
+    var favoriteBook: Book? = null
 
-  @ManyToOne(fetch = FetchType.LAZY, targetEntity = Person::class)
-  @JoinColumn
-  var favoriteAuthor: PersonInterface? = null
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = Person::class)
+    @JoinColumn
+    var favoriteAuthor: PersonInterface? = null
 
-  @ManyToMany(mappedBy = "owners", fetch = FetchType.LAZY, targetEntity = Publisher::class)
-  var ownedPublishers: List<Publisher> = listOf()
+    @ManyToMany(mappedBy = "owners", fetch = FetchType.LAZY, targetEntity = Publisher::class)
+    var ownedPublishers: List<Publisher> = listOf()
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/PersonInterface.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/PersonInterface.kt
@@ -1,6 +1,6 @@
 package com.faire.yawn.setup.entities
 
 internal interface PersonInterface {
-  val id: YawnId<Person>
-  val name: String
+    val id: YawnId<Person>
+    val name: String
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/Publisher.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/Publisher.kt
@@ -21,38 +21,38 @@ import javax.persistence.Version
 @Table(name = "publishers")
 @YawnEntity
 internal class Publisher : TimestampedEntity<Publisher>() {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  override lateinit var id: YawnId<Publisher>
-    protected set
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    override lateinit var id: YawnId<Publisher>
+        protected set
 
-  @Column
-  @Version
-  var version: Long = 0
+    @Column
+    @Version
+    var version: Long = 0
 
-  @Column
-  lateinit var name: String
+    @Column
+    lateinit var name: String
 
-  @OneToMany(mappedBy = "publisher", fetch = FetchType.LAZY, targetEntity = Book::class)
-  var books: List<Book> = listOf()
+    @OneToMany(mappedBy = "publisher", fetch = FetchType.LAZY, targetEntity = Book::class)
+    var books: List<Book> = listOf()
 
-  @ElementCollection(fetch = FetchType.LAZY)
-  @CollectionTable(
-      name = "publisher_published_books",
-      joinColumns = [JoinColumn(name = "publisher_id", referencedColumnName = "id")],
-  )
-  @Column(name = "book_id")
-  var publishedBookIds: MutableSet<YawnId<Book>> = mutableSetOf()
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+        name = "publisher_published_books",
+        joinColumns = [JoinColumn(name = "publisher_id", referencedColumnName = "id")],
+    )
+    @Column(name = "book_id")
+    var publishedBookIds: MutableSet<YawnId<Book>> = mutableSetOf()
 
-  @ManyToMany(fetch = FetchType.LAZY, targetEntity = Person::class)
-  @JoinTable(
-      name = "publisher_owners",
-      joinColumns = [JoinColumn(name = "publisher_id")],
-      inverseJoinColumns = [JoinColumn(name = "person_id")],
-  )
-  var owners: List<Person> = listOf()
+    @ManyToMany(fetch = FetchType.LAZY, targetEntity = Person::class)
+    @JoinTable(
+        name = "publisher_owners",
+        joinColumns = [JoinColumn(name = "publisher_id")],
+        inverseJoinColumns = [JoinColumn(name = "person_id")],
+    )
+    var owners: List<Person> = listOf()
 
-  @Formula("LENGTH(name)")
-  var nameLetterCount: Int = 0
-    protected set
+    @Formula("LENGTH(name)")
+    var nameLetterCount: Int = 0
+        protected set
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/TimestampedEntity.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/entities/TimestampedEntity.kt
@@ -6,11 +6,11 @@ import javax.persistence.MappedSuperclass
 
 @MappedSuperclass
 internal abstract class TimestampedEntity<T : Any> : BaseEntity<T> {
-  @Column(updatable = false)
-  lateinit var createdAt: Instant
+    @Column(updatable = false)
+    lateinit var createdAt: Instant
 
-  @Column
-  lateinit var updatedAt: Instant
+    @Column
+    lateinit var updatedAt: Instant
 
-  internal fun isCreatedAtInitialized(): Boolean = this::createdAt.isInitialized
+    internal fun isCreatedAtInitialized(): Boolean = this::createdAt.isInitialized
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnIdType.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnIdType.kt
@@ -13,78 +13,78 @@ import java.sql.SQLException
 import java.sql.Types
 
 internal class YawnIdType : UserType, ResultSetIdentifierConsumer {
-  override fun sqlTypes(): IntArray {
-    return TYPE
-  }
-
-  override fun returnedClass(): Class<*> {
-    return YawnId::class.java
-  }
-
-  @Throws(HibernateException::class)
-  override fun equals(x: Any?, y: Any?): Boolean {
-    return x == y
-  }
-
-  @Throws(HibernateException::class)
-  override fun hashCode(x: Any): Int {
-    return x.hashCode()
-  }
-
-  @Throws(HibernateException::class, SQLException::class)
-  override fun nullSafeGet(
-      resultSet: ResultSet,
-      names: Array<String>,
-      session: SharedSessionContractImplementor,
-      owner: Any?,
-  ): Any? {
-    val value = resultSet.getLong(names[0])
-    return if (resultSet.wasNull()) null else YawnId<BaseEntity<*>>(value)
-  }
-
-  @Throws(HibernateException::class, SQLException::class)
-  override fun nullSafeSet(
-      statement: PreparedStatement,
-      value: Any?,
-      index: Int,
-      session: SharedSessionContractImplementor,
-  ) {
-    if (value != null) {
-      statement.setLong(index, (value as YawnId<*>).id)
-    } else {
-      statement.setNull(index, sqlTypes()[0])
+    override fun sqlTypes(): IntArray {
+        return TYPE
     }
-  }
 
-  @Throws(HibernateException::class)
-  override fun deepCopy(value: Any?): Any? {
-    return value
-  }
+    override fun returnedClass(): Class<*> {
+        return YawnId::class.java
+    }
 
-  override fun isMutable(): Boolean {
-    return false
-  }
+    @Throws(HibernateException::class)
+    override fun equals(x: Any?, y: Any?): Boolean {
+        return x == y
+    }
 
-  @Throws(HibernateException::class)
-  override fun disassemble(value: Any): Serializable {
-    return value as Serializable
-  }
+    @Throws(HibernateException::class)
+    override fun hashCode(x: Any): Int {
+        return x.hashCode()
+    }
 
-  @Throws(HibernateException::class)
-  override fun assemble(cached: Serializable, owner: Any): Any {
-    return cached
-  }
+    @Throws(HibernateException::class, SQLException::class)
+    override fun nullSafeGet(
+        resultSet: ResultSet,
+        names: Array<String>,
+        session: SharedSessionContractImplementor,
+        owner: Any?,
+    ): Any? {
+        val value = resultSet.getLong(names[0])
+        return if (resultSet.wasNull()) null else YawnId<BaseEntity<*>>(value)
+    }
 
-  @Throws(HibernateException::class)
-  override fun replace(original: Any, target: Any, owner: Any): Any {
-    return original
-  }
+    @Throws(HibernateException::class, SQLException::class)
+    override fun nullSafeSet(
+        statement: PreparedStatement,
+        value: Any?,
+        index: Int,
+        session: SharedSessionContractImplementor,
+    ) {
+        if (value != null) {
+            statement.setLong(index, (value as YawnId<*>).id)
+        } else {
+            statement.setNull(index, sqlTypes()[0])
+        }
+    }
 
-  override fun consumeIdentifier(resultSet: ResultSet): Serializable {
-    return YawnId<BaseEntity<*>>(resultSet.getLong(1))
-  }
+    @Throws(HibernateException::class)
+    override fun deepCopy(value: Any?): Any? {
+        return value
+    }
 
-  companion object {
-    private val TYPE = intArrayOf(Types.BIGINT)
-  }
+    override fun isMutable(): Boolean {
+        return false
+    }
+
+    @Throws(HibernateException::class)
+    override fun disassemble(value: Any): Serializable {
+        return value as Serializable
+    }
+
+    @Throws(HibernateException::class)
+    override fun assemble(cached: Serializable, owner: Any): Any {
+        return cached
+    }
+
+    @Throws(HibernateException::class)
+    override fun replace(original: Any, target: Any, owner: Any): Any {
+        return original
+    }
+
+    override fun consumeIdentifier(resultSet: ResultSet): Serializable {
+        return YawnId<BaseEntity<*>>(resultSet.getLong(1))
+    }
+
+    companion object {
+        private val TYPE = intArrayOf(Types.BIGINT)
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestCompiledQuery.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestCompiledQuery.kt
@@ -6,13 +6,13 @@ import org.hibernate.Criteria
 internal class YawnTestCompiledQuery<T>(
     private val rawQuery: Criteria,
 ) : CompiledYawnQuery<T> {
-  override fun list(): List<T> {
-    @Suppress("UNCHECKED_CAST")
-    return rawQuery.list() as List<T>
-  }
+    override fun list(): List<T> {
+        @Suppress("UNCHECKED_CAST")
+        return rawQuery.list() as List<T>
+    }
 
-  override fun uniqueResult(): T? {
-    @Suppress("UNCHECKED_CAST")
-    return rawQuery.uniqueResult() as T?
-  }
+    override fun uniqueResult(): T? {
+        @Suppress("UNCHECKED_CAST")
+        return rawQuery.uniqueResult() as T?
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestQueryFactory.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestQueryFactory.kt
@@ -11,53 +11,53 @@ import org.hibernate.Session
 internal class YawnTestQueryFactory(
     val session: Session,
 ) : YawnQueryFactory {
-  override fun <T : Any> compile(query: YawnQuery<*, T>, tableDef: YawnTableDef<*, *>): CompiledYawnQuery<T> {
-    val context = YawnCompilationContext.fromQuery(query)
+    override fun <T : Any> compile(query: YawnQuery<*, T>, tableDef: YawnTableDef<*, *>): CompiledYawnQuery<T> {
+        val context = YawnCompilationContext.fromQuery(query)
 
-    @Suppress("UNCHECKED_CAST", "ReplaceCreateCriteriaWithCreateYawnCriteria")
-    val rawQuery = context.generateAlias(tableDef)?.let { rootAlias ->
-      session.createCriteria(query.clazz, rootAlias)
-    } ?: session.createCriteria(query.clazz)
+        @Suppress("UNCHECKED_CAST", "ReplaceCreateCriteriaWithCreateYawnCriteria")
+        val rawQuery = context.generateAlias(tableDef)?.let { rootAlias ->
+            session.createCriteria(query.clazz, rootAlias)
+        } ?: session.createCriteria(query.clazz)
 
-    for (hint in query.queryHints) {
-      rawQuery.addQueryHint(hint.hint)
+        for (hint in query.queryHints) {
+            rawQuery.addQueryHint(hint.hint)
+        }
+
+        for (join in query.joins) {
+            val alias = checkNotNull(context.generateAlias(join.parent)) {
+                "Unable to generate alias for join"
+            }
+
+            if (join.joinCriteria.isNotEmpty()) {
+                val criterion = And(join.joinCriteria)
+                rawQuery.createAlias(join.path(context), alias, join.joinType, criterion.compile(context))
+            } else {
+                rawQuery.createAlias(join.path(context), alias, join.joinType)
+            }
+        }
+
+        for (criterion in query.criteria.map { it.yawnRestriction.compile(context) }) {
+            rawQuery.add(criterion)
+        }
+
+        for (order in query.orders) {
+            rawQuery.addOrder(order.compile(context))
+        }
+
+        val maxResults = query.maxResults
+        if (maxResults != null) {
+            rawQuery.setMaxResults(maxResults)
+        }
+        val offset = query.offset
+        if (offset != null) {
+            rawQuery.setFirstResult(offset)
+        }
+
+        val hibernateProjection = query.projection?.compile(context)
+        if (hibernateProjection != null) {
+            rawQuery.setProjection(hibernateProjection)
+        }
+
+        return YawnTestCompiledQuery(rawQuery)
     }
-
-    for (join in query.joins) {
-      val alias = checkNotNull(context.generateAlias(join.parent)) {
-        "Unable to generate alias for join"
-      }
-
-      if (join.joinCriteria.isNotEmpty()) {
-        val criterion = And(join.joinCriteria)
-        rawQuery.createAlias(join.path(context), alias, join.joinType, criterion.compile(context))
-      } else {
-        rawQuery.createAlias(join.path(context), alias, join.joinType)
-      }
-    }
-
-    for (criterion in query.criteria.map { it.yawnRestriction.compile(context) }) {
-      rawQuery.add(criterion)
-    }
-
-    for (order in query.orders) {
-      rawQuery.addOrder(order.compile(context))
-    }
-
-    val maxResults = query.maxResults
-    if (maxResults != null) {
-      rawQuery.setMaxResults(maxResults)
-    }
-    val offset = query.offset
-    if (offset != null) {
-      rawQuery.setFirstResult(offset)
-    }
-
-    val hibernateProjection = query.projection?.compile(context)
-    if (hibernateProjection != null) {
-      rawQuery.setProjection(hibernateProjection)
-    }
-
-    return YawnTestCompiledQuery(rawQuery)
-  }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestSession.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestSession.kt
@@ -16,38 +16,38 @@ import java.time.Instant
 internal class YawnTestSession(
     val session: Session,
 ) {
-  val yawn = Yawn(queryFactory = YawnTestQueryFactory(session))
+    val yawn = Yawn(queryFactory = YawnTestQueryFactory(session))
 
-  fun <T> save(entity: T): T {
-    if (entity is TimestampedEntity<*>) {
-      updateTimestamps(entity)
+    fun <T> save(entity: T): T {
+        if (entity is TimestampedEntity<*>) {
+            updateTimestamps(entity)
+        }
+
+        session.save(entity)
+        return entity
     }
 
-    session.save(entity)
-    return entity
-  }
-
-  inline fun <reified T : BaseEntity<T>, reified DEF : YawnTableDef<T, T>> query(
-      tableRef: YawnTableRef<T, DEF>,
-      noinline lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit = {},
-  ): TypeSafeCriteriaBuilder<T, DEF> {
-    return yawn.query(T::class.java, tableRef, lambda)
-  }
-
-  inline fun <reified T : BaseEntity<T>, reified DEF : YawnTableDef<T, T>, PROJECTION : Any?> project(
-      tableRef: YawnTableRef<T, DEF>,
-      noinline lambda:
-      ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(tableDef: DEF) -> YawnQueryProjection<T, PROJECTION>,
-  ): ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION> {
-    return yawn.project(T::class.java, tableRef, lambda)
-  }
-
-  @Suppress("SystemTimeReplacedWithClock")
-  private fun updateTimestamps(entity: TimestampedEntity<*>) {
-    val now = Instant.now()
-    entity.updatedAt = now
-    if (!entity.isCreatedAtInitialized()) {
-      entity.createdAt = now
+    inline fun <reified T : BaseEntity<T>, reified DEF : YawnTableDef<T, T>> query(
+        tableRef: YawnTableRef<T, DEF>,
+        noinline lambda: TypeSafeCriteriaQuery<T, DEF>.(tableDef: DEF) -> Unit = {},
+    ): TypeSafeCriteriaBuilder<T, DEF> {
+        return yawn.query(T::class.java, tableRef, lambda)
     }
-  }
+
+    inline fun <reified T : BaseEntity<T>, reified DEF : YawnTableDef<T, T>, PROJECTION : Any?> project(
+        tableRef: YawnTableRef<T, DEF>,
+        noinline lambda:
+        ProjectedTypeSafeCriteriaQuery<T, T, DEF, PROJECTION>.(tableDef: DEF) -> YawnQueryProjection<T, PROJECTION>,
+    ): ProjectedTypeSafeCriteriaBuilder<T, DEF, PROJECTION> {
+        return yawn.project(T::class.java, tableRef, lambda)
+    }
+
+    @Suppress("SystemTimeReplacedWithClock")
+    private fun updateTimestamps(entity: TimestampedEntity<*>) {
+        val now = Instant.now()
+        entity.updatedAt = now
+        if (!entity.isCreatedAtInitialized()) {
+            entity.createdAt = now
+        }
+    }
 }

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestTransactor.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestTransactor.kt
@@ -4,24 +4,24 @@ import com.faire.yawn.setup.custom.CustomHibernateConfigurer
 import com.faire.yawn.setup.entities.BookFixtures
 
 internal class YawnTestTransactor {
-  private val sessionFactory by lazy {
-    CustomHibernateConfigurer.createSessionFactory(
-        entities = BookFixtures.entities,
-    )
-  }
-
-  fun <T> open(lambda: (YawnTestSession) -> T): T {
-    val session = sessionFactory.openSession()
-    return session.use { hibernateSession ->
-      val transaction = hibernateSession.beginTransaction()
-      try {
-        val result = lambda(YawnTestSession(hibernateSession))
-        transaction.commit()
-        result
-      } catch (t: Throwable) {
-        transaction.rollback()
-        throw t
-      }
+    private val sessionFactory by lazy {
+        CustomHibernateConfigurer.createSessionFactory(
+            entities = BookFixtures.entities,
+        )
     }
-  }
+
+    fun <T> open(lambda: (YawnTestSession) -> T): T {
+        val session = sessionFactory.openSession()
+        return session.use { hibernateSession ->
+            val transaction = hibernateSession.beginTransaction()
+            try {
+                val result = lambda(YawnTestSession(hibernateSession))
+                transaction.commit()
+                result
+            } catch (t: Throwable) {
+                transaction.rollback()
+                throw t
+            }
+        }
+    }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/BaseYawnDatabaseTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/BaseYawnDatabaseTest.kt
@@ -5,11 +5,11 @@ import com.faire.yawn.setup.hibernate.YawnTestTransactor
 import org.junit.jupiter.api.BeforeEach
 
 internal open class BaseYawnDatabaseTest {
-  protected lateinit var transactor: YawnTestTransactor
+    protected lateinit var transactor: YawnTestTransactor
 
-  @BeforeEach
-  fun setup() {
-    transactor = YawnTestTransactor()
-    BookFixtures(transactor).setup()
-  }
+    @BeforeEach
+    fun setup() {
+        transactor = YawnTestTransactor()
+        BookFixtures(transactor).setup()
+    }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnCriterionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnCriterionTest.kt
@@ -27,453 +27,453 @@ import org.hibernate.criterion.MatchMode
 import org.junit.jupiter.api.Test
 
 internal class YawnCriterionTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `eq column against String`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            eq(books.name, "The Hobbit"),
-        )
-      }.list()
+    @Test
+    fun `eq column against String`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    eq(books.name, "The Hobbit"),
+                )
+            }.list()
 
-      val theHobbit = results.single()
-      assertThat(theHobbit.name).isEqualTo("The Hobbit")
-      assertThat(theHobbit.author.name).isEqualTo("J.R.R. Tolkien")
-    }
-  }
-
-  @Test
-  fun `eq column against column`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            eq(books.sales.eBooksSold, books.numberOfPages),
-        )
-      }.list()
-
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder("The Little Mermaid")
-    }
-  }
-
-  @Test
-  fun `gt column against long`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            gt(books.numberOfPages, 300),
-        )
-      }.list()
-
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Harry Potter",
-              "Lord of the Rings",
-          )
-    }
-  }
-
-  @Test
-  fun `gt column against hibernate supported object`() {
-    transactor.open { session ->
-      val dateTimeCreatedSecondBook = session.query(BookTable) { books ->
-        add(eq(books.name, "The Hobbit"))
-      }.uniqueResult()!!.createdAt
-      val dbBook = session.query(BookTable) { books ->
-        add(gt(books.createdAt, dateTimeCreatedSecondBook))
-      }.list()
-
-      assertThat(dbBook)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Harry Potter",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
-    }
-  }
-
-  @Test
-  fun `joins with book and author`() {
-    transactor.open { session ->
-      // Find all books by J.R.R. Tolkien
-      val results = session.query(BookTable) { books ->
-        val author = join(books.author)
-        add(eq(author.name, "J.R.R. Tolkien"))
-      }.list()
-
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit")
+            val theHobbit = results.single()
+            assertThat(theHobbit.name).isEqualTo("The Hobbit")
+            assertThat(theHobbit.author.name).isEqualTo("J.R.R. Tolkien")
+        }
     }
 
-    // Find all people who have a favorite book by J.R.R. Tolkien
-    transactor.open { session ->
-      val results = session.query(PersonTable) { people ->
-        val favoriteBook = join(people.favoriteBook)
-        val favoriteBookAuthor = join(favoriteBook.author)
-        add(eq(favoriteBookAuthor.name, "J.R.R. Tolkien"))
-      }.list()
+    @Test
+    fun `eq column against column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    eq(books.sales.eBooksSold, books.numberOfPages),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder("J.K. Rowling", "Paul Duchesne")
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("The Little Mermaid")
+        }
     }
-  }
 
-  @Test
-  fun `or with and combinations`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        add(
-            or(
-                and(
-                    eq(authors.name, "Hans Christian Andersen"),
-                    gt(books.numberOfPages, 100),
-                ),
-                and(
-                    ge(books.numberOfPages, 300),
-                ),
-            ),
-        )
-      }.list()
+    @Test
+    fun `gt column against long`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    gt(books.numberOfPages, 300),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Hobbit",
-              "Lord of the Rings",
-              "Harry Potter",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Harry Potter",
+                    "Lord of the Rings",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `ne column against String`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        add(
-            ne(authors.name, "J.R.R. Tolkien"),
-        )
-      }.list()
+    @Test
+    fun `gt column against hibernate supported object`() {
+        transactor.open { session ->
+            val dateTimeCreatedSecondBook = session.query(BookTable) { books ->
+                add(eq(books.name, "The Hobbit"))
+            }.uniqueResult()!!.createdAt
+            val dbBook = session.query(BookTable) { books ->
+                add(gt(books.createdAt, dateTimeCreatedSecondBook))
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Harry Potter",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(dbBook)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Harry Potter",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `ne column against column`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            ne(books.sales.eBooksSold, books.numberOfPages),
-        )
-      }.list()
+    @Test
+    fun `joins with book and author`() {
+        transactor.open { session ->
+            // Find all books by J.R.R. Tolkien
+            val results = session.query(BookTable) { books ->
+                val author = join(books.author)
+                add(eq(author.name, "J.R.R. Tolkien"))
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Lord of the Rings",
-              "The Hobbit",
-              "Harry Potter",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit")
+        }
+
+        // Find all people who have a favorite book by J.R.R. Tolkien
+        transactor.open { session ->
+            val results = session.query(PersonTable) { people ->
+                val favoriteBook = join(people.favoriteBook)
+                val favoriteBookAuthor = join(favoriteBook.author)
+                add(eq(favoriteBookAuthor.name, "J.R.R. Tolkien"))
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("J.K. Rowling", "Paul Duchesne")
+        }
     }
-  }
 
-  @Test
-  fun `lt column against long`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            lt(books.numberOfPages, 110),
-        )
-      }.list()
+    @Test
+    fun `or with and combinations`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                add(
+                    or(
+                        and(
+                            eq(authors.name, "Hans Christian Andersen"),
+                            gt(books.numberOfPages, 100),
+                        ),
+                        and(
+                            ge(books.numberOfPages, 300),
+                        ),
+                    ),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Little Mermaid",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Hobbit",
+                    "Lord of the Rings",
+                    "Harry Potter",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `lt column against column`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            lt(books.numberOfPages, books.sales.eBooksSold),
-        )
-      }.list()
+    @Test
+    fun `ne column against String`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                add(
+                    ne(authors.name, "J.R.R. Tolkien"),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Lord of the Rings",
-              "The Hobbit",
-              "Harry Potter",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Harry Potter",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `le column against long`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            le(books.numberOfPages, 110),
-        )
-      }.list()
+    @Test
+    fun `ne column against column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    ne(books.sales.eBooksSold, books.numberOfPages),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Little Mermaid",
-              "The Ugly Duckling",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "The Hobbit",
+                    "Harry Potter",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `le column against column`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            le(books.sales.eBooksSold, books.numberOfPages),
-        )
-      }.list()
+    @Test
+    fun `lt column against long`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    lt(books.numberOfPages, 110),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Little Mermaid",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Little Mermaid",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `between column with low and high values`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            between(books.numberOfPages, 100, 300),
-        )
-      }.list()
+    @Test
+    fun `lt column against column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    lt(books.numberOfPages, books.sales.eBooksSold),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Hobbit",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "The Hobbit",
+                    "Harry Potter",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `not with criterion`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        add(
-            not(eq(authors.name, "J.R.R. Tolkien")),
-        )
-      }.list()
+    @Test
+    fun `le column against long`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    le(books.numberOfPages, 110),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Harry Potter",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `like with String and match mode`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            like(books.name, "The", MatchMode.START),
-        )
-      }.list()
+    @Test
+    fun `le column against column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    le(books.sales.eBooksSold, books.numberOfPages),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Hobbit",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Little Mermaid",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `iLike with String and match mode`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            iLike(books.name, "the", MatchMode.START),
-        )
-      }.list()
+    @Test
+    fun `between column with low and high values`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    between(books.numberOfPages, 100, 300),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Hobbit",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Hobbit",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `isNotNull with column`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            isNotNull(books.notes),
-        )
-      }.list()
+    @Test
+    fun `not with criterion`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                add(
+                    not(eq(authors.name, "J.R.R. Tolkien")),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Lord of the Rings",
-              "The Hobbit",
-              "Harry Potter",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Harry Potter",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `isNull with column`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            isNull(books.notes),
-        )
-      }.list()
+    @Test
+    fun `like with String and match mode`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    like(books.name, "The", MatchMode.START),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Hobbit",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `eqOrIsNull with column and value`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            eqOrIsNull(books.notes, "Note for LoTR"),
-        )
-      }.list()
+    @Test
+    fun `iLike with String and match mode`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    iLike(books.name, "the", MatchMode.START),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder("Lord of the Rings")
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Hobbit",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `in with column and collection`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            `in`(books.name, listOf("The Hobbit", "Harry Potter")),
-        )
-      }.list()
+    @Test
+    fun `isNotNull with column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    isNotNull(books.notes),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "The Hobbit",
-              "Harry Potter",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "The Hobbit",
+                    "Harry Potter",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `notIn with column and collection`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        add(
-            notIn(books.name, listOf("The Hobbit", "Harry Potter")),
-        )
-      }.list()
+    @Test
+    fun `isNull with column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    isNull(books.notes),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Lord of the Rings",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `isEmpty with collection column`() {
-    transactor.open { session ->
-      val results = session.query(PublisherTable) { publishers ->
-        add(
-            isEmpty(publishers.books),
-        )
-      }.list()
+    @Test
+    fun `eqOrIsNull with column and value`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    eqOrIsNull(books.notes, "Note for LoTR"),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Co-Owned",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("Lord of the Rings")
+        }
     }
-  }
 
-  @Test
-  fun `isNotEmpty with collection column`() {
-    transactor.open { session ->
-      val results = session.query(PublisherTable) { publishers ->
-        add(
-            isNotEmpty(publishers.books),
-        )
-      }.list()
+    @Test
+    fun `in with column and collection`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    `in`(books.name, listOf("The Hobbit", "Harry Potter")),
+                )
+            }.list()
 
-      assertThat(results)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Penguin",
-              "HarperCollins",
-              "Random House",
-          )
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Hobbit",
+                    "Harry Potter",
+                )
+        }
     }
-  }
+
+    @Test
+    fun `notIn with column and collection`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    notIn(books.name, listOf("The Hobbit", "Harry Potter")),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
+    }
+
+    @Test
+    fun `isEmpty with collection column`() {
+        transactor.open { session ->
+            val results = session.query(PublisherTable) { publishers ->
+                add(
+                    isEmpty(publishers.books),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Co-Owned",
+                )
+        }
+    }
+
+    @Test
+    fun `isNotEmpty with collection column`() {
+        transactor.open { session ->
+            val results = session.query(PublisherTable) { publishers ->
+                add(
+                    isNotEmpty(publishers.books),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Penguin",
+                    "HarperCollins",
+                    "Random House",
+                )
+        }
+    }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnJoinsTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnJoinsTest.kt
@@ -12,440 +12,440 @@ import org.hibernate.sql.JoinType
 import org.junit.jupiter.api.Test
 
 internal class YawnJoinsTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `yawn one-to-one inner join`() {
-    transactor.open { session ->
-      val results1 = session.query(BookRankingTable) { ranking ->
-        val books = join(ranking.bestSeller)
-        addEq(books.name, "The Hobbit")
-      }.list()
-      assertThat(results1).isEmpty()
+    @Test
+    fun `yawn one-to-one inner join`() {
+        transactor.open { session ->
+            val results1 = session.query(BookRankingTable) { ranking ->
+                val books = join(ranking.bestSeller)
+                addEq(books.name, "The Hobbit")
+            }.list()
+            assertThat(results1).isEmpty()
 
-      val results2 = session.query(BookRankingTable) { ranking ->
-        val books = join(ranking.bestSeller)
-        addEq(books.name, "Harry Potter")
-      }.list()
-      assertThat(results2.single().bestSeller.name).isEqualTo("Harry Potter")
+            val results2 = session.query(BookRankingTable) { ranking ->
+                val books = join(ranking.bestSeller)
+                addEq(books.name, "Harry Potter")
+            }.list()
+            assertThat(results2.single().bestSeller.name).isEqualTo("Harry Potter")
+        }
     }
-  }
 
-  @Test
-  fun `join with criterion`() {
-    transactor.open { session ->
-      val results1 = session.project(PersonTable) { people ->
-        val books = join(people.favoriteBook, joinType = JoinType.LEFT_OUTER_JOIN)
-        addGe(books.numberOfPages, 500)
+    @Test
+    fun `join with criterion`() {
+        transactor.open { session ->
+            val results1 = session.project(PersonTable) { people ->
+                val books = join(people.favoriteBook, joinType = JoinType.LEFT_OUTER_JOIN)
+                addGe(books.numberOfPages, 500)
 
-        project(YawnProjections.pair(people.name, books.name))
-      }.list()
-      assertThat(results1).containsExactlyInAnyOrder(
-          "J.K. Rowling" to "Lord of the Rings",
-          "Paul Duchesne" to "Lord of the Rings",
-          "Luan Nico" to "Harry Potter",
-      )
+                project(YawnProjections.pair(people.name, books.name))
+            }.list()
+            assertThat(results1).containsExactlyInAnyOrder(
+                "J.K. Rowling" to "Lord of the Rings",
+                "Paul Duchesne" to "Lord of the Rings",
+                "Luan Nico" to "Harry Potter",
+            )
 
-      val results2 = session.project(PersonTable) { people ->
-        val books = join(people.favoriteBook, joinType = JoinType.LEFT_OUTER_JOIN) { books ->
-          addGe(books.numberOfPages, 500)
+            val results2 = session.project(PersonTable) { people ->
+                val books = join(people.favoriteBook, joinType = JoinType.LEFT_OUTER_JOIN) { books ->
+                    addGe(books.numberOfPages, 500)
+                }
+
+                project(YawnProjections.pair(people.name, nullable(books.name)))
+            }.list()
+            assertThat(results2).containsExactlyInAnyOrder(
+                "J.K. Rowling" to "Lord of the Rings",
+                "Paul Duchesne" to "Lord of the Rings",
+                "Luan Nico" to "Harry Potter",
+                "Jane Doe" to null,
+                "John Doe" to null,
+                "Hans Christian Andersen" to null,
+                "J.R.R. Tolkien" to null,
+            )
+        }
+    }
+
+    @Test
+    fun `yawn many-to-one inner join`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }.list()
+            assertThat(results.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Lord of the Rings")
+        }
+    }
+
+    @Test
+    fun `yawn one-to-many inner join`() {
+        transactor.open { session ->
+            val results1 = session.query(PublisherTable) { publishers ->
+                val books = join(publishers.books)
+                val authors = join(books.author)
+                addIn(authors.name, setOf("J.R.R. Tolkien", "J.K. Rowling"))
+            }.set()
+            assertThat(results1.map { it.name }).containsExactlyInAnyOrder("Penguin", "HarperCollins", "Random House")
+
+            val results2 = session.query(PublisherTable) { publishers ->
+                val books = join(publishers.books)
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+            }.set()
+            assertThat(results2.map { it.name }).containsExactlyInAnyOrder("Penguin")
+        }
+    }
+
+    @Test
+    fun `yawn many-to-many inner join`() {
+        transactor.open { session ->
+            val results1 = session.query(PublisherTable) { publishers ->
+                val owners = join(publishers.owners)
+                addEq(owners.name, "John Doe")
+            }.list()
+            assertThat(results1.map { it.name }).containsExactlyInAnyOrder("Penguin", "Random House", "Co-Owned")
+
+            val results2 = session.query(PublisherTable) { publishers ->
+                val owners = join(publishers.owners)
+                addEq(owners.name, "Jane Doe")
+            }.list()
+            assertThat(results2.map { it.name }).containsExactlyInAnyOrder("HarperCollins", "Co-Owned")
+
+            val results3 = session.query(PersonTable) { people ->
+                val publishers = join(people.ownedPublishers)
+                addIn(publishers.name, setOf("Penguin", "HarperCollins"))
+            }.list()
+            assertThat(results3.map { it.name }).containsExactlyInAnyOrder("John Doe", "Jane Doe")
+        }
+    }
+
+    @Test
+    fun `yawn left join - books with publishers`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN)
+                addIsNotNull(publishers.id)
+            }.list()
+            assertThat(results.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+                "Harry Potter",
+                "The Emperor's New Clothes",
+            )
+        }
+    }
+
+    @Test
+    fun `yawn left join - books without publishers`() {
+        transactor.open { session ->
+            val results2 = session.query(BookTable) { books ->
+                val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN)
+                addIsNull(publishers.id)
+            }.list()
+            assertThat(results2.map { it.name }).containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling")
+        }
+    }
+
+    @Test
+    fun `yawn right join - books without publisher`() {
+        transactor.open { session ->
+            val results = session.project(PublisherTable) { publishers ->
+                val books = join(publishers.books, joinType = JoinType.RIGHT_OUTER_JOIN)
+                addIsNull(publishers.id)
+                project(books.name)
+            }.list()
+            assertThat(results).containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling")
+        }
+    }
+
+    @Test
+    fun `yawn right join - publisher without books`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                val publishers = join(books.publisher, joinType = JoinType.RIGHT_OUTER_JOIN)
+                addIsNull(books.id)
+
+                project(publishers.name)
+            }.list()
+            assertThat(results).containsExactlyInAnyOrder("Co-Owned")
+        }
+    }
+
+    @Test
+    fun `yawn foreign key after join`() {
+        transactor.open { session ->
+            val tolkien = session.query(PersonTable) { people ->
+                addEq(people.name, "J.R.R. Tolkien")
+            }.uniqueResult()!!
+            val results = session.project(PublisherTable) { publishers ->
+                val books = join(publishers.books)
+                addEq(books.author, tolkien.id)
+
+                project(publishers.name)
+            }.set()
+            assertThat(results).containsExactlyInAnyOrder("HarperCollins", "Random House")
+        }
+    }
+
+    @Test
+    fun `yawn is empty - publishers without books`() {
+        transactor.open { session ->
+            val results = session.query(PublisherTable) { publishers ->
+                addIsEmpty(publishers.books)
+            }.list().map { it.name }
+            assertThat(results).containsExactlyInAnyOrder("Co-Owned")
+        }
+    }
+
+    @Test
+    fun `yawn not is empty - publishers with books`() {
+        transactor.open { session ->
+            val results = session.query(PublisherTable) { publishers ->
+                addIsNotEmpty(publishers.books)
+            }.list().map { it.name }
+            assertThat(results).containsExactlyInAnyOrder("Penguin", "HarperCollins", "Random House")
+        }
+    }
+
+    // NOTE: mysql does not support full outer joins
+
+    @Test
+    fun `yawn deeply-nested join structure - anyone that published Tolkien`() {
+        transactor.open { session ->
+            val results = session.query(PersonTable) { people ->
+                val publishers = join(people.ownedPublishers)
+                val books = join(publishers.books)
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }.set()
+            assertThat(results.map { it.name }).containsExactlyInAnyOrder("Jane Doe", "John Doe")
+        }
+    }
+
+    @YawnProjection
+    data class PublishersWithPagesPublished(val name: String, val pagesPublished: Long)
+
+    @Test
+    fun `yawn deeply-nested join structure - publishers with pages published`() {
+        transactor.open { session ->
+            val results = session.project(PublisherTable) { publishers ->
+                val books = join(publishers.books)
+                project(
+                    YawnJoinsTest_PublishersWithPagesPublishedProjection.create(
+                        name = YawnProjections.groupBy(publishers.name),
+                        pagesPublished = YawnProjections.sum(books.numberOfPages),
+                    ),
+                )
+            }.list()
+
+            assertThat(results).containsExactlyInAnyOrder(
+                PublishersWithPagesPublished("HarperCollins", 1_000),
+                PublishersWithPagesPublished("Penguin", 620),
+                PublishersWithPagesPublished("Random House", 300),
+            )
+        }
+    }
+
+    @YawnProjection
+    data class PublishersWithBooksPublished(val name: String, val booksPublished: Long)
+
+    @Test
+    fun `yawn deeply-nested join structure - publishers with books published`() {
+        transactor.open { session ->
+            val results = session.project(PublisherTable) { publishers ->
+                val books = join(publishers.books)
+                project(
+                    YawnJoinsTest_PublishersWithBooksPublishedProjection.create(
+                        name = YawnProjections.groupBy(publishers.name),
+                        booksPublished = YawnProjections.countDistinct(books.id),
+                    ),
+                )
+            }.list()
+
+            assertThat(results).containsExactlyInAnyOrder(
+                PublishersWithBooksPublished("HarperCollins", 1),
+                PublishersWithBooksPublished("Penguin", 2),
+                PublishersWithBooksPublished("Random House", 1),
+            )
+        }
+    }
+
+    @Test
+    fun `yawn deeply-nested join structure - publishers with books published with left join`() {
+        transactor.open { session ->
+            val results = session.project(PublisherTable) { publishers ->
+                val books = join(publishers.books, joinType = JoinType.LEFT_OUTER_JOIN)
+                project(
+                    YawnJoinsTest_PublishersWithBooksPublishedProjection.create(
+                        name = YawnProjections.groupBy(publishers.name),
+                        booksPublished = YawnProjections.countDistinct(books.id),
+                    ),
+                )
+            }.list()
+
+            assertThat(results).containsExactlyInAnyOrder(
+                PublishersWithBooksPublished("HarperCollins", 1),
+                PublishersWithBooksPublished("Penguin", 2),
+                PublishersWithBooksPublished("Random House", 1),
+                PublishersWithBooksPublished("Co-Owned", 0),
+            )
+        }
+    }
+
+    @Test
+    fun `yawn deeply-nested join structure - people who's favorite books are not their own writing`() {
+        transactor.open { session ->
+            val results = session.query(PersonTable) { people ->
+                val favouriteBooks = join(people.favoriteBook)
+                val authors = join(favouriteBooks.author)
+                addNotEq(people.name, authors.name)
+            }.list()
+            assertThat(results.map { it.name }).containsExactlyInAnyOrder(
+                "J.R.R. Tolkien",
+                "J.K. Rowling",
+                "Luan Nico",
+                "Paul Duchesne",
+                "Jane Doe",
+            )
+        }
+    }
+
+    @Test
+    fun `yawn deeply-nested join structure - authors who's favorite books are not their own writing'`() {
+        val authors = createProjectedDetachedCriteria(BookTable) { books ->
+            val author = join(books.author)
+            project(author.name)
         }
 
-        project(YawnProjections.pair(people.name, nullable(books.name)))
-      }.list()
-      assertThat(results2).containsExactlyInAnyOrder(
-          "J.K. Rowling" to "Lord of the Rings",
-          "Paul Duchesne" to "Lord of the Rings",
-          "Luan Nico" to "Harry Potter",
-          "Jane Doe" to null,
-          "John Doe" to null,
-          "Hans Christian Andersen" to null,
-          "J.R.R. Tolkien" to null,
-      )
-    }
-  }
-
-  @Test
-  fun `yawn many-to-one inner join`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }.list()
-      assertThat(results.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Lord of the Rings")
-    }
-  }
-
-  @Test
-  fun `yawn one-to-many inner join`() {
-    transactor.open { session ->
-      val results1 = session.query(PublisherTable) { publishers ->
-        val books = join(publishers.books)
-        val authors = join(books.author)
-        addIn(authors.name, setOf("J.R.R. Tolkien", "J.K. Rowling"))
-      }.set()
-      assertThat(results1.map { it.name }).containsExactlyInAnyOrder("Penguin", "HarperCollins", "Random House")
-
-      val results2 = session.query(PublisherTable) { publishers ->
-        val books = join(publishers.books)
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-      }.set()
-      assertThat(results2.map { it.name }).containsExactlyInAnyOrder("Penguin")
-    }
-  }
-
-  @Test
-  fun `yawn many-to-many inner join`() {
-    transactor.open { session ->
-      val results1 = session.query(PublisherTable) { publishers ->
-        val owners = join(publishers.owners)
-        addEq(owners.name, "John Doe")
-      }.list()
-      assertThat(results1.map { it.name }).containsExactlyInAnyOrder("Penguin", "Random House", "Co-Owned")
-
-      val results2 = session.query(PublisherTable) { publishers ->
-        val owners = join(publishers.owners)
-        addEq(owners.name, "Jane Doe")
-      }.list()
-      assertThat(results2.map { it.name }).containsExactlyInAnyOrder("HarperCollins", "Co-Owned")
-
-      val results3 = session.query(PersonTable) { people ->
-        val publishers = join(people.ownedPublishers)
-        addIn(publishers.name, setOf("Penguin", "HarperCollins"))
-      }.list()
-      assertThat(results3.map { it.name }).containsExactlyInAnyOrder("John Doe", "Jane Doe")
-    }
-  }
-
-  @Test
-  fun `yawn left join - books with publishers`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN)
-        addIsNotNull(publishers.id)
-      }.list()
-      assertThat(results.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-          "Harry Potter",
-          "The Emperor's New Clothes",
-      )
-    }
-  }
-
-  @Test
-  fun `yawn left join - books without publishers`() {
-    transactor.open { session ->
-      val results2 = session.query(BookTable) { books ->
-        val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN)
-        addIsNull(publishers.id)
-      }.list()
-      assertThat(results2.map { it.name }).containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling")
-    }
-  }
-
-  @Test
-  fun `yawn right join - books without publisher`() {
-    transactor.open { session ->
-      val results = session.project(PublisherTable) { publishers ->
-        val books = join(publishers.books, joinType = JoinType.RIGHT_OUTER_JOIN)
-        addIsNull(publishers.id)
-        project(books.name)
-      }.list()
-      assertThat(results).containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling")
-    }
-  }
-
-  @Test
-  fun `yawn right join - publisher without books`() {
-    transactor.open { session ->
-      val results = session.project(BookTable) { books ->
-        val publishers = join(books.publisher, joinType = JoinType.RIGHT_OUTER_JOIN)
-        addIsNull(books.id)
-
-        project(publishers.name)
-      }.list()
-      assertThat(results).containsExactlyInAnyOrder("Co-Owned")
-    }
-  }
-
-  @Test
-  fun `yawn foreign key after join`() {
-    transactor.open { session ->
-      val tolkien = session.query(PersonTable) { people ->
-        addEq(people.name, "J.R.R. Tolkien")
-      }.uniqueResult()!!
-      val results = session.project(PublisherTable) { publishers ->
-        val books = join(publishers.books)
-        addEq(books.author, tolkien.id)
-
-        project(publishers.name)
-      }.set()
-      assertThat(results).containsExactlyInAnyOrder("HarperCollins", "Random House")
-    }
-  }
-
-  @Test
-  fun `yawn is empty - publishers without books`() {
-    transactor.open { session ->
-      val results = session.query(PublisherTable) { publishers ->
-        addIsEmpty(publishers.books)
-      }.list().map { it.name }
-      assertThat(results).containsExactlyInAnyOrder("Co-Owned")
-    }
-  }
-
-  @Test
-  fun `yawn not is empty - publishers with books`() {
-    transactor.open { session ->
-      val results = session.query(PublisherTable) { publishers ->
-        addIsNotEmpty(publishers.books)
-      }.list().map { it.name }
-      assertThat(results).containsExactlyInAnyOrder("Penguin", "HarperCollins", "Random House")
-    }
-  }
-
-  // NOTE: mysql does not support full outer joins
-
-  @Test
-  fun `yawn deeply-nested join structure - anyone that published Tolkien`() {
-    transactor.open { session ->
-      val results = session.query(PersonTable) { people ->
-        val publishers = join(people.ownedPublishers)
-        val books = join(publishers.books)
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }.set()
-      assertThat(results.map { it.name }).containsExactlyInAnyOrder("Jane Doe", "John Doe")
-    }
-  }
-
-  @YawnProjection
-  data class PublishersWithPagesPublished(val name: String, val pagesPublished: Long)
-
-  @Test
-  fun `yawn deeply-nested join structure - publishers with pages published`() {
-    transactor.open { session ->
-      val results = session.project(PublisherTable) { publishers ->
-        val books = join(publishers.books)
-        project(
-            YawnJoinsTest_PublishersWithPagesPublishedProjection.create(
-                name = YawnProjections.groupBy(publishers.name),
-                pagesPublished = YawnProjections.sum(books.numberOfPages),
-            ),
+        val results = transactor.open { session ->
+            session.query(PersonTable) { people ->
+                val favouriteBooks = join(people.favoriteBook)
+                val favouriteBooksAuthors = join(favouriteBooks.author)
+                addIn(people.name, authors)
+                addNotEq(people.name, favouriteBooksAuthors.name)
+            }.list()
+        }
+        assertThat(results.map { it.name }).containsExactlyInAnyOrder(
+            "J.R.R. Tolkien",
+            "J.K. Rowling",
         )
-      }.list()
-
-      assertThat(results).containsExactlyInAnyOrder(
-          PublishersWithPagesPublished("HarperCollins", 1_000),
-          PublishersWithPagesPublished("Penguin", 620),
-          PublishersWithPagesPublished("Random House", 300),
-      )
-    }
-  }
-
-  @YawnProjection
-  data class PublishersWithBooksPublished(val name: String, val booksPublished: Long)
-
-  @Test
-  fun `yawn deeply-nested join structure - publishers with books published`() {
-    transactor.open { session ->
-      val results = session.project(PublisherTable) { publishers ->
-        val books = join(publishers.books)
-        project(
-            YawnJoinsTest_PublishersWithBooksPublishedProjection.create(
-                name = YawnProjections.groupBy(publishers.name),
-                booksPublished = YawnProjections.countDistinct(books.id),
-            ),
-        )
-      }.list()
-
-      assertThat(results).containsExactlyInAnyOrder(
-          PublishersWithBooksPublished("HarperCollins", 1),
-          PublishersWithBooksPublished("Penguin", 2),
-          PublishersWithBooksPublished("Random House", 1),
-      )
-    }
-  }
-
-  @Test
-  fun `yawn deeply-nested join structure - publishers with books published with left join`() {
-    transactor.open { session ->
-      val results = session.project(PublisherTable) { publishers ->
-        val books = join(publishers.books, joinType = JoinType.LEFT_OUTER_JOIN)
-        project(
-            YawnJoinsTest_PublishersWithBooksPublishedProjection.create(
-                name = YawnProjections.groupBy(publishers.name),
-                booksPublished = YawnProjections.countDistinct(books.id),
-            ),
-        )
-      }.list()
-
-      assertThat(results).containsExactlyInAnyOrder(
-          PublishersWithBooksPublished("HarperCollins", 1),
-          PublishersWithBooksPublished("Penguin", 2),
-          PublishersWithBooksPublished("Random House", 1),
-          PublishersWithBooksPublished("Co-Owned", 0),
-      )
-    }
-  }
-
-  @Test
-  fun `yawn deeply-nested join structure - people who's favorite books are not their own writing`() {
-    transactor.open { session ->
-      val results = session.query(PersonTable) { people ->
-        val favouriteBooks = join(people.favoriteBook)
-        val authors = join(favouriteBooks.author)
-        addNotEq(people.name, authors.name)
-      }.list()
-      assertThat(results.map { it.name }).containsExactlyInAnyOrder(
-          "J.R.R. Tolkien",
-          "J.K. Rowling",
-          "Luan Nico",
-          "Paul Duchesne",
-          "Jane Doe",
-      )
-    }
-  }
-
-  @Test
-  fun `yawn deeply-nested join structure - authors who's favorite books are not their own writing'`() {
-    val authors = createProjectedDetachedCriteria(BookTable) { books ->
-      val author = join(books.author)
-      project(author.name)
     }
 
-    val results = transactor.open { session ->
-      session.query(PersonTable) { people ->
-        val favouriteBooks = join(people.favoriteBook)
-        val favouriteBooksAuthors = join(favouriteBooks.author)
-        addIn(people.name, authors)
-        addNotEq(people.name, favouriteBooksAuthors.name)
-      }.list()
+    @Test
+    fun `joins to the same table - book's authors favourite books`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                val authors = join(books.author)
+
+                val favoriteBooks = join(authors.favoriteBook)
+                addIsNotNull(favoriteBooks.id)
+
+                project(
+                    YawnProjections.pair(
+                        books.name,
+                        favoriteBooks.name,
+                    ),
+                )
+            }.list()
+            assertThat(results).containsExactlyInAnyOrder(
+                "Harry Potter" to "Lord of the Rings",
+                "Lord of the Rings" to "The Little Mermaid",
+                "The Hobbit" to "The Little Mermaid",
+            )
+        }
     }
-    assertThat(results.map { it.name }).containsExactlyInAnyOrder(
-        "J.R.R. Tolkien",
-        "J.K. Rowling",
-    )
-  }
 
-  @Test
-  fun `joins to the same table - book's authors favourite books`() {
-    transactor.open { session ->
-      val results = session.project(BookTable) { books ->
-        val authors = join(books.author)
+    @Test
+    fun `multiple joins to the same table - book's authors favourite authors`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                val authors = join(books.author)
 
-        val favoriteBooks = join(authors.favoriteBook)
-        addIsNotNull(favoriteBooks.id)
+                val favoriteBooks = join(authors.favoriteBook)
+                addIsNotNull(favoriteBooks.id)
 
-        project(
-            YawnProjections.pair(
-                books.name,
-                favoriteBooks.name,
-            ),
-        )
-      }.list()
-      assertThat(results).containsExactlyInAnyOrder(
-          "Harry Potter" to "Lord of the Rings",
-          "Lord of the Rings" to "The Little Mermaid",
-          "The Hobbit" to "The Little Mermaid",
-      )
+                val favoriteAuthors = join(favoriteBooks.author)
+                addIsNotNull(favoriteAuthors.id)
+
+                project(
+                    YawnProjections.pair(
+                        books.name,
+                        favoriteAuthors.name,
+                    ),
+                )
+            }.list()
+
+            assertThat(results).containsExactlyInAnyOrder(
+                "Harry Potter" to "J.R.R. Tolkien",
+                "Lord of the Rings" to "Hans Christian Andersen",
+                "The Hobbit" to "Hans Christian Andersen",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `multiple joins to the same table - book's authors favourite authors`() {
-    transactor.open { session ->
-      val results = session.project(BookTable) { books ->
-        val authors = join(books.author)
+    @Test
+    fun `simplest join reference`() {
+        transactor.open { session ->
+            val criteria = session.query(BookTable)
+            val authorsRef = criteria.joinRef { author }
 
-        val favoriteBooks = join(authors.favoriteBook)
-        addIsNotNull(favoriteBooks.id)
+            criteria.applyFilter { books ->
+                val authors = authorsRef.get(books)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }
 
-        val favoriteAuthors = join(favoriteBooks.author)
-        addIsNotNull(favoriteAuthors.id)
-
-        project(
-            YawnProjections.pair(
-                books.name,
-                favoriteAuthors.name,
-            ),
-        )
-      }.list()
-
-      assertThat(results).containsExactlyInAnyOrder(
-          "Harry Potter" to "J.R.R. Tolkien",
-          "Lord of the Rings" to "Hans Christian Andersen",
-          "The Hobbit" to "Hans Christian Andersen",
-      )
+            val results = criteria.list()
+            assertThat(results.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `simplest join reference`() {
-    transactor.open { session ->
-      val criteria = session.query(BookTable)
-      val authorsRef = criteria.joinRef { author }
+    @Test
+    fun `multiple joins to the same table using join references - book's authors favourite authors`() {
+        transactor.open { session ->
+            val criteria = session.query(BookTable)
 
-      criteria.applyFilter { books ->
-        val authors = authorsRef.get(books)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }
+            // join refs
+            val authorsRef = criteria.joinRef { author }
+            val favoriteBooksRef = criteria.joinRef {
+                val authors = authorsRef.get(this)
+                authors.favoriteBook
+            }
+            val favoriteAuthorsRef = criteria.joinRef {
+                val favoriteBooks = favoriteBooksRef.get(this)
+                favoriteBooks.author
+            }
 
-      val results = criteria.list()
-      assertThat(results.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-      )
+            // these can be done
+            criteria.applyFilter { books ->
+                val favoriteBooks = favoriteBooksRef.get(books)
+                addIsNotNull(favoriteBooks.id)
+            }
+            // in multiple places
+            criteria.applyFilter { books ->
+                val favoriteAuthors = favoriteAuthorsRef.get(books)
+                addIsNotNull(favoriteAuthors.id)
+            }
+            // over multiple functions
+            criteria.applyFilter { books ->
+                val authors = authorsRef.get(books)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }
+
+            val results = criteria.applyProjection { books ->
+                val favoriteAuthors = favoriteAuthorsRef.get(books)
+                project(
+                    YawnProjections.pair(
+                        books.name,
+                        favoriteAuthors.name,
+                    ),
+                )
+            }
+                .list()
+
+            assertThat(results).containsExactlyInAnyOrder(
+                "Lord of the Rings" to "Hans Christian Andersen",
+                "The Hobbit" to "Hans Christian Andersen",
+            )
+        }
     }
-  }
-
-  @Test
-  fun `multiple joins to the same table using join references - book's authors favourite authors`() {
-    transactor.open { session ->
-      val criteria = session.query(BookTable)
-
-      // join refs
-      val authorsRef = criteria.joinRef { author }
-      val favoriteBooksRef = criteria.joinRef {
-        val authors = authorsRef.get(this)
-        authors.favoriteBook
-      }
-      val favoriteAuthorsRef = criteria.joinRef {
-        val favoriteBooks = favoriteBooksRef.get(this)
-        favoriteBooks.author
-      }
-
-      // these can be done
-      criteria.applyFilter { books ->
-        val favoriteBooks = favoriteBooksRef.get(books)
-        addIsNotNull(favoriteBooks.id)
-      }
-      // in multiple places
-      criteria.applyFilter { books ->
-        val favoriteAuthors = favoriteAuthorsRef.get(books)
-        addIsNotNull(favoriteAuthors.id)
-      }
-      // over multiple functions
-      criteria.applyFilter { books ->
-        val authors = authorsRef.get(books)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }
-
-      val results = criteria.applyProjection { books ->
-        val favoriteAuthors = favoriteAuthorsRef.get(books)
-        project(
-            YawnProjections.pair(
-                books.name,
-                favoriteAuthors.name,
-            ),
-        )
-      }
-          .list()
-
-      assertThat(results).containsExactlyInAnyOrder(
-          "Lord of the Rings" to "Hans Christian Andersen",
-          "The Hobbit" to "Hans Christian Andersen",
-      )
-    }
-  }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnMinAndMaxByTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnMinAndMaxByTest.kt
@@ -5,41 +5,41 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class YawnMinAndMaxByTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `yawn maxBy works`() {
-    transactor.open { session ->
-      assertThat(session.query(BookTable).maxBy { createdAt }!!.name).isEqualTo("The Emperor's New Clothes")
-      assertThat(session.query(BookTable).maxBy { name }!!.name).isEqualTo("The Ugly Duckling")
-      assertThat(session.query(BookTable).maxBy { numberOfPages }!!.name).isEqualTo("Lord of the Rings")
+    @Test
+    fun `yawn maxBy works`() {
+        transactor.open { session ->
+            assertThat(session.query(BookTable).maxBy { createdAt }!!.name).isEqualTo("The Emperor's New Clothes")
+            assertThat(session.query(BookTable).maxBy { name }!!.name).isEqualTo("The Ugly Duckling")
+            assertThat(session.query(BookTable).maxBy { numberOfPages }!!.name).isEqualTo("Lord of the Rings")
+        }
     }
-  }
 
-  @Test
-  fun `yawn minBy works`() {
-    transactor.open { session ->
-      assertThat(session.query(BookTable).minBy { createdAt }!!.name).isEqualTo("Lord of the Rings")
-      assertThat(session.query(BookTable).minBy { name }!!.name).isEqualTo("Harry Potter")
-      assertThat(session.query(BookTable).minBy { numberOfPages }!!.name).isEqualTo("The Little Mermaid")
+    @Test
+    fun `yawn minBy works`() {
+        transactor.open { session ->
+            assertThat(session.query(BookTable).minBy { createdAt }!!.name).isEqualTo("Lord of the Rings")
+            assertThat(session.query(BookTable).minBy { name }!!.name).isEqualTo("Harry Potter")
+            assertThat(session.query(BookTable).minBy { numberOfPages }!!.name).isEqualTo("The Little Mermaid")
+        }
     }
-  }
 
-  @Test
-  fun `yawn maxByMultiple works`() {
-    transactor.open { session ->
-      // Max by originalLanguage is "ENGLISH" (Tolkien, Rowling)
-      // Max of "Lord of the Rings", "The Hobbit", and "Harry Potter" is "The Hobbit"
-      val maxBy = session.query(BookTable).maxBy({ originalLanguage }, { name })!!
-      assertThat(maxBy.name).isEqualTo("The Hobbit")
+    @Test
+    fun `yawn maxByMultiple works`() {
+        transactor.open { session ->
+            // Max by originalLanguage is "ENGLISH" (Tolkien, Rowling)
+            // Max of "Lord of the Rings", "The Hobbit", and "Harry Potter" is "The Hobbit"
+            val maxBy = session.query(BookTable).maxBy({ originalLanguage }, { name })!!
+            assertThat(maxBy.name).isEqualTo("The Hobbit")
+        }
     }
-  }
 
-  @Test
-  fun `yawn minByMultiple works`() {
-    transactor.open { session ->
-      // Min by originalLanguage is "DANISH" (Andersen)
-      // Min of "The Little Mermaid", "The Ugly Duckling", and "The Emperor's New Clothes"
-      val minBy = session.query(BookTable).minBy({ originalLanguage }, { name })!!
-      assertThat(minBy.name).isEqualTo("The Emperor's New Clothes")
+    @Test
+    fun `yawn minByMultiple works`() {
+        transactor.open { session ->
+            // Min by originalLanguage is "DANISH" (Andersen)
+            // Min of "The Little Mermaid", "The Ugly Duckling", and "The Emperor's New Clothes"
+            val minBy = session.query(BookTable).minBy({ originalLanguage }, { name })!!
+            assertThat(minBy.name).isEqualTo("The Emperor's New Clothes")
+        }
     }
-  }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnPaginationQueriesTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnPaginationQueriesTest.kt
@@ -6,230 +6,230 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class YawnPaginationQueriesTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `count distinct`() {
-    transactor.open { session ->
-      val count = session.query(BookTable)
-          .countDistinct { originalLanguage }
-      assertThat(count).isEqualTo(2)
+    @Test
+    fun `count distinct`() {
+        transactor.open { session ->
+            val count = session.query(BookTable)
+                .countDistinct { originalLanguage }
+            assertThat(count).isEqualTo(2)
+        }
     }
-  }
 
-  @Test
-  fun `list paginated`() {
-    transactor.open { session ->
-      fun paginate(pageNumber: Int, pageSize: Int = 2): List<String> {
-        return session.query(BookTable)
-            .listPaginatedZeroIndexed(
-                pageNumber = pageNumber,
-                pageSize = pageSize,
-                orders = listOf(
-                    { YawnQueryOrder.asc(originalLanguage) },
-                    { YawnQueryOrder.desc(name) },
-                ),
-            )
-            .map { it.name }
-      }
-
-      val books1 = paginate(pageNumber = 0)
-      assertThat(books1).containsExactly("The Ugly Duckling", "The Little Mermaid")
-
-      val books2 = paginate(pageNumber = 1)
-      assertThat(books2).containsExactly("The Emperor's New Clothes", "The Hobbit")
-
-      val books3 = paginate(pageNumber = 2)
-      assertThat(books3).containsExactly("Lord of the Rings", "Harry Potter")
-
-      val book4 = paginate(pageNumber = 3)
-      assertThat(book4).isEmpty()
-
-      val bigPage1 = paginate(pageNumber = 0, pageSize = 4)
-      assertThat(bigPage1).containsExactly(
-          "The Ugly Duckling",
-          "The Little Mermaid",
-          "The Emperor's New Clothes",
-          "The Hobbit",
-      )
-
-      val bigPage2 = paginate(pageNumber = 1, pageSize = 4)
-      assertThat(bigPage2).containsExactly(
-          "Lord of the Rings",
-          "Harry Potter",
-      )
-
-      val hugePage = paginate(pageNumber = 2, pageSize = 100)
-      assertThat(hugePage).isEmpty()
-    }
-  }
-
-  @Test
-  fun `list with total results`() {
-    transactor.open { session ->
-      fun paginate(pageNumber: Int, pageSize: Int = 2): Pair<Long, List<String>> {
-        return session.query(BookTable)
-            .listPaginatedWithTotalResultsZeroIndexed(
-                pageNumber = pageNumber,
-                pageSize = pageSize,
-                orders = listOf(
-                    { YawnQueryOrder.asc(originalLanguage) },
-                    { YawnQueryOrder.desc(name) },
-                ),
-                uniqueColumn = { id },
-            )
-            .let { it.first to it.second.map { it.name } }
-      }
-
-      val (total1, books1) = paginate(pageNumber = 0)
-      assertThat(total1).isEqualTo(6)
-      assertThat(books1).containsExactly("The Ugly Duckling", "The Little Mermaid")
-
-      val (total2, books2) = paginate(pageNumber = 1)
-      assertThat(total2).isEqualTo(6)
-      assertThat(books2).containsExactly("The Emperor's New Clothes", "The Hobbit")
-
-      val (total3, books3) = paginate(pageNumber = 2)
-      assertThat(total3).isEqualTo(6)
-      assertThat(books3).containsExactly("Lord of the Rings", "Harry Potter")
-
-      val (total4, book4) = paginate(pageNumber = 3)
-      assertThat(total4).isEqualTo(6)
-      assertThat(book4).isEmpty()
-
-      val (totalBig1, bigPage1) = paginate(pageNumber = 0, pageSize = 4)
-      assertThat(totalBig1).isEqualTo(6)
-      assertThat(bigPage1).containsExactly(
-          "The Ugly Duckling",
-          "The Little Mermaid",
-          "The Emperor's New Clothes",
-          "The Hobbit",
-      )
-
-      val (totalBig2, bigPage2) = paginate(pageNumber = 1, pageSize = 4)
-      assertThat(totalBig2).isEqualTo(6)
-      assertThat(bigPage2).containsExactly(
-          "Lord of the Rings",
-          "Harry Potter",
-      )
-
-      val (totalHuge, hugePage) = paginate(pageNumber = 2, pageSize = 100)
-      assertThat(totalHuge).isEqualTo(6)
-      assertThat(hugePage).isEmpty()
-    }
-  }
-
-  @Test
-  fun `list with join`() {
-    transactor.open { session ->
-      val (total, books) = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-      }
-          .listPaginatedWithTotalResultsZeroIndexed(
-              pageNumber = 1,
-              pageSize = 2,
-              orders = listOf(
-                  { YawnQueryOrder.desc(name) },
-              ),
-              uniqueColumn = { id },
-          )
-
-      assertThat(total).isEqualTo(3)
-      assertThat(books.map { it.name }).containsExactly(
-          "The Emperor's New Clothes",
-      )
-    }
-  }
-
-  @Test
-  fun `do paginated`() {
-    val results = mutableListOf<String>()
-
-    transactor.open { session ->
-      session.query(BookTable).doPaginated(
-          pageSize = 2,
-          orders = listOf { YawnQueryOrder.asc(name) },
-          action = { books ->
-            for (book in books) {
-              results.add(book.author.name)
+    @Test
+    fun `list paginated`() {
+        transactor.open { session ->
+            fun paginate(pageNumber: Int, pageSize: Int = 2): List<String> {
+                return session.query(BookTable)
+                    .listPaginatedZeroIndexed(
+                        pageNumber = pageNumber,
+                        pageSize = pageSize,
+                        orders = listOf(
+                            { YawnQueryOrder.asc(originalLanguage) },
+                            { YawnQueryOrder.desc(name) },
+                        ),
+                    )
+                    .map { it.name }
             }
-          },
-      )
+
+            val books1 = paginate(pageNumber = 0)
+            assertThat(books1).containsExactly("The Ugly Duckling", "The Little Mermaid")
+
+            val books2 = paginate(pageNumber = 1)
+            assertThat(books2).containsExactly("The Emperor's New Clothes", "The Hobbit")
+
+            val books3 = paginate(pageNumber = 2)
+            assertThat(books3).containsExactly("Lord of the Rings", "Harry Potter")
+
+            val book4 = paginate(pageNumber = 3)
+            assertThat(book4).isEmpty()
+
+            val bigPage1 = paginate(pageNumber = 0, pageSize = 4)
+            assertThat(bigPage1).containsExactly(
+                "The Ugly Duckling",
+                "The Little Mermaid",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+            )
+
+            val bigPage2 = paginate(pageNumber = 1, pageSize = 4)
+            assertThat(bigPage2).containsExactly(
+                "Lord of the Rings",
+                "Harry Potter",
+            )
+
+            val hugePage = paginate(pageNumber = 2, pageSize = 100)
+            assertThat(hugePage).isEmpty()
+        }
     }
 
-    assertThat(results).containsExactly(
-        "J.K. Rowling", // Harry Potter
-        "J.R.R. Tolkien", // Lord of the Rings
-        "Hans Christian Andersen", // The Emperor's New Clothes
-        "J.R.R. Tolkien", // The Hobbit
-        "Hans Christian Andersen", // The Little Mermaid
-        "Hans Christian Andersen", // The Ugly Duckling
-    )
-  }
-
-  @Test
-  fun `listing with batched`() {
-    transactor.open { session ->
-      val results = session.query(BookTable).listBatched(
-          batchSize = 2,
-          orders = listOf { YawnQueryOrder.asc(name) },
-      )
-
-      assertThat(results.map { it.name }).containsExactly(
-          "Harry Potter",
-          "Lord of the Rings",
-          "The Emperor's New Clothes",
-          "The Hobbit",
-          "The Little Mermaid",
-          "The Ugly Duckling",
-      )
-    }
-  }
-
-  @Test
-  fun `paginate with projection`() {
-    transactor.open { session ->
-      val bookNames = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-        project(books.name)
-      }.paginateZeroIndexed(
-          pageNumber = 0,
-          pageSize = 3,
-          orders = listOf { YawnQueryOrder.desc(numberOfPages) },
-      ).list()
-
-      assertThat(bookNames).containsExactly(
-          "The Emperor's New Clothes", // 120 pages
-          "The Ugly Duckling", // 110 pages
-          "The Little Mermaid", // 100 pages
-      )
-    }
-  }
-
-  @Test
-  fun `do paginate with projection`() {
-    val bookNames = mutableListOf<String>()
-    transactor.open { session ->
-      session.project(BookTable) { books ->
-        project(books.name)
-      }.doPaginated(
-          pageSize = 3,
-          orders = listOf { YawnQueryOrder.asc(numberOfPages) },
-          action = { names ->
-            for ((idx, bookName) in names.withIndex()) {
-              bookNames.add("[$idx] $bookName")
+    @Test
+    fun `list with total results`() {
+        transactor.open { session ->
+            fun paginate(pageNumber: Int, pageSize: Int = 2): Pair<Long, List<String>> {
+                return session.query(BookTable)
+                    .listPaginatedWithTotalResultsZeroIndexed(
+                        pageNumber = pageNumber,
+                        pageSize = pageSize,
+                        orders = listOf(
+                            { YawnQueryOrder.asc(originalLanguage) },
+                            { YawnQueryOrder.desc(name) },
+                        ),
+                        uniqueColumn = { id },
+                    )
+                    .let { it.first to it.second.map { it.name } }
             }
-          },
-      )
+
+            val (total1, books1) = paginate(pageNumber = 0)
+            assertThat(total1).isEqualTo(6)
+            assertThat(books1).containsExactly("The Ugly Duckling", "The Little Mermaid")
+
+            val (total2, books2) = paginate(pageNumber = 1)
+            assertThat(total2).isEqualTo(6)
+            assertThat(books2).containsExactly("The Emperor's New Clothes", "The Hobbit")
+
+            val (total3, books3) = paginate(pageNumber = 2)
+            assertThat(total3).isEqualTo(6)
+            assertThat(books3).containsExactly("Lord of the Rings", "Harry Potter")
+
+            val (total4, book4) = paginate(pageNumber = 3)
+            assertThat(total4).isEqualTo(6)
+            assertThat(book4).isEmpty()
+
+            val (totalBig1, bigPage1) = paginate(pageNumber = 0, pageSize = 4)
+            assertThat(totalBig1).isEqualTo(6)
+            assertThat(bigPage1).containsExactly(
+                "The Ugly Duckling",
+                "The Little Mermaid",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+            )
+
+            val (totalBig2, bigPage2) = paginate(pageNumber = 1, pageSize = 4)
+            assertThat(totalBig2).isEqualTo(6)
+            assertThat(bigPage2).containsExactly(
+                "Lord of the Rings",
+                "Harry Potter",
+            )
+
+            val (totalHuge, hugePage) = paginate(pageNumber = 2, pageSize = 100)
+            assertThat(totalHuge).isEqualTo(6)
+            assertThat(hugePage).isEmpty()
+        }
     }
 
-    assertThat(bookNames).containsExactly(
-        "[0] The Little Mermaid", // 100 pages
-        "[1] The Ugly Duckling", // 110 pages
-        "[2] The Emperor's New Clothes", // 120 pages
-        "[0] The Hobbit", // 300 pages
-        "[1] Harry Potter", // 500 pages
-        "[2] Lord of the Rings", // 1000 pages
-    )
-  }
+    @Test
+    fun `list with join`() {
+        transactor.open { session ->
+            val (total, books) = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+            }
+                .listPaginatedWithTotalResultsZeroIndexed(
+                    pageNumber = 1,
+                    pageSize = 2,
+                    orders = listOf(
+                        { YawnQueryOrder.desc(name) },
+                    ),
+                    uniqueColumn = { id },
+                )
+
+            assertThat(total).isEqualTo(3)
+            assertThat(books.map { it.name }).containsExactly(
+                "The Emperor's New Clothes",
+            )
+        }
+    }
+
+    @Test
+    fun `do paginated`() {
+        val results = mutableListOf<String>()
+
+        transactor.open { session ->
+            session.query(BookTable).doPaginated(
+                pageSize = 2,
+                orders = listOf { YawnQueryOrder.asc(name) },
+                action = { books ->
+                    for (book in books) {
+                        results.add(book.author.name)
+                    }
+                },
+            )
+        }
+
+        assertThat(results).containsExactly(
+            "J.K. Rowling", // Harry Potter
+            "J.R.R. Tolkien", // Lord of the Rings
+            "Hans Christian Andersen", // The Emperor's New Clothes
+            "J.R.R. Tolkien", // The Hobbit
+            "Hans Christian Andersen", // The Little Mermaid
+            "Hans Christian Andersen", // The Ugly Duckling
+        )
+    }
+
+    @Test
+    fun `listing with batched`() {
+        transactor.open { session ->
+            val results = session.query(BookTable).listBatched(
+                batchSize = 2,
+                orders = listOf { YawnQueryOrder.asc(name) },
+            )
+
+            assertThat(results.map { it.name }).containsExactly(
+                "Harry Potter",
+                "Lord of the Rings",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+                "The Little Mermaid",
+                "The Ugly Duckling",
+            )
+        }
+    }
+
+    @Test
+    fun `paginate with projection`() {
+        transactor.open { session ->
+            val bookNames = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+                project(books.name)
+            }.paginateZeroIndexed(
+                pageNumber = 0,
+                pageSize = 3,
+                orders = listOf { YawnQueryOrder.desc(numberOfPages) },
+            ).list()
+
+            assertThat(bookNames).containsExactly(
+                "The Emperor's New Clothes", // 120 pages
+                "The Ugly Duckling", // 110 pages
+                "The Little Mermaid", // 100 pages
+            )
+        }
+    }
+
+    @Test
+    fun `do paginate with projection`() {
+        val bookNames = mutableListOf<String>()
+        transactor.open { session ->
+            session.project(BookTable) { books ->
+                project(books.name)
+            }.doPaginated(
+                pageSize = 3,
+                orders = listOf { YawnQueryOrder.asc(numberOfPages) },
+                action = { names ->
+                    for ((idx, bookName) in names.withIndex()) {
+                        bookNames.add("[$idx] $bookName")
+                    }
+                },
+            )
+        }
+
+        assertThat(bookNames).containsExactly(
+            "[0] The Little Mermaid", // 100 pages
+            "[1] The Ugly Duckling", // 110 pages
+            "[2] The Emperor's New Clothes", // 120 pages
+            "[0] The Hobbit", // 300 pages
+            "[1] Harry Potter", // 500 pages
+            "[2] Lord of the Rings", // 1000 pages
+        )
+    }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -11,643 +11,643 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class YawnProjectionTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `yawn query with projection`() {
-    transactor.open { session ->
-      val languages = session.project(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-        project(books.originalLanguage)
-      }.list()
+    @Test
+    fun `yawn query with projection`() {
+        transactor.open { session ->
+            val languages = session.project(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+                project(books.originalLanguage)
+            }.list()
 
-      val language = languages.single()
-      assertThat(language).isEqualTo(ENGLISH)
+            val language = languages.single()
+            assertThat(language).isEqualTo(ENGLISH)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with post projection`() {
-    transactor.open { session ->
-      val languages = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }
-          .applyProjection { project(it.originalLanguage) }
-          .list()
+    @Test
+    fun `yawn query with post projection`() {
+        transactor.open { session ->
+            val languages = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }
+                .applyProjection { project(it.originalLanguage) }
+                .list()
 
-      val language = languages.single()
-      assertThat(language).isEqualTo(ENGLISH)
+            val language = languages.single()
+            assertThat(language).isEqualTo(ENGLISH)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with nullable post projection`() {
-    transactor.open { session ->
-      val metadata1 = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }
-          .applyProjection { project(it.bookMetadata) }
-          .uniqueResult()!!
+    @Test
+    fun `yawn query with nullable post projection`() {
+        transactor.open { session ->
+            val metadata1 = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }
+                .applyProjection { project(it.bookMetadata) }
+                .uniqueResult()!!
 
-      assertThat(metadata1.isbn).isEqualTo("978-0-261-10221-7")
+            assertThat(metadata1.isbn).isEqualTo("978-0-261-10221-7")
 
-      val metadata2 = session.query(BookTable) { books ->
-        addEq(books.name, "Harry Potter")
-      }
-          .applyProjection { project(it.bookMetadata) }
-          .uniqueResult()
+            val metadata2 = session.query(BookTable) { books ->
+                addEq(books.name, "Harry Potter")
+            }
+                .applyProjection { project(it.bookMetadata) }
+                .uniqueResult()
 
-      assertThat(metadata2).isNull()
+            assertThat(metadata2).isNull()
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection - full entity`() {
-    transactor.open { session ->
-      val publishers = session.project(BookTable) { books ->
-        addLike(books.name, "The %")
+    @Test
+    fun `yawn query with projection - full entity`() {
+        transactor.open { session ->
+            val publishers = session.project(BookTable) { books ->
+                addLike(books.name, "The %")
 
-        // TODO(yawn): publisher should be nullable
-        addIsNotNull(nullable(books.publisher.foreignKey))
+                // TODO(yawn): publisher should be nullable
+                addIsNotNull(nullable(books.publisher.foreignKey))
 
-        project(books.publisher)
-      }.set()
-      assertThat(publishers.map { it.name }).containsExactlyInAnyOrder(
-          "Random House",
-          "Penguin",
-      )
+                project(books.publisher)
+            }.set()
+            assertThat(publishers.map { it.name }).containsExactlyInAnyOrder(
+                "Random House",
+                "Penguin",
+            )
 
-      val publisher = session.project(BookTable) { books ->
-        addEq(books.name, "Harry Potter")
-        project(books.publisher)
-      }.uniqueResult()!!
-      assertThat(publisher.name).isEqualTo("Penguin")
+            val publisher = session.project(BookTable) { books ->
+                addEq(books.name, "Harry Potter")
+                project(books.publisher)
+            }.uniqueResult()!!
+            assertThat(publisher.name).isEqualTo("Penguin")
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection - foreign key`() {
-    transactor.open { session ->
-      val publisherIdMap = session.project(PublisherTable) { publishers ->
-        project(YawnProjections.pair(publishers.name, publishers.id))
-      }.set().toMap()
+    @Test
+    fun `yawn query with projection - foreign key`() {
+        transactor.open { session ->
+            val publisherIdMap = session.project(PublisherTable) { publishers ->
+                project(YawnProjections.pair(publishers.name, publishers.id))
+            }.set().toMap()
 
-      val publisherWithThe = session.project(BookTable) { books ->
-        addLike(books.name, "The %")
-        addIsNotNull(books.publisher.foreignKey)
+            val publisherWithThe = session.project(BookTable) { books ->
+                addLike(books.name, "The %")
+                addIsNotNull(books.publisher.foreignKey)
 
-        // note that no join is necessary when using the `foreignKey` helper!
-        project(books.publisher.foreignKey)
-      }.set()
-      assertThat(publisherWithThe)
-          .containsExactlyInAnyOrder(
-              publisherIdMap.getValue("Penguin"),
-              publisherIdMap.getValue("Random House"),
-          )
+                // note that no join is necessary when using the `foreignKey` helper!
+                project(books.publisher.foreignKey)
+            }.set()
+            assertThat(publisherWithThe)
+                .containsExactlyInAnyOrder(
+                    publisherIdMap.getValue("Penguin"),
+                    publisherIdMap.getValue("Random House"),
+                )
 
-      val publishersWithJ = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addLike(authors.name, "J.%")
-        addIsNotNull(books.publisher.foreignKey)
+            val publishersWithJ = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addLike(authors.name, "J.%")
+                addIsNotNull(books.publisher.foreignKey)
 
-        project(books.publisher.foreignKey)
-      }.set()
-      assertThat(publishersWithJ)
-          .containsExactlyInAnyOrder(
-              publisherIdMap.getValue("HarperCollins"),
-              publisherIdMap.getValue("Penguin"),
-              publisherIdMap.getValue("Random House"),
-          )
+                project(books.publisher.foreignKey)
+            }.set()
+            assertThat(publishersWithJ)
+                .containsExactlyInAnyOrder(
+                    publisherIdMap.getValue("HarperCollins"),
+                    publisherIdMap.getValue("Penguin"),
+                    publisherIdMap.getValue("Random House"),
+                )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection - foreign key via join`() {
-    transactor.open { session ->
-      val publisherIdMap = session.project(PublisherTable) { publishers ->
-        project(YawnProjections.pair(publishers.name, publishers.id))
-      }.set().toMap()
+    @Test
+    fun `yawn query with projection - foreign key via join`() {
+        transactor.open { session ->
+            val publisherIdMap = session.project(PublisherTable) { publishers ->
+                project(YawnProjections.pair(publishers.name, publishers.id))
+            }.set().toMap()
 
-      val results = session.project(BookTable) { books ->
-        addLike(books.name, "The %")
+            val results = session.project(BookTable) { books ->
+                addLike(books.name, "The %")
 
-        // do not confuse!
-        // addEq("parent.id", 123L) => addEq(children.parent.foreignKey, 123L)
-        // createAlias("parent", "parent").addEq("parent.id", 123L) => addEq(join(children.parent).id, 123L)
+                // do not confuse!
+                // addEq("parent.id", 123L) => addEq(children.parent.foreignKey, 123L)
+                // createAlias("parent", "parent").addEq("parent.id", 123L) => addEq(join(children.parent).id, 123L)
 
-        // though no join is necessary when using the `foreignKey` helper, we can def do one if desired!
-        project(join(books.publisher).id) // is equivalent to `children.parent.foreignKey`
-      }.set()
-      assertThat(results)
-          .containsExactlyInAnyOrder(
-              publisherIdMap.getValue("Random House"),
-              publisherIdMap.getValue("Penguin"),
-          )
+                // though no join is necessary when using the `foreignKey` helper, we can def do one if desired!
+                project(join(books.publisher).id) // is equivalent to `children.parent.foreignKey`
+            }.set()
+            assertThat(results)
+                .containsExactlyInAnyOrder(
+                    publisherIdMap.getValue("Random House"),
+                    publisherIdMap.getValue("Penguin"),
+                )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - count`() {
-    transactor.open { session ->
-      val count = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-        project(YawnProjections.count(books.id))
-      }.uniqueResult()!!
-      assertThat(count).isEqualTo(3L)
+    @Test
+    fun `yawn query with projection function - count`() {
+        transactor.open { session ->
+            val count = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+                project(YawnProjections.count(books.id))
+            }.uniqueResult()!!
+            assertThat(count).isEqualTo(3L)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - count distinct`() {
-    transactor.open { session ->
-      val countToken = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-        project(YawnProjections.countDistinct(books.id))
-      }.uniqueResult()!!
-      assertThat(countToken).isEqualTo(3L)
+    @Test
+    fun `yawn query with projection function - count distinct`() {
+        transactor.open { session ->
+            val countToken = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+                project(YawnProjections.countDistinct(books.id))
+            }.uniqueResult()!!
+            assertThat(countToken).isEqualTo(3L)
 
-      val countAuthor = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-        project(YawnProjections.countDistinct(authors.name))
-      }.uniqueResult()!!
-      assertThat(countAuthor).isEqualTo(1)
+            val countAuthor = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+                project(YawnProjections.countDistinct(authors.name))
+            }.uniqueResult()!!
+            assertThat(countAuthor).isEqualTo(1)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - distinct`() {
-    transactor.open { session ->
-      val authors = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        project(YawnProjections.distinct(authors.name))
-      }.list()
-      assertThat(authors).containsExactlyInAnyOrder(
-          "J.R.R. Tolkien",
-          "J.K. Rowling",
-          "Hans Christian Andersen",
-      )
+    @Test
+    fun `yawn query with projection function - distinct`() {
+        transactor.open { session ->
+            val authors = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                project(YawnProjections.distinct(authors.name))
+            }.list()
+            assertThat(authors).containsExactlyInAnyOrder(
+                "J.R.R. Tolkien",
+                "J.K. Rowling",
+                "Hans Christian Andersen",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - sum`() {
-    transactor.open { session ->
-      val sum = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-        project(YawnProjections.sum(books.numberOfPages))
-      }.uniqueResult()!!
-      assertThat(sum).isEqualTo(1_300L)
+    @Test
+    fun `yawn query with projection function - sum`() {
+        transactor.open { session ->
+            val sum = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+                project(YawnProjections.sum(books.numberOfPages))
+            }.uniqueResult()!!
+            assertThat(sum).isEqualTo(1_300L)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - sum with nullable columns`() {
-    transactor.open { session ->
-      fun getSumRatingsByLanguage(vararg authorNames: String): Map<Book.Language, Long?> {
-        return session.project(BookTable) { books ->
-          val authors = join(books.author)
-          addIn(authors.name, *authorNames)
-          project(
-              YawnProjections.pair(
-                  YawnProjections.groupBy(books.originalLanguage),
-                  YawnProjections.sum(books.rating),
-              ),
-          )
-        }.list().associate { it.first to it.second }
-      }
+    @Test
+    fun `yawn query with projection function - sum with nullable columns`() {
+        transactor.open { session ->
+            fun getSumRatingsByLanguage(vararg authorNames: String): Map<Book.Language, Long?> {
+                return session.project(BookTable) { books ->
+                    val authors = join(books.author)
+                    addIn(authors.name, *authorNames)
+                    project(
+                        YawnProjections.pair(
+                            YawnProjections.groupBy(books.originalLanguage),
+                            YawnProjections.sum(books.rating),
+                        ),
+                    )
+                }.list().associate { it.first to it.second }
+            }
 
-      // All null
-      assertThat(getSumRatingsByLanguage("J.K. Rowling")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to null))
+            // All null
+            assertThat(getSumRatingsByLanguage("J.K. Rowling")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to null))
 
-      // Mixed null and non-null, nulls are ignored
-      assertThat(getSumRatingsByLanguage("J.K. Rowling", "J.R.R. Tolkien"))
-          .containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 19))
+            // Mixed null and non-null, nulls are ignored
+            assertThat(getSumRatingsByLanguage("J.K. Rowling", "J.R.R. Tolkien"))
+                .containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 19))
 
-      // All non-null
-      assertThat(getSumRatingsByLanguage("J.R.R. Tolkien")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 19))
+            // All non-null
+            assertThat(getSumRatingsByLanguage("J.R.R. Tolkien")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 19))
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - avg`() {
-    transactor.open { session ->
-      val tolkienAvg = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
+    @Test
+    fun `yawn query with projection function - avg`() {
+        transactor.open { session ->
+            val tolkienAvg = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
 
-        project(YawnProjections.avg(books.numberOfPages))
-      }.uniqueResult()!!
-      assertThat(tolkienAvg).isEqualTo(650.0)
+                project(YawnProjections.avg(books.numberOfPages))
+            }.uniqueResult()!!
+            assertThat(tolkienAvg).isEqualTo(650.0)
 
-      val andersenAvg = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
+            val andersenAvg = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
 
-        project(YawnProjections.avg(books.numberOfPages))
-      }.uniqueResult()!!
-      assertThat(andersenAvg).isEqualTo(110.0)
+                project(YawnProjections.avg(books.numberOfPages))
+            }.uniqueResult()!!
+            assertThat(andersenAvg).isEqualTo(110.0)
 
-      val totalAvg = session.project(BookTable) { books ->
-        project(YawnProjections.avg(books.numberOfPages))
-      }.uniqueResult()!!
-      assertThat(totalAvg).isEqualTo(355.0)
+            val totalAvg = session.project(BookTable) { books ->
+                project(YawnProjections.avg(books.numberOfPages))
+            }.uniqueResult()!!
+            assertThat(totalAvg).isEqualTo(355.0)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - avg with nullable columns`() {
-    transactor.open { session ->
-      fun getAvgRatingsByLanguage(vararg authorNames: String): Map<Book.Language, Double?> {
-        return session.project(BookTable) { books ->
-          val authors = join(books.author)
-          addIn(authors.name, *authorNames)
-          project(
-              YawnProjections.pair(
-                  YawnProjections.groupBy(books.originalLanguage),
-                  YawnProjections.avg(books.rating),
-              ),
-          )
-        }.list().associate { it.first to it.second }
-      }
+    @Test
+    fun `yawn query with projection function - avg with nullable columns`() {
+        transactor.open { session ->
+            fun getAvgRatingsByLanguage(vararg authorNames: String): Map<Book.Language, Double?> {
+                return session.project(BookTable) { books ->
+                    val authors = join(books.author)
+                    addIn(authors.name, *authorNames)
+                    project(
+                        YawnProjections.pair(
+                            YawnProjections.groupBy(books.originalLanguage),
+                            YawnProjections.avg(books.rating),
+                        ),
+                    )
+                }.list().associate { it.first to it.second }
+            }
 
-      // All null
-      assertThat(getAvgRatingsByLanguage("J.K. Rowling")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to null))
+            // All null
+            assertThat(getAvgRatingsByLanguage("J.K. Rowling")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to null))
 
-      // Mixed null and non-null, nulls are ignored
-      assertThat(getAvgRatingsByLanguage("J.K. Rowling", "J.R.R. Tolkien"))
-          .containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 9.5))
+            // Mixed null and non-null, nulls are ignored
+            assertThat(getAvgRatingsByLanguage("J.K. Rowling", "J.R.R. Tolkien"))
+                .containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 9.5))
 
-      // All non-null
-      assertThat(getAvgRatingsByLanguage("J.R.R. Tolkien")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 9.5))
+            // All non-null
+            assertThat(getAvgRatingsByLanguage("J.R.R. Tolkien")).containsExactlyInAnyOrderEntriesOf(mapOf(ENGLISH to 9.5))
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection function - min & max`() {
-    transactor.open { session ->
-      val minAuthor = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        project(YawnProjections.min(authors.name))
-      }.uniqueResult()!!
-      assertThat(minAuthor).isEqualTo("Hans Christian Andersen")
+    @Test
+    fun `yawn query with projection function - min & max`() {
+        transactor.open { session ->
+            val minAuthor = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                project(YawnProjections.min(authors.name))
+            }.uniqueResult()!!
+            assertThat(minAuthor).isEqualTo("Hans Christian Andersen")
 
-      val maxAuthor = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        project(YawnProjections.max(authors.name))
-      }.uniqueResult()!!
-      assertThat(maxAuthor).isEqualTo("J.R.R. Tolkien")
+            val maxAuthor = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                project(YawnProjections.max(authors.name))
+            }.uniqueResult()!!
+            assertThat(maxAuthor).isEqualTo("J.R.R. Tolkien")
 
-      val minPages = session.project(BookTable) { books ->
-        project(YawnProjections.min(books.numberOfPages))
-      }.uniqueResult()!!
-      assertThat(minPages).isEqualTo(100L)
+            val minPages = session.project(BookTable) { books ->
+                project(YawnProjections.min(books.numberOfPages))
+            }.uniqueResult()!!
+            assertThat(minPages).isEqualTo(100L)
 
-      val maxRowlingPages = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.K. Rowling")
-        project(YawnProjections.max(books.numberOfPages))
-      }.uniqueResult()!!
-      assertThat(maxRowlingPages).isEqualTo(500L)
+            val maxRowlingPages = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.K. Rowling")
+                project(YawnProjections.max(books.numberOfPages))
+            }.uniqueResult()!!
+            assertThat(maxRowlingPages).isEqualTo(500L)
 
-      val distinctNotes = session.project(BookTable) { books ->
-        project(YawnProjections.countDistinct(books.notes))
-      }.uniqueResult()!!
-      assertThat(distinctNotes).isEqualTo(2)
+            val distinctNotes = session.project(BookTable) { books ->
+                project(YawnProjections.countDistinct(books.notes))
+            }.uniqueResult()!!
+            assertThat(distinctNotes).isEqualTo(2)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with rowCount projection`() {
-    transactor.open { session ->
-      val allAuthors = session.query(BookTable).rowCount()
-      assertThat(allAuthors).isEqualTo(6)
-      val jaysWithDupes = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addLike(authors.name, "J.%")
-      }.rowCount()
-      assertThat(jaysWithDupes).isEqualTo(3)
-      val uniqueJays = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addLike(authors.name, "J.%")
-        project(YawnProjections.countDistinct(authors.name))
-      }.uniqueResult()!!
-      assertThat(uniqueJays).isEqualTo(2)
+    @Test
+    fun `yawn query with rowCount projection`() {
+        transactor.open { session ->
+            val allAuthors = session.query(BookTable).rowCount()
+            assertThat(allAuthors).isEqualTo(6)
+            val jaysWithDupes = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addLike(authors.name, "J.%")
+            }.rowCount()
+            assertThat(jaysWithDupes).isEqualTo(3)
+            val uniqueJays = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addLike(authors.name, "J.%")
+                project(YawnProjections.countDistinct(authors.name))
+            }.uniqueResult()!!
+            assertThat(uniqueJays).isEqualTo(2)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with exists projection`() {
-    transactor.open { session ->
-      val existsMany = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }.exists()
-      assertThat(existsMany).isTrue()
+    @Test
+    fun `yawn query with exists projection`() {
+        transactor.open { session ->
+            val existsMany = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }.exists()
+            assertThat(existsMany).isTrue()
 
-      val existsOne = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-        addEq(books.name, "The Hobbit")
-      }.exists()
-      assertThat(existsOne).isTrue()
+            val existsOne = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+                addEq(books.name, "The Hobbit")
+            }.exists()
+            assertThat(existsOne).isTrue()
 
-      val existsZero = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-        addEq(books.name, "The Hobbit 2 - Electric Boogaloo")
-      }.exists()
-      assertThat(existsZero).isFalse()
+            val existsZero = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+                addEq(books.name, "The Hobbit 2 - Electric Boogaloo")
+            }.exists()
+            assertThat(existsZero).isFalse()
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with pair projection`() {
-    transactor.open { session ->
-      val uniqueResult = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.K. Rowling")
-        project(YawnProjections.pair(authors.name, books.numberOfPages))
-      }.uniqueResult()!!
-      assertThat(uniqueResult.first).isEqualTo("J.K. Rowling")
-      assertThat(uniqueResult.second).isEqualTo(500L)
+    @Test
+    fun `yawn query with pair projection`() {
+        transactor.open { session ->
+            val uniqueResult = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.K. Rowling")
+                project(YawnProjections.pair(authors.name, books.numberOfPages))
+            }.uniqueResult()!!
+            assertThat(uniqueResult.first).isEqualTo("J.K. Rowling")
+            assertThat(uniqueResult.second).isEqualTo(500L)
 
-      val list = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-        project(YawnProjections.pair(authors.name, books.numberOfPages))
-      }.list()
+            val list = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+                project(YawnProjections.pair(authors.name, books.numberOfPages))
+            }.list()
 
-      assertThat(list).containsExactlyInAnyOrder(
-          "Hans Christian Andersen" to 100,
-          "Hans Christian Andersen" to 110,
-          "Hans Christian Andersen" to 120,
-      )
+            assertThat(list).containsExactlyInAnyOrder(
+                "Hans Christian Andersen" to 100,
+                "Hans Christian Andersen" to 110,
+                "Hans Christian Andersen" to 120,
+            )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with triple projection`() {
-    transactor.open { session ->
-      val uniqueResult = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.K. Rowling")
+    @Test
+    fun `yawn query with triple projection`() {
+        transactor.open { session ->
+            val uniqueResult = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.K. Rowling")
 
-        project(
-            YawnProjections.triple(books.name, authors.name, books.numberOfPages),
-        )
-      }.uniqueResult()!!
-      assertThat(uniqueResult.first).isEqualTo("Harry Potter")
-      assertThat(uniqueResult.second).isEqualTo("J.K. Rowling")
-      assertThat(uniqueResult.third).isEqualTo(500L)
+                project(
+                    YawnProjections.triple(books.name, authors.name, books.numberOfPages),
+                )
+            }.uniqueResult()!!
+            assertThat(uniqueResult.first).isEqualTo("Harry Potter")
+            assertThat(uniqueResult.second).isEqualTo("J.K. Rowling")
+            assertThat(uniqueResult.third).isEqualTo(500L)
 
-      val list = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
-        orderAsc(books.numberOfPages)
+            val list = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
+                orderAsc(books.numberOfPages)
 
-        project(YawnProjections.triple(books.name, authors.name, books.numberOfPages))
-      }.list()
+                project(YawnProjections.triple(books.name, authors.name, books.numberOfPages))
+            }.list()
 
-      assertThat(list).containsExactly(
-          Triple("The Little Mermaid", "Hans Christian Andersen", 100),
-          Triple("The Ugly Duckling", "Hans Christian Andersen", 110),
-          Triple("The Emperor's New Clothes", "Hans Christian Andersen", 120),
-      )
+            assertThat(list).containsExactly(
+                Triple("The Little Mermaid", "Hans Christian Andersen", 100),
+                Triple("The Ugly Duckling", "Hans Christian Andersen", 110),
+                Triple("The Emperor's New Clothes", "Hans Christian Andersen", 120),
+            )
+        }
     }
-  }
 
-  @YawnProjection
-  internal data class SimpleBook(
-      val author: String,
-      val numberOfPages: Long,
-  )
+    @YawnProjection
+    internal data class SimpleBook(
+        val author: String,
+        val numberOfPages: Long,
+    )
 
-  @Test
-  fun `yawn query with data class projection`() {
-    transactor.open { session ->
-      val uniqueResult = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.K. Rowling")
-        project(
-            YawnProjectionTest_SimpleBookProjection.create(
-                author = authors.name,
-                numberOfPages = books.numberOfPages,
-            ),
-        )
-      }.uniqueResult()!!
-      assertThat(uniqueResult.author).isEqualTo("J.K. Rowling")
-      assertThat(uniqueResult.numberOfPages).isEqualTo(500L)
+    @Test
+    fun `yawn query with data class projection`() {
+        transactor.open { session ->
+            val uniqueResult = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.K. Rowling")
+                project(
+                    YawnProjectionTest_SimpleBookProjection.create(
+                        author = authors.name,
+                        numberOfPages = books.numberOfPages,
+                    ),
+                )
+            }.uniqueResult()!!
+            assertThat(uniqueResult.author).isEqualTo("J.K. Rowling")
+            assertThat(uniqueResult.numberOfPages).isEqualTo(500L)
 
-      val list = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "Hans Christian Andersen")
+            val list = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "Hans Christian Andersen")
 
-        project(
-            YawnProjectionTest_SimpleBookProjection.create(
-                author = authors.name,
-                numberOfPages = books.numberOfPages,
-            ),
-        )
-      }.list()
+                project(
+                    YawnProjectionTest_SimpleBookProjection.create(
+                        author = authors.name,
+                        numberOfPages = books.numberOfPages,
+                    ),
+                )
+            }.list()
 
-      assertThat(list).containsExactlyInAnyOrder(
-          SimpleBook("Hans Christian Andersen", 100),
-          SimpleBook("Hans Christian Andersen", 110),
-          SimpleBook("Hans Christian Andersen", 120),
-      )
+            assertThat(list).containsExactlyInAnyOrder(
+                SimpleBook("Hans Christian Andersen", 100),
+                SimpleBook("Hans Christian Andersen", 110),
+                SimpleBook("Hans Christian Andersen", 120),
+            )
+        }
     }
-  }
 
-  @YawnProjection
-  internal data class AuthorAndBooks(
-      val author: String,
-      val numberOfBooks: Long,
-  )
+    @YawnProjection
+    internal data class AuthorAndBooks(
+        val author: String,
+        val numberOfBooks: Long,
+    )
 
-  @Test
-  fun `yawn query with group by`() {
-    transactor.open { session ->
-      val results = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        project(
-            YawnProjectionTest_AuthorAndBooksProjection.create(
-                author = YawnProjections.groupBy(authors.name),
-                numberOfBooks = YawnProjections.count(books.name),
-            ),
-        )
-      }.list()
+    @Test
+    fun `yawn query with group by`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                project(
+                    YawnProjectionTest_AuthorAndBooksProjection.create(
+                        author = YawnProjections.groupBy(authors.name),
+                        numberOfBooks = YawnProjections.count(books.name),
+                    ),
+                )
+            }.list()
 
-      assertThat(results).containsExactlyInAnyOrder(
-          AuthorAndBooks("J.R.R. Tolkien", 2),
-          AuthorAndBooks("J.K. Rowling", 1),
-          AuthorAndBooks("Hans Christian Andersen", 3),
-      )
+            assertThat(results).containsExactlyInAnyOrder(
+                AuthorAndBooks("J.R.R. Tolkien", 2),
+                AuthorAndBooks("J.K. Rowling", 1),
+                AuthorAndBooks("Hans Christian Andersen", 3),
+            )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with projection and join`() {
-    transactor.open { session ->
-      val results1 = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
+    @Test
+    fun `yawn query with projection and join`() {
+        transactor.open { session ->
+            val results1 = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
 
-        project(authors.name)
-        // TODO(luan): calling list().toSet() here triggers some obscure detekt bug!
-      }.set()
-      assertThat(results1).containsExactlyInAnyOrder("J.R.R. Tolkien")
+                project(authors.name)
+                // TODO(luan): calling list().toSet() here triggers some obscure detekt bug!
+            }.set()
+            assertThat(results1).containsExactlyInAnyOrder("J.R.R. Tolkien")
 
-      val results2 = session.project(BookTable) { books ->
-        addLike(books.name, "The %")
+            val results2 = session.project(BookTable) { books ->
+                addLike(books.name, "The %")
 
-        val authors = join(books.author)
-        project(authors.name)
-      }.set()
-      assertThat(results2).containsExactlyInAnyOrder("J.R.R. Tolkien", "Hans Christian Andersen")
+                val authors = join(books.author)
+                project(authors.name)
+            }.set()
+            assertThat(results2).containsExactlyInAnyOrder("J.R.R. Tolkien", "Hans Christian Andersen")
+        }
     }
-  }
 
-  @YawnProjection
-  internal data class AuthorAndBookName(
-      val authorName: String,
-      val bookName: String,
-  )
+    @YawnProjection
+    internal data class AuthorAndBookName(
+        val authorName: String,
+        val bookName: String,
+    )
 
-  @Test
-  fun `yawn query with projection and order`() {
-    transactor.open { session ->
-      val resultsAsc = session.project(BookTable) { books ->
-        orderAsc(books.name)
-        project(books.name)
-      }.list()
+    @Test
+    fun `yawn query with projection and order`() {
+        transactor.open { session ->
+            val resultsAsc = session.project(BookTable) { books ->
+                orderAsc(books.name)
+                project(books.name)
+            }.list()
 
-      assertThat(resultsAsc).containsExactly(
-          "Harry Potter",
-          "Lord of the Rings",
-          "The Emperor's New Clothes",
-          "The Hobbit",
-          "The Little Mermaid",
-          "The Ugly Duckling",
-      )
+            assertThat(resultsAsc).containsExactly(
+                "Harry Potter",
+                "Lord of the Rings",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+                "The Little Mermaid",
+                "The Ugly Duckling",
+            )
 
-      val resultsDesc = session.project(BookTable) { books ->
-        orderDesc(books.name)
-        project(books.name)
-      }.list()
+            val resultsDesc = session.project(BookTable) { books ->
+                orderDesc(books.name)
+                project(books.name)
+            }.list()
 
-      assertThat(resultsDesc).containsExactly(
-          "The Ugly Duckling",
-          "The Little Mermaid",
-          "The Hobbit",
-          "The Emperor's New Clothes",
-          "Lord of the Rings",
-          "Harry Potter",
-      )
+            assertThat(resultsDesc).containsExactly(
+                "The Ugly Duckling",
+                "The Little Mermaid",
+                "The Hobbit",
+                "The Emperor's New Clothes",
+                "Lord of the Rings",
+                "Harry Potter",
+            )
 
-      val resultMultiple = session.project(BookTable) { books ->
-        val authors = join(books.author)
-        order(YawnQueryOrder.asc(authors.name), YawnQueryOrder.desc(books.name))
-        project(YawnProjectionTest_AuthorAndBookNameProjection.create(authors.name, books.name))
-      }.list()
+            val resultMultiple = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                order(YawnQueryOrder.asc(authors.name), YawnQueryOrder.desc(books.name))
+                project(YawnProjectionTest_AuthorAndBookNameProjection.create(authors.name, books.name))
+            }.list()
 
-      assertThat(resultMultiple.map { "${it.authorName} - ${it.bookName}" }).containsExactly(
-          "Hans Christian Andersen - The Ugly Duckling",
-          "Hans Christian Andersen - The Little Mermaid",
-          "Hans Christian Andersen - The Emperor's New Clothes",
-          "J.K. Rowling - Harry Potter",
-          "J.R.R. Tolkien - The Hobbit",
-          "J.R.R. Tolkien - Lord of the Rings",
-      )
+            assertThat(resultMultiple.map { "${it.authorName} - ${it.bookName}" }).containsExactly(
+                "Hans Christian Andersen - The Ugly Duckling",
+                "Hans Christian Andersen - The Little Mermaid",
+                "Hans Christian Andersen - The Emperor's New Clothes",
+                "J.K. Rowling - Harry Potter",
+                "J.R.R. Tolkien - The Hobbit",
+                "J.R.R. Tolkien - Lord of the Rings",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with maxValueOf and minValueOf`() {
-    transactor.open { session ->
-      assertThat(session.query(BookTable).maxValueOf { name }).isEqualTo("The Ugly Duckling")
-      assertThat(session.query(BookTable).minValueOf { name }).isEqualTo("Harry Potter")
+    @Test
+    fun `yawn query with maxValueOf and minValueOf`() {
+        transactor.open { session ->
+            assertThat(session.query(BookTable).maxValueOf { name }).isEqualTo("The Ugly Duckling")
+            assertThat(session.query(BookTable).minValueOf { name }).isEqualTo("Harry Potter")
+        }
     }
-  }
 
-  @YawnProjection
-  data class NullabilityAllowance(
-      val name: String,
-      val aLong: Long,
-      val aNullableLong: Long?,
-      val aString: String,
-      val aNullableString: String?,
-  )
+    @YawnProjection
+    data class NullabilityAllowance(
+        val name: String,
+        val aLong: Long,
+        val aNullableLong: Long?,
+        val aString: String,
+        val aNullableString: String?,
+    )
 
-  @Test
-  fun `non-null values can be coerced into null values in projections`() {
-    transactor.open { session ->
-      val results = session.project(BookTable) { books ->
-        addIn(books.name, setOf("The Hobbit", "The Little Mermaid"))
-        project(
-            YawnProjectionTest_NullabilityAllowanceProjection.create(
-                name = books.name,
-                aLong = books.numberOfPages,
-                aNullableLong = books.numberOfPages,
-                // TODO(yawn): extended coalesce syntax
-                aString = YawnProjections.coalesce(books.notes, "fallback"),
-                aNullableString = books.notes,
-            ),
-        )
-      }.list()
+    @Test
+    fun `non-null values can be coerced into null values in projections`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                addIn(books.name, setOf("The Hobbit", "The Little Mermaid"))
+                project(
+                    YawnProjectionTest_NullabilityAllowanceProjection.create(
+                        name = books.name,
+                        aLong = books.numberOfPages,
+                        aNullableLong = books.numberOfPages,
+                        // TODO(yawn): extended coalesce syntax
+                        aString = YawnProjections.coalesce(books.notes, "fallback"),
+                        aNullableString = books.notes,
+                    ),
+                )
+            }.list()
 
-      with(results.single { it.name == "The Hobbit" }) {
-        assertThat(aLong).isEqualTo(300L)
-        assertThat(aNullableLong).isEqualTo(300L)
-        assertThat(aString).isEqualTo("Note for The Hobbit and Harry Potter")
-        assertThat(aNullableString).isEqualTo("Note for The Hobbit and Harry Potter")
-      }
+            with(results.single { it.name == "The Hobbit" }) {
+                assertThat(aLong).isEqualTo(300L)
+                assertThat(aNullableLong).isEqualTo(300L)
+                assertThat(aString).isEqualTo("Note for The Hobbit and Harry Potter")
+                assertThat(aNullableString).isEqualTo("Note for The Hobbit and Harry Potter")
+            }
 
-      with(results.single { it.name == "The Little Mermaid" }) {
-        assertThat(aLong).isEqualTo(100L)
-        assertThat(aNullableLong).isEqualTo(100L)
-        assertThat(aString).isEqualTo("fallback")
-        assertThat(aNullableString).isNull()
-      }
+            with(results.single { it.name == "The Little Mermaid" }) {
+                assertThat(aLong).isEqualTo(100L)
+                assertThat(aNullableLong).isEqualTo(100L)
+                assertThat(aString).isEqualTo("fallback")
+                assertThat(aNullableString).isNull()
+            }
+        }
     }
-  }
 
-  @Test
-  fun `use constant projection`() {
-    transactor.open { session ->
-      val results = session.project(BookTable) { books ->
-        addIn(books.name, setOf("The Hobbit", "The Little Mermaid"))
+    @Test
+    fun `use constant projection`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                addIn(books.name, setOf("The Hobbit", "The Little Mermaid"))
 
-        val authors = join(books.author)
-        project(
-            YawnProjectionTest_NullabilityAllowanceProjection.create(
-                name = books.name,
-                // TODO(yawn): support selectConstant for non-String types and multiple different values
-                aLong = books.numberOfPages,
-                aNullableLong = YawnProjections.`null`(),
-                aString = authors.name,
-                aNullableString = YawnProjections.`null`(),
-            ),
-        )
-      }.list()
+                val authors = join(books.author)
+                project(
+                    YawnProjectionTest_NullabilityAllowanceProjection.create(
+                        name = books.name,
+                        // TODO(yawn): support selectConstant for non-String types and multiple different values
+                        aLong = books.numberOfPages,
+                        aNullableLong = YawnProjections.`null`(),
+                        aString = authors.name,
+                        aNullableString = YawnProjections.`null`(),
+                    ),
+                )
+            }.list()
 
-      assertThat(results).containsExactlyInAnyOrder(
-          NullabilityAllowance(
-              name = "The Hobbit",
-              aLong = 300,
-              aNullableLong = null,
-              aString = "J.R.R. Tolkien",
-              aNullableString = null,
-          ),
-          NullabilityAllowance(
-              name = "The Little Mermaid",
-              aLong = 100,
-              aNullableLong = null,
-              aString = "Hans Christian Andersen",
-              aNullableString = null,
-          ),
-      )
+            assertThat(results).containsExactlyInAnyOrder(
+                NullabilityAllowance(
+                    name = "The Hobbit",
+                    aLong = 300,
+                    aNullableLong = null,
+                    aString = "J.R.R. Tolkien",
+                    aNullableString = null,
+                ),
+                NullabilityAllowance(
+                    name = "The Little Mermaid",
+                    aLong = 100,
+                    aNullableLong = null,
+                    aString = "Hans Christian Andersen",
+                    aNullableString = null,
+                ),
+            )
+        }
     }
-  }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSimpleQueriesTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSimpleQueriesTest.kt
@@ -20,760 +20,777 @@ import org.hibernate.NullPrecedence.FIRST
 import org.hibernate.NullPrecedence.LAST
 import org.junit.jupiter.api.Test
 import java.sql.SQLException
-import kotlin.jvm.java
 
 internal class YawnSimpleQueriesTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `exists()`() {
-    /**
-     * The exists() implementation will run a query selecting '1' and seeing if anything is returned.
-     *
-     * Example:
-     *     SELECT
-     *         '1' as _yawn_ct
-     *     FROM
-     *         books this_
-     *     WHERE
-     *         ...
-     *     LIMIT 1
-     */
+    @Test
+    fun `exists()`() {
+        /**
+         * The exists() implementation will run a query selecting '1' and seeing if anything is returned.
+         *
+         * Example:
+         *     SELECT
+         *         '1' as _yawn_ct
+         *     FROM
+         *         books this_
+         *     WHERE
+         *         ...
+         *     LIMIT 1
+         */
 
-    transactor.open { session ->
-      val result1 = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }.exists()
-      assertThat(result1).isTrue()
+        transactor.open { session ->
+            val result1 = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }.exists()
+            assertThat(result1).isTrue()
 
-      val result2 = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
+            val result2 = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
 
-        val authors = join(books.author)
-        addEq(authors.name, "J.K. Rowling")
-      }.exists()
-      assertThat(result2).isFalse()
+                val authors = join(books.author)
+                addEq(authors.name, "J.K. Rowling")
+            }.exists()
+            assertThat(result2).isFalse()
 
-      val result3 = session.query(BookTable) { books ->
-        val publishers = join(books.publisher)
-        addEq(publishers.name, "HarperCollins")
+            val result3 = session.query(BookTable) { books ->
+                val publishers = join(books.publisher)
+                addEq(publishers.name, "HarperCollins")
 
-        addGt(books.sales.paperBacksSold, 1_000_000)
-      }.exists()
-      assertThat(result3).isTrue()
+                addGt(books.sales.paperBacksSold, 1_000_000)
+            }.exists()
+            assertThat(result3).isTrue()
 
-      val result4 = session.query(BookTable) { books ->
-        val publishers = join(books.publisher)
-        addEq(publishers.name, "HarperCollins")
+            val result4 = session.query(BookTable) { books ->
+                val publishers = join(books.publisher)
+                addEq(publishers.name, "HarperCollins")
 
-        addGt(books.sales.paperBacksSold, 2_000_000)
-      }.exists()
-      assertThat(result4).isFalse()
+                addGt(books.sales.paperBacksSold, 2_000_000)
+            }.exists()
+            assertThat(result4).isFalse()
+        }
     }
-  }
 
-  @Test
-  fun `yawn fetch complete entity`() {
-    transactor.open { session ->
-      val book = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }.uniqueResult()!!
+    @Test
+    fun `yawn fetch complete entity`() {
+        transactor.open { session ->
+            val book = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }.uniqueResult()!!
 
-      with(book) {
-        assertThat(name).isEqualTo("The Hobbit")
-        assertThat(author.name).isEqualTo("J.R.R. Tolkien")
-        assertThat(publisher!!.name).isEqualTo("Random House")
-        assertThat(genres).containsExactlyInAnyOrder(FANTASY, ADVENTURE)
-        assertThat(numberOfPages).isEqualTo(300)
-        assertThat(notes).isEqualTo("Note for The Hobbit and Harry Potter")
-      }
+            with(book) {
+                assertThat(name).isEqualTo("The Hobbit")
+                assertThat(author.name).isEqualTo("J.R.R. Tolkien")
+                assertThat(publisher!!.name).isEqualTo("Random House")
+                assertThat(genres).containsExactlyInAnyOrder(FANTASY, ADVENTURE)
+                assertThat(numberOfPages).isEqualTo(300)
+                assertThat(notes).isEqualTo("Note for The Hobbit and Harry Potter")
+            }
 
-      with(book.bookMetadata!!) {
-        assertThat(isbn).isEqualTo("978-0-261-10221-7")
-        assertThat(publicationYear).isEqualTo(1937)
-      }
+            with(book.bookMetadata!!) {
+                assertThat(isbn).isEqualTo("978-0-261-10221-7")
+                assertThat(publicationYear).isEqualTo(1937)
+            }
 
-      with(book.sales) {
-        assertThat(paperBacksSold).isEqualTo(2_000_000)
-        assertThat(hardBacksSold).isEqualTo(1_999_999)
-        assertThat(countryWithMostCopiesSold).isEqualTo("UK")
-      }
+            with(book.sales) {
+                assertThat(paperBacksSold).isEqualTo(2_000_000)
+                assertThat(hardBacksSold).isEqualTo(1_999_999)
+                assertThat(countryWithMostCopiesSold).isEqualTo("UK")
+            }
+        }
     }
-  }
 
-  @Test
-  fun `yawn query by string equals`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }.list()
+    @Test
+    fun `yawn query by string equals`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }.list()
 
-      val theHobbit = results.single()
-      assertThat(theHobbit.name).isEqualTo("The Hobbit")
-      assertThat(theHobbit.author.name).isEqualTo("J.R.R. Tolkien")
+            val theHobbit = results.single()
+            assertThat(theHobbit.name).isEqualTo("The Hobbit")
+            assertThat(theHobbit.author.name).isEqualTo("J.R.R. Tolkien")
+        }
     }
-  }
 
-  @Test
-  fun `yawn query by id`() {
-    transactor.open { session ->
-      val theHobbitId = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }.uniqueResult()!!.id
+    @Test
+    fun `yawn query by id`() {
+        transactor.open { session ->
+            val theHobbitId = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }.uniqueResult()!!.id
 
-      val theHobbit = session.query(BookTable) { books ->
-        addEq(books.id, theHobbitId)
-      }.uniqueResult()!!
+            val theHobbit = session.query(BookTable) { books ->
+                addEq(books.id, theHobbitId)
+            }.uniqueResult()!!
 
-      with(theHobbit) {
-        assertThat(id).isEqualTo(theHobbitId)
-        assertThat(author.name).isEqualTo("J.R.R. Tolkien")
-      }
+            with(theHobbit) {
+                assertThat(id).isEqualTo(theHobbitId)
+                assertThat(author.name).isEqualTo("J.R.R. Tolkien")
+            }
+        }
     }
-  }
 
-  @Test
-  fun `yawn query using apply filter`() {
-    transactor.open { session ->
-      val results = session.query(BookTable)
-          .applyFilter { addEq(it.name, "The Hobbit") }
-          .list()
+    @Test
+    fun `yawn query using apply filter`() {
+        transactor.open { session ->
+            val results = session.query(BookTable)
+                .applyFilter { addEq(it.name, "The Hobbit") }
+                .list()
 
-      val theHobbit = results.single()
-      assertThat(theHobbit.name).isEqualTo("The Hobbit")
-      assertThat(theHobbit.author.name).isEqualTo("J.R.R. Tolkien")
+            val theHobbit = results.single()
+            assertThat(theHobbit.name).isEqualTo("The Hobbit")
+            assertThat(theHobbit.author.name).isEqualTo("J.R.R. Tolkien")
+        }
     }
-  }
 
-  @Test
-  fun `yawn query by string multiple`() {
-    transactor.open { session ->
-      val results = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }.list()
+    @Test
+    fun `yawn query by string multiple`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }.list()
 
-      assertThat(results).hasSize(2)
-      assertThat(results.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Lord of the Rings")
+            assertThat(results).hasSize(2)
+            assertThat(results.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Lord of the Rings")
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with max results`() {
-    transactor.open { session ->
-      val allResults = session.query(BookTable)
-          .list()
-      assertThat(allResults).hasSize(6)
+    @Test
+    fun `yawn query with max results`() {
+        transactor.open { session ->
+            val allResults = session.query(BookTable)
+                .list()
+            assertThat(allResults).hasSize(6)
 
-      val threeResults = session.query(BookTable)
-          .maxResults(3)
-          .list()
-      assertThat(threeResults).hasSize(3)
+            val threeResults = session.query(BookTable)
+                .maxResults(3)
+                .list()
+            assertThat(threeResults).hasSize(3)
 
-      val twoResults = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }
-          .maxResults(3)
-          .list()
-      assertThat(twoResults).hasSize(2)
+            val twoResults = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }
+                .maxResults(3)
+                .list()
+            assertThat(twoResults).hasSize(2)
+        }
     }
-  }
 
-  @Test
-  fun `yawn all ways of ordering`() {
-    transactor.open { session ->
-      val orderedBooks = setOf(
-          "Harry Potter",
-          "Lord of the Rings",
-          "The Emperor's New Clothes",
-          "The Hobbit",
-          "The Little Mermaid",
-          "The Ugly Duckling",
-      )
+    @Test
+    fun `yawn all ways of ordering`() {
+        transactor.open { session ->
+            val orderedBooks = setOf(
+                "Harry Potter",
+                "Lord of the Rings",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+                "The Little Mermaid",
+                "The Ugly Duckling",
+            )
 
-      fun assertOrderedBooks(books: List<Book>) {
-        assertThat(books.map { it.name }).containsExactlyElementsOf(orderedBooks)
-      }
+            fun assertOrderedBooks(books: List<Book>) {
+                assertThat(books.map { it.name }).containsExactlyElementsOf(orderedBooks)
+            }
 
-      val insideLambda = session.query(BookTable) { books ->
-        orderAsc(books.name)
-      }.list()
-      assertOrderedBooks(insideLambda)
+            val insideLambda = session.query(BookTable) { books ->
+                orderAsc(books.name)
+            }.list()
+            assertOrderedBooks(insideLambda)
 
-      val orderAsc = session.query(BookTable)
-          .orderAsc { name }
-          .list()
-      assertOrderedBooks(orderAsc)
+            val orderAsc = session.query(BookTable)
+                .orderAsc { name }
+                .list()
+            assertOrderedBooks(orderAsc)
 
-      val applyOrder = session.query(BookTable)
-          .applyOrder { YawnQueryOrder.asc(name) }
-          .list()
-      assertOrderedBooks(applyOrder)
+            val applyOrder = session.query(BookTable)
+                .applyOrder { YawnQueryOrder.asc(name) }
+                .list()
+            assertOrderedBooks(applyOrder)
 
-      val applyOrders = session.query(BookTable)
-          .applyOrders(
-              listOf(
-                  { YawnQueryOrder.asc(name) },
-              ),
-          )
-          .list()
-      assertOrderedBooks(applyOrders)
+            val applyOrders = session.query(BookTable)
+                .applyOrders(
+                    listOf(
+                        { YawnQueryOrder.asc(name) },
+                    ),
+                )
+                .list()
+            assertOrderedBooks(applyOrders)
+        }
     }
-  }
 
-  @Test
-  fun `yawn query with offset`() {
-    transactor.open { session ->
-      val allBooks = session.query(BookTable) { orderAsc(it.name) }
-          .maxResults(4)
-          .list()
-          .map { it.name }
-      assertThat(allBooks).containsExactly(
-          "Harry Potter",
-          "Lord of the Rings",
-          "The Emperor's New Clothes",
-          "The Hobbit",
-      )
+    @Test
+    fun `yawn query with offset`() {
+        transactor.open { session ->
+            val allBooks = session.query(BookTable) { orderAsc(it.name) }
+                .maxResults(4)
+                .list()
+                .map { it.name }
+            assertThat(allBooks).containsExactly(
+                "Harry Potter",
+                "Lord of the Rings",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+            )
 
-      val offset0 = session.query(BookTable) { orderAsc(it.name) }
-          .maxResults(2)
-          .offset(0)
-          .list()
-          .map { it.name }
-      assertThat(offset0).containsExactly(
-          "Harry Potter",
-          "Lord of the Rings",
-      )
+            val offset0 = session.query(BookTable) { orderAsc(it.name) }
+                .maxResults(2)
+                .offset(0)
+                .list()
+                .map { it.name }
+            assertThat(offset0).containsExactly(
+                "Harry Potter",
+                "Lord of the Rings",
+            )
 
-      val offset1 = session.query(BookTable) { orderAsc(it.name) }
-          .maxResults(2)
-          .offset(1)
-          .list()
-          .map { it.name }
-      assertThat(offset1).containsExactly(
-          "Lord of the Rings",
-          "The Emperor's New Clothes",
-      )
+            val offset1 = session.query(BookTable) { orderAsc(it.name) }
+                .maxResults(2)
+                .offset(1)
+                .list()
+                .map { it.name }
+            assertThat(offset1).containsExactly(
+                "Lord of the Rings",
+                "The Emperor's New Clothes",
+            )
 
-      val offset2 = session.query(BookTable) { orderAsc(it.name) }
-          .maxResults(2)
-          .offset(2)
-          .list()
-          .map { it.name }
+            val offset2 = session.query(BookTable) { orderAsc(it.name) }
+                .maxResults(2)
+                .offset(2)
+                .list()
+                .map { it.name }
 
-      assertThat(offset2).containsExactly(
-          "The Emperor's New Clothes",
-          "The Hobbit",
-      )
+            assertThat(offset2).containsExactly(
+                "The Emperor's New Clothes",
+                "The Hobbit",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `custom type adapter - EmailAddress`() {
-    transactor.open { session ->
-      val tolkien = session.query(PersonTable) { people ->
-        addEq(people.name, "J.R.R. Tolkien")
-      }.uniqueResult()!!
-      assertThat(tolkien.email).isEqualTo(EmailAddress("tolkien@faire.com"))
+    @Test
+    fun `custom type adapter - EmailAddress`() {
+        transactor.open { session ->
+            val tolkien = session.query(PersonTable) { people ->
+                addEq(people.name, "J.R.R. Tolkien")
+            }.uniqueResult()!!
+            assertThat(tolkien.email).isEqualTo(EmailAddress("tolkien@faire.com"))
 
-      val rowling = session.query(PersonTable) { people ->
-        addEq(people.email, EmailAddress("rowling@faire.com"))
-      }.uniqueResult()!!
-      assertThat(rowling.name).isEqualTo("J.K. Rowling")
+            val rowling = session.query(PersonTable) { people ->
+                addEq(people.email, EmailAddress("rowling@faire.com"))
+            }.uniqueResult()!!
+            assertThat(rowling.name).isEqualTo("J.K. Rowling")
+        }
     }
-  }
 
-  @Test
-  fun `query a type with @SerializeAsJson`() {
-    transactor.open { session ->
-      val dbBook = session.query(BookTable) { books ->
-        addEq(books.name, "Lord of the Rings")
-      }.uniqueResult()!!
+    @Test
+    fun `query a type with @SerializeAsJson`() {
+        transactor.open { session ->
+            val dbBook = session.query(BookTable) { books ->
+                addEq(books.name, "Lord of the Rings")
+            }.uniqueResult()!!
 
-      with(dbBook) {
-        assertThat(name).isEqualTo("Lord of the Rings")
-        assertThat(bookMetadata!!.publicationYear).isEqualTo(1954)
-        assertThat(bookMetadata!!.isbn).isEqualTo("978-3-16-148410-0")
-      }
+            with(dbBook) {
+                assertThat(name).isEqualTo("Lord of the Rings")
+                assertThat(bookMetadata!!.publicationYear).isEqualTo(1954)
+                assertThat(bookMetadata!!.isbn).isEqualTo("978-3-16-148410-0")
+            }
+        }
     }
-  }
 
-  @Test
-  fun `query against a hibernate supported object`() {
-    transactor.open { session ->
-      val dateTimeCreatedSecondBook = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }.uniqueResult()!!.createdAt
-      val books = session.query(BookTable) { books ->
-        addGt(books.createdAt, dateTimeCreatedSecondBook)
-      }.list()
+    @Test
+    fun `query against a hibernate supported object`() {
+        transactor.open { session ->
+            val dateTimeCreatedSecondBook = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }.uniqueResult()!!.createdAt
+            val books = session.query(BookTable) { books ->
+                addGt(books.createdAt, dateTimeCreatedSecondBook)
+            }.list()
 
-      assertThat(books)
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              "Harry Potter",
-              "The Little Mermaid",
-              "The Ugly Duckling",
-              "The Emperor's New Clothes",
-          )
+            assertThat(books)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Harry Potter",
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                    "The Emperor's New Clothes",
+                )
+        }
     }
-  }
 
-  @Test
-  fun `supports joins`() {
-    transactor.open { session ->
-      val tolkienBooks = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }.list()
+    @Test
+    fun `supports joins`() {
+        transactor.open { session ->
+            val tolkienBooks = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }.list()
 
-      assertThat(tolkienBooks.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Lord of the Rings")
+            assertThat(tolkienBooks.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Lord of the Rings")
 
-      val jHBooks = session.query(BookTable) { books ->
-        addLike(books.name, "%H%")
+            val jHBooks = session.query(BookTable) { books ->
+                addLike(books.name, "%H%")
 
-        val authors = join(books.author)
-        addLike(authors.name, "J.%")
-      }.list()
+                val authors = join(books.author)
+                addLike(authors.name, "J.%")
+            }.list()
 
-      assertThat(jHBooks.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Harry Potter")
+            assertThat(jHBooks.map { it.name }).containsExactlyInAnyOrder("The Hobbit", "Harry Potter")
+        }
     }
-  }
 
-  @Test
-  fun `supports nested joins`() {
-    transactor.open { session ->
-      val ranking = session.query(BookRankingTable) { ranking ->
-        val bestSeller = join(ranking.bestSeller)
-        val author = join(bestSeller.author)
-        addEq(author.name, "J.K. Rowling")
-      }.uniqueResult()!!
+    @Test
+    fun `supports nested joins`() {
+        transactor.open { session ->
+            val ranking = session.query(BookRankingTable) { ranking ->
+                val bestSeller = join(ranking.bestSeller)
+                val author = join(bestSeller.author)
+                addEq(author.name, "J.K. Rowling")
+            }.uniqueResult()!!
 
-      assertThat(ranking.ratingYear).isEqualTo(2007)
-      assertThat(ranking.ratingMonth).isEqualTo(1)
-      assertThat(ranking.bestSeller.name).isEqualTo("Harry Potter")
-      assertThat(ranking.bestSeller.author.name).isEqualTo("J.K. Rowling")
+            assertThat(ranking.ratingYear).isEqualTo(2007)
+            assertThat(ranking.ratingMonth).isEqualTo(1)
+            assertThat(ranking.bestSeller.name).isEqualTo("Harry Potter")
+            assertThat(ranking.bestSeller.author.name).isEqualTo("J.K. Rowling")
+        }
     }
-  }
 
-  @Test
-  fun `order by`() {
-    transactor.open { session ->
-      val resultsAsc = session.query(BookTable) { books ->
-        orderAsc(books.name)
-      }.list()
+    @Test
+    fun `order by`() {
+        transactor.open { session ->
+            val resultsAsc = session.query(BookTable) { books ->
+                orderAsc(books.name)
+            }.list()
 
-      assertThat(resultsAsc.map { it.name }).containsExactly(
-          "Harry Potter",
-          "Lord of the Rings",
-          "The Emperor's New Clothes",
-          "The Hobbit",
-          "The Little Mermaid",
-          "The Ugly Duckling",
-      )
+            assertThat(resultsAsc.map { it.name }).containsExactly(
+                "Harry Potter",
+                "Lord of the Rings",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+                "The Little Mermaid",
+                "The Ugly Duckling",
+            )
 
-      val resultsDesc = session.query(BookTable) { books ->
-        orderDesc(books.name)
-      }.list()
+            val resultsDesc = session.query(BookTable) { books ->
+                orderDesc(books.name)
+            }.list()
 
-      assertThat(resultsDesc.map { it.name }).containsExactly(
-          "The Ugly Duckling",
-          "The Little Mermaid",
-          "The Hobbit",
-          "The Emperor's New Clothes",
-          "Lord of the Rings",
-          "Harry Potter",
-      )
+            assertThat(resultsDesc.map { it.name }).containsExactly(
+                "The Ugly Duckling",
+                "The Little Mermaid",
+                "The Hobbit",
+                "The Emperor's New Clothes",
+                "Lord of the Rings",
+                "Harry Potter",
+            )
 
-      val resultMultiple = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        order(YawnQueryOrder.asc(authors.name), YawnQueryOrder.desc(books.name))
-      }.list()
+            val resultMultiple = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                order(YawnQueryOrder.asc(authors.name), YawnQueryOrder.desc(books.name))
+            }.list()
 
-      assertThat(resultMultiple.map { "${it.author.name} - ${it.name}" }).containsExactly(
-          "Hans Christian Andersen - The Ugly Duckling",
-          "Hans Christian Andersen - The Little Mermaid",
-          "Hans Christian Andersen - The Emperor's New Clothes",
-          "J.K. Rowling - Harry Potter",
-          "J.R.R. Tolkien - The Hobbit",
-          "J.R.R. Tolkien - Lord of the Rings",
-      )
+            assertThat(resultMultiple.map { "${it.author.name} - ${it.name}" }).containsExactly(
+                "Hans Christian Andersen - The Ugly Duckling",
+                "Hans Christian Andersen - The Little Mermaid",
+                "Hans Christian Andersen - The Emperor's New Clothes",
+                "J.K. Rowling - Harry Potter",
+                "J.R.R. Tolkien - The Hobbit",
+                "J.R.R. Tolkien - Lord of the Rings",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `set finalizer`() {
-    transactor.open { session ->
-      val results = session.project(BookTable) { books ->
-        addNotEq(books.name, "Harry Potter")
+    @Test
+    fun `set finalizer`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                addNotEq(books.name, "Harry Potter")
 
-        val authors = join(books.author)
-        project(authors.name)
-      }.set()
+                val authors = join(books.author)
+                project(authors.name)
+            }.set()
 
-      assertThat(results).containsExactlyInAnyOrder(
-          "Hans Christian Andersen",
-          "J.R.R. Tolkien",
-      )
+            assertThat(results).containsExactlyInAnyOrder(
+                "Hans Christian Andersen",
+                "J.R.R. Tolkien",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query against embedded fields`() {
-    transactor.open { session ->
-      val byPaperbacksSold = session.query(BookTable) { books ->
-        addGt(books.sales.paperBacksSold, 1_000_000)
-      }.list()
-      val byPaperbacksSoldNames = byPaperbacksSold.map { it.name }
-      assertThat(byPaperbacksSoldNames).containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit")
+    @Test
+    fun `yawn query against embedded fields`() {
+        transactor.open { session ->
+            val byPaperbacksSold = session.query(BookTable) { books ->
+                addGt(books.sales.paperBacksSold, 1_000_000)
+            }.list()
+            val byPaperbacksSoldNames = byPaperbacksSold.map { it.name }
+            assertThat(byPaperbacksSoldNames).containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit")
 
-      val theHobbitSales = byPaperbacksSold.single { it.name == "The Hobbit" }.sales
-      val theHobbit = session.query(BookTable) { books ->
-        addEq(books.sales, theHobbitSales)
-      }.uniqueResult()!!
-      assertThat(theHobbit.name).isEqualTo("The Hobbit")
-      val lotrSales = byPaperbacksSold.single { it.name == "Lord of the Rings" }.sales
-      val inQuery = session.query(BookTable) { books ->
-        addIn(books.sales, listOf(theHobbitSales, lotrSales))
-      }.list().map { it.name }
-      assertThat(inQuery).containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit")
+            val theHobbitSales = byPaperbacksSold.single { it.name == "The Hobbit" }.sales
+            val theHobbit = session.query(BookTable) { books ->
+                addEq(books.sales, theHobbitSales)
+            }.uniqueResult()!!
+            assertThat(theHobbit.name).isEqualTo("The Hobbit")
+            val lotrSales = byPaperbacksSold.single { it.name == "Lord of the Rings" }.sales
+            val inQuery = session.query(BookTable) { books ->
+                addIn(books.sales, listOf(theHobbitSales, lotrSales))
+            }.list().map { it.name }
+            assertThat(inQuery).containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit")
 
-      val combinedEmbeddedAndTopLevelFieldQuery = session.query(BookTable) { books ->
-        addEq(books.sales.countryWithMostCopiesSold, "UK")
+            val combinedEmbeddedAndTopLevelFieldQuery = session.query(BookTable) { books ->
+                addEq(books.sales.countryWithMostCopiesSold, "UK")
 
-        val authors = join(books.author)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }.list().map { it.name }
-      assertThat(combinedEmbeddedAndTopLevelFieldQuery).containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit")
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }.list().map { it.name }
+            assertThat(combinedEmbeddedAndTopLevelFieldQuery).containsExactlyInAnyOrder(
+                "Lord of the Rings",
+                "The Hobbit",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `yawn query against embedded fields through join`() {
-    transactor.open { session ->
-      val publishersWithMoreThan1MBooksSold = session.query(PublisherTable) { publishers ->
-        val books = join(publishers.books)
-        addGt(books.sales.paperBacksSold, 1_000_000)
-      }
-          .set()
-          .map { it.name }
+    @Test
+    fun `yawn query against embedded fields through join`() {
+        transactor.open { session ->
+            val publishersWithMoreThan1MBooksSold = session.query(PublisherTable) { publishers ->
+                val books = join(publishers.books)
+                addGt(books.sales.paperBacksSold, 1_000_000)
+            }
+                .set()
+                .map { it.name }
 
-      assertThat(publishersWithMoreThan1MBooksSold).containsExactlyInAnyOrder("HarperCollins", "Random House")
+            assertThat(publishersWithMoreThan1MBooksSold).containsExactlyInAnyOrder("HarperCollins", "Random House")
+        }
     }
-  }
 
-  @Test
-  fun `yawn in`() {
-    transactor.open { session ->
-      val allBookNames = session.project(BookTable) { project(it.name) }.set()
-      assertThat(allBookNames).hasSize(6)
+    @Test
+    fun `yawn in`() {
+        transactor.open { session ->
+            val allBookNames = session.project(BookTable) { project(it.name) }.set()
+            assertThat(allBookNames).hasSize(6)
 
-      val noBooks = session.project(BookTable) { books ->
-        addIn(books.name, listOf())
-        project(books.name)
-      }.list()
-      assertThat(noBooks).isEmpty()
-      val oneBook = session.project(BookTable) { books ->
-        addIn(books.name, listOf("The Hobbit"))
-        project(books.name)
-      }.list()
-      assertThat(oneBook).containsOnly("The Hobbit")
-      val twoBooks = session.project(BookTable) { books ->
-        addIn(books.name, listOf("The Hobbit", "Harry Potter"))
-        project(books.name)
-      }.list()
-      assertThat(twoBooks).containsExactlyInAnyOrder("The Hobbit", "Harry Potter")
-      val allButTwoBooks = session.project(BookTable) { books ->
-        addIn(books.name, allBookNames - setOf("The Hobbit", "Harry Potter"))
-        project(books.name)
-      }.list()
-      assertThat(allButTwoBooks).containsExactlyInAnyOrderElementsOf(allBookNames - setOf("The Hobbit", "Harry Potter"))
-      val allButOneBook = session.project(BookTable) { books ->
-        addIn(books.name, allBookNames - "The Hobbit")
-        project(books.name)
-      }.list()
-      assertThat(allButOneBook).containsExactlyInAnyOrderElementsOf(allBookNames - "The Hobbit")
-      val allBooks = session.project(BookTable) { books ->
-        addIn(books.name, allBookNames)
-        project(books.name)
-      }.list()
-      assertThat(allBooks).containsExactlyInAnyOrderElementsOf(allBookNames)
+            val noBooks = session.project(BookTable) { books ->
+                addIn(books.name, listOf())
+                project(books.name)
+            }.list()
+            assertThat(noBooks).isEmpty()
+            val oneBook = session.project(BookTable) { books ->
+                addIn(books.name, listOf("The Hobbit"))
+                project(books.name)
+            }.list()
+            assertThat(oneBook).containsOnly("The Hobbit")
+            val twoBooks = session.project(BookTable) { books ->
+                addIn(books.name, listOf("The Hobbit", "Harry Potter"))
+                project(books.name)
+            }.list()
+            assertThat(twoBooks).containsExactlyInAnyOrder("The Hobbit", "Harry Potter")
+            val allButTwoBooks = session.project(BookTable) { books ->
+                addIn(books.name, allBookNames - setOf("The Hobbit", "Harry Potter"))
+                project(books.name)
+            }.list()
+            assertThat(allButTwoBooks).containsExactlyInAnyOrderElementsOf(
+                allBookNames - setOf(
+                    "The Hobbit",
+                    "Harry Potter",
+                ),
+            )
+            val allButOneBook = session.project(BookTable) { books ->
+                addIn(books.name, allBookNames - "The Hobbit")
+                project(books.name)
+            }.list()
+            assertThat(allButOneBook).containsExactlyInAnyOrderElementsOf(allBookNames - "The Hobbit")
+            val allBooks = session.project(BookTable) { books ->
+                addIn(books.name, allBookNames)
+                project(books.name)
+            }.list()
+            assertThat(allBooks).containsExactlyInAnyOrderElementsOf(allBookNames)
+        }
     }
-  }
 
-  @Test
-  fun `yawn not in`() {
-    transactor.open { session ->
-      val allBookNames = session.project(BookTable) { project(it.name) }.set()
-      assertThat(allBookNames).hasSize(6)
+    @Test
+    fun `yawn not in`() {
+        transactor.open { session ->
+            val allBookNames = session.project(BookTable) { project(it.name) }.set()
+            assertThat(allBookNames).hasSize(6)
 
-      val allBooks = session.project(BookTable) { books ->
-        addNotIn(books.name, listOf())
-        project(books.name)
-      }.list()
-      assertThat(allBooks).containsExactlyInAnyOrderElementsOf(allBookNames)
-      val allButOneBook = session.project(BookTable) { books ->
-        addNotIn(books.name, listOf("The Hobbit"))
-        project(books.name)
-      }.list()
-      assertThat(allButOneBook).containsExactlyInAnyOrderElementsOf(allBookNames - "The Hobbit")
-      val allButTwoBooks = session.project(BookTable) { books ->
-        addNotIn(books.name, listOf("The Hobbit", "Harry Potter"))
-        project(books.name)
-      }.list()
-      assertThat(allButTwoBooks).containsExactlyInAnyOrderElementsOf(allBookNames - setOf("The Hobbit", "Harry Potter"))
+            val allBooks = session.project(BookTable) { books ->
+                addNotIn(books.name, listOf())
+                project(books.name)
+            }.list()
+            assertThat(allBooks).containsExactlyInAnyOrderElementsOf(allBookNames)
+            val allButOneBook = session.project(BookTable) { books ->
+                addNotIn(books.name, listOf("The Hobbit"))
+                project(books.name)
+            }.list()
+            assertThat(allButOneBook).containsExactlyInAnyOrderElementsOf(allBookNames - "The Hobbit")
+            val allButTwoBooks = session.project(BookTable) { books ->
+                addNotIn(books.name, listOf("The Hobbit", "Harry Potter"))
+                project(books.name)
+            }.list()
+            assertThat(allButTwoBooks).containsExactlyInAnyOrderElementsOf(
+                allBookNames - setOf(
+                    "The Hobbit",
+                    "Harry Potter",
+                ),
+            )
 
-      val twoBooks = session.project(BookTable) { books ->
-        addNotIn(books.name, allBookNames - setOf("The Hobbit", "Harry Potter"))
-        project(books.name)
-      }.list()
-      assertThat(twoBooks).containsExactlyInAnyOrder("The Hobbit", "Harry Potter")
-      val oneBook = session.project(BookTable) { books ->
-        addNotIn(books.name, allBookNames - "The Hobbit")
-        project(books.name)
-      }.list()
-      assertThat(oneBook).containsOnly("The Hobbit")
-      val noBooks = session.project(BookTable) { books ->
-        addNotIn(books.name, allBookNames)
-        project(books.name)
-      }.list()
-      assertThat(noBooks).isEmpty()
+            val twoBooks = session.project(BookTable) { books ->
+                addNotIn(books.name, allBookNames - setOf("The Hobbit", "Harry Potter"))
+                project(books.name)
+            }.list()
+            assertThat(twoBooks).containsExactlyInAnyOrder("The Hobbit", "Harry Potter")
+            val oneBook = session.project(BookTable) { books ->
+                addNotIn(books.name, allBookNames - "The Hobbit")
+                project(books.name)
+            }.list()
+            assertThat(oneBook).containsOnly("The Hobbit")
+            val noBooks = session.project(BookTable) { books ->
+                addNotIn(books.name, allBookNames)
+                project(books.name)
+            }.list()
+            assertThat(noBooks).isEmpty()
+        }
     }
-  }
 
-  @Test
-  fun `view entity`() {
-    transactor.open { session ->
-      val bookView = session.query(BookViewTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }.uniqueResult()
+    @Test
+    fun `view entity`() {
+        transactor.open { session ->
+            val bookView = session.query(BookViewTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }.uniqueResult()
 
-      with(bookView!!) {
-        assertThat(id).isNotNull()
-        assertThat(name).isEqualTo("The Hobbit")
-      }
+            with(bookView!!) {
+                assertThat(id).isNotNull()
+                assertThat(name).isEqualTo("The Hobbit")
+            }
+        }
     }
-  }
 
-  @Test
-  fun `@ElementCollection queries`() {
-    transactor.open { session ->
-      val fairyTaleBooks = session.query(BookTable) { books ->
-        val genres = join(books.genres)
-        addEq(genres.elements, FAIRY_TALE)
-      }.list()
-      assertThat(fairyTaleBooks.map { it.author.name }.toSet()).containsOnly("Hans Christian Andersen")
+    @Test
+    fun `@ElementCollection queries`() {
+        transactor.open { session ->
+            val fairyTaleBooks = session.query(BookTable) { books ->
+                val genres = join(books.genres)
+                addEq(genres.elements, FAIRY_TALE)
+            }.list()
+            assertThat(fairyTaleBooks.map { it.author.name }.toSet()).containsOnly("Hans Christian Andersen")
 
-      val results = session.query(BookTable) { books ->
-        addLe(books.numberOfPages, 300L)
+            val results = session.query(BookTable) { books ->
+                addLe(books.numberOfPages, 300L)
 
-        val genres = join(books.genres)
-        addIn(genres.elements, FANTASY, FAIRY_TALE)
-      }.list().map { it.name }
-      assertThat(results).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "The Little Mermaid",
-          "The Ugly Duckling",
-          "The Emperor's New Clothes",
-      )
+                val genres = join(books.genres)
+                addIn(genres.elements, FANTASY, FAIRY_TALE)
+            }.list().map { it.name }
+            assertThat(results).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "The Little Mermaid",
+                "The Ugly Duckling",
+                "The Emperor's New Clothes",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `@ElementCollection of ids`() {
-    transactor.open { session ->
-      val lotrId = session.query(BookTable) { books ->
-        addEq(books.name, "Lord of the Rings")
-      }.uniqueResult()!!.id
-      val publishers = session.query(PublisherTable) { publishers ->
-        val publishedBooks = join(publishers.publishedBookIds)
-        addEq(publishedBooks.elements, lotrId)
-      }.list()
-      assertThat(publishers).hasSize(1)
-      assertThat(publishers.single().name).isEqualTo("HarperCollins")
+    @Test
+    fun `@ElementCollection of ids`() {
+        transactor.open { session ->
+            val lotrId = session.query(BookTable) { books ->
+                addEq(books.name, "Lord of the Rings")
+            }.uniqueResult()!!.id
+            val publishers = session.query(PublisherTable) { publishers ->
+                val publishedBooks = join(publishers.publishedBookIds)
+                addEq(publishedBooks.elements, lotrId)
+            }.list()
+            assertThat(publishers).hasSize(1)
+            assertThat(publishers.single().name).isEqualTo("HarperCollins")
+        }
     }
-  }
 
-  @Test
-  fun `@ElementCollection isEmpty`() {
-    transactor.open { session ->
-      val allBooks = session.query(BookTable) { books ->
-        addIsNotEmpty(books.genres)
-      }.list()
-      assertThat(allBooks).hasSize(6)
+    @Test
+    fun `@ElementCollection isEmpty`() {
+        transactor.open { session ->
+            val allBooks = session.query(BookTable) { books ->
+                addIsNotEmpty(books.genres)
+            }.list()
+            assertThat(allBooks).hasSize(6)
 
-      val noBooks = session.query(BookTable) { books ->
-        addIsEmpty(books.genres)
-      }.list()
-      assertThat(noBooks).isEmpty()
+            val noBooks = session.query(BookTable) { books ->
+                addIsEmpty(books.genres)
+            }.list()
+            assertThat(noBooks).isEmpty()
+        }
     }
-  }
 
-  @Test
-  fun `yawn equal or is null`() {
-    transactor.open { session ->
-      val result = session.query(BookTable) { books ->
-        addEqOrIsNull(books.notes, "Note for LoTR")
-      }.uniqueResult()!!
+    @Test
+    fun `yawn equal or is null`() {
+        transactor.open { session ->
+            val result = session.query(BookTable) { books ->
+                addEqOrIsNull(books.notes, "Note for LoTR")
+            }.uniqueResult()!!
 
-      assertThat(result.name).isEqualTo("Lord of the Rings")
+            assertThat(result.name).isEqualTo("Lord of the Rings")
 
-      val results = session.query(BookTable) { books ->
-        addEqOrIsNull(books.notes, null)
-      }.list()
+            val results = session.query(BookTable) { books ->
+                addEqOrIsNull(books.notes, null)
+            }.list()
 
-      assertThat(results.map { it.name })
-          .containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling", "The Emperor's New Clothes")
+            assertThat(results.map { it.name })
+                .containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling", "The Emperor's New Clothes")
+        }
     }
-  }
 
-  @Test
-  fun `yawn formula queries`() {
-    transactor.open { session ->
-      val booksWithPublisher = session.query(BookTable) { books ->
-        addEq(books.hasPublisher, true)
-      }.list()
-      assertThat(booksWithPublisher.map { it.name })
-          .containsExactlyInAnyOrder("Lord of the Rings", "The Hobbit", "Harry Potter", "The Emperor's New Clothes")
+    @Test
+    fun `yawn formula queries`() {
+        transactor.open { session ->
+            val booksWithPublisher = session.query(BookTable) { books ->
+                addEq(books.hasPublisher, true)
+            }.list()
+            assertThat(booksWithPublisher.map { it.name })
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "The Hobbit",
+                    "Harry Potter",
+                    "The Emperor's New Clothes",
+                )
 
-      val booksWithoutPublisher = session.query(BookTable) { books ->
-        addEq(books.hasPublisher, false)
-      }.list()
-      assertThat(booksWithoutPublisher.map { it.name })
-          .containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling")
+            val booksWithoutPublisher = session.query(BookTable) { books ->
+                addEq(books.hasPublisher, false)
+            }.list()
+            assertThat(booksWithoutPublisher.map { it.name })
+                .containsExactlyInAnyOrder("The Little Mermaid", "The Ugly Duckling")
 
-      val publishersSortedByNameLength = session.query(PublisherTable) { publishers ->
-        orderAsc(publishers.nameLetterCount)
-      }.list()
-      assertThat(publishersSortedByNameLength.map { "${it.name} (${it.nameLetterCount})" })
-          .containsExactly("Penguin (7)", "Co-Owned (8)", "Random House (12)", "HarperCollins (13)")
+            val publishersSortedByNameLength = session.query(PublisherTable) { publishers ->
+                orderAsc(publishers.nameLetterCount)
+            }.list()
+            assertThat(publishersSortedByNameLength.map { "${it.name} (${it.nameLetterCount})" })
+                .containsExactly("Penguin (7)", "Co-Owned (8)", "Random House (12)", "HarperCollins (13)")
+        }
     }
-  }
 
-  @Test
-  fun `yawn order with null precedence`() {
-    transactor.open { session ->
-      val booksNullNotesLast = session.query(BookTable) { books ->
-        order(YawnQueryOrder(books.notes, ASC, nullPrecedence = LAST))
-      }.list()
-      assertThat(booksNullNotesLast.map { it.notes }).containsExactly(
-          "Note for LoTR",
-          "Note for The Hobbit and Harry Potter",
-          "Note for The Hobbit and Harry Potter",
-          null,
-          null,
-          null,
-      )
-      val booksNullNotesFirst = session.query(BookTable) { books ->
-        order(YawnQueryOrder(books.notes, ASC, nullPrecedence = FIRST))
-      }.list()
-      assertThat(booksNullNotesFirst.map { it.notes }).containsExactly(
-          null,
-          null,
-          null,
-          "Note for LoTR",
-          "Note for The Hobbit and Harry Potter",
-          "Note for The Hobbit and Harry Potter",
-      )
+    @Test
+    fun `yawn order with null precedence`() {
+        transactor.open { session ->
+            val booksNullNotesLast = session.query(BookTable) { books ->
+                order(YawnQueryOrder(books.notes, ASC, nullPrecedence = LAST))
+            }.list()
+            assertThat(booksNullNotesLast.map { it.notes }).containsExactly(
+                "Note for LoTR",
+                "Note for The Hobbit and Harry Potter",
+                "Note for The Hobbit and Harry Potter",
+                null,
+                null,
+                null,
+            )
+            val booksNullNotesFirst = session.query(BookTable) { books ->
+                order(YawnQueryOrder(books.notes, ASC, nullPrecedence = FIRST))
+            }.list()
+            assertThat(booksNullNotesFirst.map { it.notes }).containsExactly(
+                null,
+                null,
+                null,
+                "Note for LoTR",
+                "Note for The Hobbit and Harry Potter",
+                "Note for The Hobbit and Harry Potter",
+            )
+        }
     }
-  }
 
-  // notes about nullability:
-  // addEq(<anything>, null) - will never compile, because it is a footgun
-  // addIsNull/addIsNotNull(<anything>) - will always compile, because we don't have
-  //                                      advanced nullability checks on Yawn yet
-  // please check our docs for more details:
-  // https://www.notion.so/faire/Nullability-Yawn-1772efb5c25a809dbb26eea1ff3100cb
+    // notes about nullability:
+    // addEq(<anything>, null) - will never compile, because it is a footgun
+    // addIsNull/addIsNotNull(<anything>) - will always compile, because we don't have
+    //                                      advanced nullability checks on Yawn yet
+    // please check our docs for more details:
+    // https://www.notion.so/faire/Nullability-Yawn-1772efb5c25a809dbb26eea1ff3100cb
 
-  @Test
-  fun `nullable queries`() {
-    transactor.open { session ->
-      val query1 = session.query(BookTable) { books ->
-        // name is NOT nullable but could fill the role of a nullable field;
-        // for example:
-        val authors = join(books.author)
-        addEq(nullable(authors.name), books.notes)
-      }
-      assertThat(query1.list()).isEmpty()
+    @Test
+    fun `nullable queries`() {
+        transactor.open { session ->
+            val query1 = session.query(BookTable) { books ->
+                // name is NOT nullable but could fill the role of a nullable field;
+                // for example:
+                val authors = join(books.author)
+                addEq(nullable(authors.name), books.notes)
+            }
+            assertThat(query1.list()).isEmpty()
 
-      val theHobbit = session.query(BookTable) { books ->
-        addEq(books.name, "The Hobbit")
-      }.uniqueResult()!!
-      theHobbit.notes = "The Hobbit"
-      session.save(theHobbit)
+            val theHobbit = session.query(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+            }.uniqueResult()!!
+            theHobbit.notes = "The Hobbit"
+            session.save(theHobbit)
 
-      val query2 = session.query(BookTable) { books ->
-        addEq(nullable(books.name), books.notes)
-      }
-      assertThat(query2.list().single().name).isEqualTo("The Hobbit")
+            val query2 = session.query(BookTable) { books ->
+                addEq(nullable(books.name), books.notes)
+            }
+            assertThat(query2.list().single().name).isEqualTo("The Hobbit")
+        }
     }
-  }
 
-  @Test
-  fun `query hints`() {
-    transactor.open { session ->
-      val result = session.query(BookTable)
-          .addQueryHint("idx_name")
-          .applyFilter { books -> addEq(books.name, "The Hobbit") }
-          .uniqueResult()!!
-      assertThat(result.name).isEqualTo("The Hobbit")
+    @Test
+    fun `query hints`() {
+        transactor.open { session ->
+            val result = session.query(BookTable)
+                .addQueryHint("idx_name")
+                .applyFilter { books -> addEq(books.name, "The Hobbit") }
+                .uniqueResult()!!
+            assertThat(result.name).isEqualTo("The Hobbit")
 
-      assertThatThrownBy {
-        session.query(BookTable)
-            .addQueryHint("idx_INVALID")
-            .applyFilter { books -> addEq(books.name, "The Hobbit") }
-            .uniqueResult()!!
-      }
-          .rootCause
-          .isInstanceOf(SQLException::class.java)
-          .hasMessageStartingWith("Index \"idx_INVALID\" not found;")
+            assertThatThrownBy {
+                session.query(BookTable)
+                    .addQueryHint("idx_INVALID")
+                    .applyFilter { books -> addEq(books.name, "The Hobbit") }
+                    .uniqueResult()!!
+            }
+                .rootCause
+                .isInstanceOf(SQLException::class.java)
+                .hasMessageStartingWith("Index \"idx_INVALID\" not found;")
+        }
     }
-  }
 
-  @Test
-  fun `querying and joining with @TargetEntity annotation with distinct types`() {
-    transactor.open { session ->
-      val result1 = session.query(PersonTable) { people ->
-        val authors = join(people.favoriteAuthor)
-        addEq(authors.name, "J.K. Rowling")
-      }.uniqueResult()
-      with(result1!!) {
-        assertThat(name).isEqualTo("John Doe")
-        assertThat(favoriteAuthor).isInstanceOf(PersonInterface::class.java)
-        assertThat(favoriteAuthor).isInstanceOf(Person::class.java)
-        assertThat(favoriteAuthor!!.name).isEqualTo("J.K. Rowling")
-      }
+    @Test
+    fun `querying and joining with @TargetEntity annotation with distinct types`() {
+        transactor.open { session ->
+            val result1 = session.query(PersonTable) { people ->
+                val authors = join(people.favoriteAuthor)
+                addEq(authors.name, "J.K. Rowling")
+            }.uniqueResult()
+            with(result1!!) {
+                assertThat(name).isEqualTo("John Doe")
+                assertThat(favoriteAuthor).isInstanceOf(PersonInterface::class.java)
+                assertThat(favoriteAuthor).isInstanceOf(Person::class.java)
+                assertThat(favoriteAuthor!!.name).isEqualTo("J.K. Rowling")
+            }
 
-      val result2 = session.query(PersonTable) { people ->
-        val authors = join(people.favoriteAuthor)
-        addEq(authors.name, "J.R.R. Tolkien")
-      }.list()
-      with(result2.single { it.name == "Luan Nico" }) {
-        assertThat(favoriteAuthor).isInstanceOf(PersonInterface::class.java)
-        assertThat(favoriteAuthor).isInstanceOf(Person::class.java)
-        assertThat(favoriteAuthor!!.name).isEqualTo("J.R.R. Tolkien")
-      }
-      with(result2.single { it.name == "J.K. Rowling" }) {
-        assertThat(favoriteAuthor).isInstanceOf(PersonInterface::class.java)
-        assertThat(favoriteAuthor).isInstanceOf(Person::class.java)
-        assertThat(favoriteAuthor!!.name).isEqualTo("J.R.R. Tolkien")
-      }
+            val result2 = session.query(PersonTable) { people ->
+                val authors = join(people.favoriteAuthor)
+                addEq(authors.name, "J.R.R. Tolkien")
+            }.list()
+            with(result2.single { it.name == "Luan Nico" }) {
+                assertThat(favoriteAuthor).isInstanceOf(PersonInterface::class.java)
+                assertThat(favoriteAuthor).isInstanceOf(Person::class.java)
+                assertThat(favoriteAuthor!!.name).isEqualTo("J.R.R. Tolkien")
+            }
+            with(result2.single { it.name == "J.K. Rowling" }) {
+                assertThat(favoriteAuthor).isInstanceOf(PersonInterface::class.java)
+                assertThat(favoriteAuthor).isInstanceOf(Person::class.java)
+                assertThat(favoriteAuthor!!.name).isEqualTo("J.R.R. Tolkien")
+            }
 
-      val result3 = session.query(PersonTable) { people ->
-        val authors = join(people.favoriteAuthor)
-        addEq(authors.name, "Luan Nico")
-      }.uniqueResult()
-      assertThat(result3).isNull()
+            val result3 = session.query(PersonTable) { people ->
+                val authors = join(people.favoriteAuthor)
+                addEq(authors.name, "Luan Nico")
+            }.uniqueResult()
+            assertThat(result3).isNull()
+        }
     }
-  }
 
-  @Test
-  fun `people whose favorite book was written by their favorite author`() {
-    transactor.open { session ->
-      val result = session.query(PersonTable) { people ->
-        val favoriteBook = join(people.favoriteBook)
-        addEq(people.favoriteAuthor, favoriteBook.author)
-      }.list()
-      assertThat(result.map { it.name }).containsExactlyInAnyOrder("J.K. Rowling", "J.R.R. Tolkien")
+    @Test
+    fun `people whose favorite book was written by their favorite author`() {
+        transactor.open { session ->
+            val result = session.query(PersonTable) { people ->
+                val favoriteBook = join(people.favoriteBook)
+                addEq(people.favoriteAuthor, favoriteBook.author)
+            }.list()
+            assertThat(result.map { it.name }).containsExactlyInAnyOrder("J.K. Rowling", "J.R.R. Tolkien")
+        }
     }
-  }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnStringQueriesTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnStringQueriesTest.kt
@@ -6,123 +6,123 @@ import org.hibernate.criterion.MatchMode
 import org.junit.jupiter.api.Test
 
 internal class YawnStringQueriesTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `like on non-nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addLike(authors.name, "J.R.R%")
-      }.list()
+    @Test
+    fun `like on non-nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addLike(authors.name, "J.R.R%")
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `like on nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        addLike(books.notes, "Note for%")
-      }.list()
+    @Test
+    fun `like on nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                addLike(books.notes, "Note for%")
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-          "Harry Potter",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+                "Harry Potter",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `like with match mode on non-nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addLike(authors.name, "J.R.R", MatchMode.START)
-      }.list()
+    @Test
+    fun `like with match mode on non-nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addLike(authors.name, "J.R.R", MatchMode.START)
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `like with match mode on nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        addLike(books.notes, "Note for", MatchMode.START)
-      }.list()
+    @Test
+    fun `like with match mode on nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                addLike(books.notes, "Note for", MatchMode.START)
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-          "Harry Potter",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+                "Harry Potter",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `ilike on non-nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addILike(authors.name, "j.r.r%")
-      }.list()
+    @Test
+    fun `ilike on non-nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addILike(authors.name, "j.r.r%")
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `ilike on nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        addILike(books.notes, "nOtE FoR%")
-      }.list()
+    @Test
+    fun `ilike on nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                addILike(books.notes, "nOtE FoR%")
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-          "Harry Potter",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+                "Harry Potter",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `ilike with match mode on non-nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addILike(authors.name, "j.r.r", MatchMode.START)
-      }.list()
+    @Test
+    fun `ilike with match mode on non-nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addILike(authors.name, "j.r.r", MatchMode.START)
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+            )
+        }
     }
-  }
 
-  @Test
-  fun `ilike with match mode on nullable column`() {
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        addILike(books.notes, "nOtE fOr", MatchMode.START)
-      }.list()
+    @Test
+    fun `ilike with match mode on nullable column`() {
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                addILike(books.notes, "nOtE fOr", MatchMode.START)
+            }.list()
 
-      assertThat(books.map { it.name }).containsExactlyInAnyOrder(
-          "The Hobbit",
-          "Lord of the Rings",
-          "Harry Potter",
-      )
+            assertThat(books.map { it.name }).containsExactlyInAnyOrder(
+                "The Hobbit",
+                "Lord of the Rings",
+                "Harry Potter",
+            )
+        }
     }
-  }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSubQueryTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSubQueryTest.kt
@@ -9,132 +9,132 @@ import org.hibernate.sql.JoinType
 import org.junit.jupiter.api.Test
 
 internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
-  @Test
-  fun `yawn query with a sub query using detached criteria`() {
-    val detachedCriteria = createProjectedDetachedCriteria(PersonTable) { person ->
-      addEq(person.name, "J.R.R. Tolkien")
+    @Test
+    fun `yawn query with a sub query using detached criteria`() {
+        val detachedCriteria = createProjectedDetachedCriteria(PersonTable) { person ->
+            addEq(person.name, "J.R.R. Tolkien")
 
-      project(person.name)
-    }
-
-    transactor.open { session ->
-      val book = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addEq(authors.name, detachedCriteria)
-
-        addLt(books.numberOfPages, 500)
-      }.uniqueResult()!!
-
-      with(book) {
-        assertThat(name).isEqualTo("The Hobbit")
-        assertThat(author.name).isEqualTo("J.R.R. Tolkien")
-      }
-    }
-  }
-
-  @Test
-  fun `yawn query with a sub query using detached criteria with join`() {
-    val detachedCriteria = createProjectedDetachedCriteria(PersonTable) { person ->
-      addEq(person.name, "J.R.R. Tolkien")
-      project(person.id)
-    }
-
-    transactor.open { session ->
-      val book = session.query(BookTable) { books ->
-        addEq(books.author, detachedCriteria)
-        addLt(books.numberOfPages, 500)
-      }.uniqueResult()!!
-
-      with(book) {
-        assertThat(name).isEqualTo("The Hobbit")
-        assertThat(author.name).isEqualTo("J.R.R. Tolkien")
-      }
-    }
-  }
-
-  @Test
-  fun `yawn query with a sub query using detached criteria projected to a collection`() {
-    val detachedCriteria = createProjectedDetachedCriteria(PersonTable) { person ->
-      addLike(person.name, "J.%")
-      project(YawnProjections.distinct(person.name))
-    }
-
-    transactor.open { session ->
-      val books = session.query(BookTable) { books ->
-        val authors = join(books.author)
-        addIn(authors.name, detachedCriteria)
-        addLt(books.numberOfPages, 500)
-      }.list()
-
-      assertThat(books).hasSize(1)
-      with(books.single()) {
-        assertThat(name).isEqualTo("The Hobbit")
-        assertThat(author.name).isEqualTo("J.R.R. Tolkien")
-      }
-    }
-  }
-
-  @Test
-  fun `yawn query with a sub query using detached criteria with left join`() {
-    val detachedCriteria = createProjectedDetachedCriteria(BookTable) { books ->
-      val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN)
-      addIsNull(publishers.id)
-      project(books.author.foreignKey)
-    }
-
-    transactor.open { session ->
-      val people = session.query(PersonTable) { people ->
-        addIn(people.id, detachedCriteria)
-      }.list()
-
-      assertThat(people).hasSize(1)
-      assertThat(people.single().name).isEqualTo("Hans Christian Andersen")
-    }
-  }
-
-  @Test
-  fun `yawn query with a sub query using detached criteria with join criteria`() {
-    val detachedCriteria = createProjectedDetachedCriteria(BookTable) { books ->
-      val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN) { publisher ->
-        addNotLike(publisher.name, "%-%")
-        addNotLike(publisher.name, "% %")
-      }
-      addIsNull(publishers.id)
-      project(books.author.foreignKey)
-    }
-
-    transactor.open { session ->
-      val people = session.query(PersonTable) { people ->
-        addIn(people.id, detachedCriteria)
-      }.list()
-
-      assertThat(people).hasSize(2)
-      assertThat(people.map { it.name }).containsExactlyInAnyOrder("Hans Christian Andersen", "J.R.R. Tolkien")
-    }
-  }
-
-  @Test
-  fun `can find authors of large books using a correlated subquery`() {
-    transactor.open { session ->
-      // Authors who have written a 500+ page book
-      val people = session.query(PersonTable) { people ->
-        val subQuery = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
-          addEq(books.author.foreignKey, people.id)
-          addGt(books.numberOfPages, 500)
-          project(books.author.foreignKey)
+            project(person.name)
         }
 
-        val secondSubQuery = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
-          addEq(books.author.foreignKey, people.id)
-          addNotEq(books.name, "Fake book")
-          project(books.author.foreignKey)
+        transactor.open { session ->
+            val book = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, detachedCriteria)
+
+                addLt(books.numberOfPages, 500)
+            }.uniqueResult()!!
+
+            with(book) {
+                assertThat(name).isEqualTo("The Hobbit")
+                assertThat(author.name).isEqualTo("J.R.R. Tolkien")
+            }
+        }
+    }
+
+    @Test
+    fun `yawn query with a sub query using detached criteria with join`() {
+        val detachedCriteria = createProjectedDetachedCriteria(PersonTable) { person ->
+            addEq(person.name, "J.R.R. Tolkien")
+            project(person.id)
         }
 
-        addExists(subQuery)
-        addExists(secondSubQuery)
-      }.list()
+        transactor.open { session ->
+            val book = session.query(BookTable) { books ->
+                addEq(books.author, detachedCriteria)
+                addLt(books.numberOfPages, 500)
+            }.uniqueResult()!!
 
-      assertThat(people.single().name).isEqualTo("J.R.R. Tolkien")
+            with(book) {
+                assertThat(name).isEqualTo("The Hobbit")
+                assertThat(author.name).isEqualTo("J.R.R. Tolkien")
+            }
+        }
     }
-  }
+
+    @Test
+    fun `yawn query with a sub query using detached criteria projected to a collection`() {
+        val detachedCriteria = createProjectedDetachedCriteria(PersonTable) { person ->
+            addLike(person.name, "J.%")
+            project(YawnProjections.distinct(person.name))
+        }
+
+        transactor.open { session ->
+            val books = session.query(BookTable) { books ->
+                val authors = join(books.author)
+                addIn(authors.name, detachedCriteria)
+                addLt(books.numberOfPages, 500)
+            }.list()
+
+            assertThat(books).hasSize(1)
+            with(books.single()) {
+                assertThat(name).isEqualTo("The Hobbit")
+                assertThat(author.name).isEqualTo("J.R.R. Tolkien")
+            }
+        }
+    }
+
+    @Test
+    fun `yawn query with a sub query using detached criteria with left join`() {
+        val detachedCriteria = createProjectedDetachedCriteria(BookTable) { books ->
+            val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN)
+            addIsNull(publishers.id)
+            project(books.author.foreignKey)
+        }
+
+        transactor.open { session ->
+            val people = session.query(PersonTable) { people ->
+                addIn(people.id, detachedCriteria)
+            }.list()
+
+            assertThat(people).hasSize(1)
+            assertThat(people.single().name).isEqualTo("Hans Christian Andersen")
+        }
+    }
+
+    @Test
+    fun `yawn query with a sub query using detached criteria with join criteria`() {
+        val detachedCriteria = createProjectedDetachedCriteria(BookTable) { books ->
+            val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN) { publisher ->
+                addNotLike(publisher.name, "%-%")
+                addNotLike(publisher.name, "% %")
+            }
+            addIsNull(publishers.id)
+            project(books.author.foreignKey)
+        }
+
+        transactor.open { session ->
+            val people = session.query(PersonTable) { people ->
+                addIn(people.id, detachedCriteria)
+            }.list()
+
+            assertThat(people).hasSize(2)
+            assertThat(people.map { it.name }).containsExactlyInAnyOrder("Hans Christian Andersen", "J.R.R. Tolkien")
+        }
+    }
+
+    @Test
+    fun `can find authors of large books using a correlated subquery`() {
+        transactor.open { session ->
+            // Authors who have written a 500+ page book
+            val people = session.query(PersonTable) { people ->
+                val subQuery = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
+                    addEq(books.author.foreignKey, people.id)
+                    addGt(books.numberOfPages, 500)
+                    project(books.author.foreignKey)
+                }
+
+                val secondSubQuery = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
+                    addEq(books.author.foreignKey, people.id)
+                    addNotEq(books.name, "Fake book")
+                    project(books.author.foreignKey)
+                }
+
+                addExists(subQuery)
+                addExists(secondSubQuery)
+            }.list()
+
+            assertThat(people.single().name).isEqualTo("J.R.R. Tolkien")
+        }
+    }
 }

--- a/yawn-gradle-plugin/src/test/kotlin/com/faire/gradle/yawn/FaireYawnTest.kt
+++ b/yawn-gradle-plugin/src/test/kotlin/com/faire/gradle/yawn/FaireYawnTest.kt
@@ -13,63 +13,63 @@ import java.io.File
     projectsRoot = "src/test/projects/yawn",
 )
 internal class FaireYawnTest {
-  /**
-   * This tests the setup provided by the KSP plugin
-   * by using it to bind a test processor that creates *Bar version
-   * of annotated classes.
-   *
-   * The test is not for the processor itself, but rather for the
-   * setup of the plugin.
-   */
-  @Test
-  @GradleProject("basic-project")
-  @GradleTestKitConfiguration(
-      buildDirectoryMode = PRISTINE,
-  )
-  fun `basic project with ksp processor`(
-      @GradleProject.Runner runner: GradleRunner,
-      @GradleProject.Root root: File,
-  ) {
-    val fooClassFolder = root.resolve("src/main/kotlin/com/faire/ksp/")
-    fooClassFolder.mkdirs()
-    val sourceFooClassFile = File.createTempFile("Foo", ".kt", fooClassFolder)
-    val classContent = """
+    /**
+     * This tests the setup provided by the KSP plugin
+     * by using it to bind a test processor that creates *Bar version
+     * of annotated classes.
+     *
+     * The test is not for the processor itself, but rather for the
+     * setup of the plugin.
+     */
+    @Test
+    @GradleProject("basic-project")
+    @GradleTestKitConfiguration(
+        buildDirectoryMode = PRISTINE,
+    )
+    fun `basic project with ksp processor`(
+        @GradleProject.Runner runner: GradleRunner,
+        @GradleProject.Root root: File,
+    ) {
+        val fooClassFolder = root.resolve("src/main/kotlin/com/faire/ksp/")
+        fooClassFolder.mkdirs()
+        val sourceFooClassFile = File.createTempFile("Foo", ".kt", fooClassFolder)
+        val classContent = """
       package com.faire.ksp
 
       @Flag
       class Foo
-    """.trimIndent()
-    sourceFooClassFile.writeText(classContent)
-    val result1 = runner.withArguments("build").build()
+        """.trimIndent()
+        sourceFooClassFile.writeText(classContent)
+        val result1 = runner.withArguments("build").build()
 
-    val expectedGeneratedContent = """
+        val expectedGeneratedContent = """
       package com.faire.ksp
       
       class FooBar
-    """.trimIndent()
+        """.trimIndent()
 
-    val builtFooBarFile = getBuiltFileFromQualifiedClassName(root, "com.faire.ksp.FooBar")
-    assertThat(builtFooBarFile).hasContent(expectedGeneratedContent)
+        val builtFooBarFile = getBuiltFileFromQualifiedClassName(root, "com.faire.ksp.FooBar")
+        assertThat(builtFooBarFile).hasContent(expectedGeneratedContent)
 
-    // test update the Foo file, and make sure the generated file is updated
-    val expectedUpdatedGeneratedContent = expectedGeneratedContent.replace("FooBar", "Foo2Bar")
-    sourceFooClassFile.writeText(classContent.replace("Foo", "Foo2"))
+        // test update the Foo file, and make sure the generated file is updated
+        val expectedUpdatedGeneratedContent = expectedGeneratedContent.replace("FooBar", "Foo2Bar")
+        sourceFooClassFile.writeText(classContent.replace("Foo", "Foo2"))
 
-    val result2 = runner.withArguments("build").build()
+        val result2 = runner.withArguments("build").build()
 
-    val builtFoo2BarFile = getBuiltFileFromQualifiedClassName(root, "com.faire.ksp.Foo2Bar")
-    assertThat(builtFoo2BarFile).hasContent(expectedUpdatedGeneratedContent)
-    assertThat(root.resolve("build/generated/ksp/main/kotlin/com/faire/ksp/FooBar.kt")).doesNotExist()
+        val builtFoo2BarFile = getBuiltFileFromQualifiedClassName(root, "com.faire.ksp.Foo2Bar")
+        assertThat(builtFoo2BarFile).hasContent(expectedUpdatedGeneratedContent)
+        assertThat(root.resolve("build/generated/ksp/main/kotlin/com/faire/ksp/FooBar.kt")).doesNotExist()
 
-    assertThat(result1).task(":build").isSuccess()
-    assertThat(result2).task(":build").isSuccess()
-  }
+        assertThat(result1).task(":build").isSuccess()
+        assertThat(result2).task(":build").isSuccess()
+    }
 
-  private fun getBuiltFileFromQualifiedClassName(
-      root: File,
-      qualifiedClassName: String,
-  ): File {
-    val classPath = qualifiedClassName.replace('.', '/')
-    return root.resolve("build/generated/ksp/main/kotlin/$classPath.kt")
-  }
+    private fun getBuiltFileFromQualifiedClassName(
+        root: File,
+        qualifiedClassName: String,
+    ): File {
+        val classPath = qualifiedClassName.replace('.', '/')
+        return root.resolve("build/generated/ksp/main/kotlin/$classPath.kt")
+    }
 }

--- a/yawn-gradle-plugin/src/test/projects/yawn/basic-project/build.gradle.kts
+++ b/yawn-gradle-plugin/src/test/projects/yawn/basic-project/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-  id("com.faire.yawn")
+    id("com.faire.yawn")
 }
 
 repositories {
-  mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-  implementation(project(":ksp-annotation"))
+    implementation(project(":ksp-annotation"))
 }

--- a/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-annotation/build.gradle.kts
+++ b/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-annotation/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  kotlin("jvm")
+    kotlin("jvm")
 }
 
 repositories {
-  mavenCentral()
+    mavenCentral()
 }

--- a/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-project/build.gradle.kts
+++ b/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-project/build.gradle.kts
@@ -1,16 +1,16 @@
 plugins {
-  kotlin("jvm")
-  id("com.google.devtools.ksp")
+    kotlin("jvm")
+    id("com.google.devtools.ksp")
 }
 
 repositories {
-  mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-  api("com.google.devtools.ksp:symbol-processing-api:1.9.23-1.0.20")
+    api("com.google.devtools.ksp:symbol-processing-api:1.9.23-1.0.20")
 
-  ksp("dev.zacsweers.autoservice:auto-service-ksp:1.1.0")
+    ksp("dev.zacsweers.autoservice:auto-service-ksp:1.1.0")
 
-  implementation("com.google.auto.service:auto-service-annotations:1.0.2")
+    implementation("com.google.auto.service:auto-service-annotations:1.0.2")
 }

--- a/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-project/src/main/kotlin/com/faire/ksp/TestEntityProcessor.kt
+++ b/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-project/src/main/kotlin/com/faire/ksp/TestEntityProcessor.kt
@@ -19,28 +19,32 @@ class TestEntityProcessor(
     private val logger: KSPLogger,
     private val codeGenerator: CodeGenerator,
 ) : SymbolProcessor {
-  override fun process(resolver: Resolver): List<KSAnnotated> {
-    resolver.getSymbolsWithAnnotation("com.faire.ksp.Flag")
-        .filterIsInstance<KSClassDeclaration>()
-        .forEach { generateFile(it) }
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getSymbolsWithAnnotation("com.faire.ksp.Flag")
+            .filterIsInstance<KSClassDeclaration>()
+            .forEach { generateFile(it) }
 
-    return listOf()
-  }
-
-  /**
-   * Given a class that was selected in the [process] method, this will create a new file within the same package with
-   * a single class that has the same name as the original class, but with "Bar" appended to it.
-   *
-   * Again, this has absolutely no purpose other than testing that KSP is configured and running correctly.
-   */
-  private fun generateFile(ksClass: KSClassDeclaration) {
-    val newClassName = ksClass.simpleName.asString() + "Bar"
-
-    val outputFile = codeGenerator.createNewFile(Dependencies.ALL_FILES, ksClass.packageName.asString(), newClassName)
-
-    outputFile.writer().use { writer ->
-      writer.append("package ${ksClass.packageName.asString()}\n\n")
-      writer.append("class $newClassName")
+        return listOf()
     }
-  }
+
+    /**
+     * Given a class that was selected in the [process] method, this will create a new file within the same package with
+     * a single class that has the same name as the original class, but with "Bar" appended to it.
+     *
+     * Again, this has absolutely no purpose other than testing that KSP is configured and running correctly.
+     */
+    private fun generateFile(ksClass: KSClassDeclaration) {
+        val newClassName = ksClass.simpleName.asString() + "Bar"
+
+        val outputFile = codeGenerator.createNewFile(
+            Dependencies.ALL_FILES,
+            ksClass.packageName.asString(),
+            newClassName
+        )
+
+        outputFile.writer().use { writer ->
+            writer.append("package ${ksClass.packageName.asString()}\n\n")
+            writer.append("class $newClassName")
+        }
+    }
 }

--- a/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-project/src/main/kotlin/com/faire/ksp/TestProcessorProvider.kt
+++ b/yawn-gradle-plugin/src/test/projects/yawn/basic-project/ksp-project/src/main/kotlin/com/faire/ksp/TestProcessorProvider.kt
@@ -7,10 +7,10 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 
 @AutoService(SymbolProcessorProvider::class)
 class TestProcessorProvider : SymbolProcessorProvider {
-  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
-    return TestEntityProcessor(
-        logger = environment.logger,
-        codeGenerator = environment.codeGenerator,
-    )
-  }
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return TestEntityProcessor(
+            logger = environment.logger,
+            codeGenerator = environment.codeGenerator,
+        )
+    }
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/EmbeddableEntity.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/EmbeddableEntity.kt
@@ -5,11 +5,11 @@ import javax.persistence.Embeddable
 
 @Embeddable
 internal class EmbeddableEntity {
-  @Column
-  lateinit var foo: String
-    private set
+    @Column
+    lateinit var foo: String
+        private set
 
-  @Column
-  var bar: Int = 0
-    private set
+    @Column
+    var bar: Int = 0
+        private set
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithElementCollection.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithElementCollection.kt
@@ -7,17 +7,17 @@ import javax.persistence.JoinTable
 
 @YawnEntity
 internal class EntityWithElementCollection {
-  @ElementCollection
-  @JoinTable
-  var strings = mutableListOf<String>()
+    @ElementCollection
+    @JoinTable
+    var strings = mutableListOf<String>()
 
-  @ElementCollection(targetClass = Enums::class)
-  @JoinTable
-  @Enumerated(EnumType.STRING)
-  var enums = listOf<Enums>()
+    @ElementCollection(targetClass = Enums::class)
+    @JoinTable
+    @Enumerated(EnumType.STRING)
+    var enums = listOf<Enums>()
 }
 
 internal enum class Enums {
-  HELLO,
-  THERE,
+    HELLO,
+    THERE,
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithEmbeddedProperties.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithEmbeddedProperties.kt
@@ -4,7 +4,7 @@ import javax.persistence.Embedded
 
 @YawnEntity
 internal class EntityWithEmbeddedProperties {
-  @Embedded
-  lateinit var embedded: EmbeddableEntity
-    private set
+    @Embedded
+    lateinit var embedded: EmbeddableEntity
+        private set
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithSimpleRelations.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithSimpleRelations.kt
@@ -9,35 +9,35 @@ import javax.persistence.OneToOne
 
 @YawnEntity
 internal class EntityWithSimpleRelations {
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn
-  var nullableOneToOneYawn: YawnEntityInAnotherPackage? = null
-    protected set
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    var nullableOneToOneYawn: YawnEntityInAnotherPackage? = null
+        protected set
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn
-  lateinit var nonNullOneToOneYawn: YawnEntityInAnotherPackage
-    protected set
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    lateinit var nonNullOneToOneYawn: YawnEntityInAnotherPackage
+        protected set
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn
-  var oneToOneNonYawn: NonYawnEntityInAnotherPackage? = null
-    protected set
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    var oneToOneNonYawn: NonYawnEntityInAnotherPackage? = null
+        protected set
 
-  @OneToOne(fetch = FetchType.LAZY, targetEntity = YawnEntityInAnotherPackage::class)
-  @JoinColumn
-  var oneToOneYawnWithTargetEntity: Any? = null
-    protected set
+    @OneToOne(fetch = FetchType.LAZY, targetEntity = YawnEntityInAnotherPackage::class)
+    @JoinColumn
+    var oneToOneYawnWithTargetEntity: Any? = null
+        protected set
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
-  lateinit var manyToOneYawn: YawnEntityInAnotherPackage
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    lateinit var manyToOneYawn: YawnEntityInAnotherPackage
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
-  lateinit var manyToOneNonYawn: NonYawnEntityInAnotherPackage
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    lateinit var manyToOneNonYawn: NonYawnEntityInAnotherPackage
 
-  @ManyToOne(fetch = FetchType.LAZY, targetEntity = YawnEntityInAnotherPackage::class)
-  @JoinColumn
-  lateinit var manyToOneYawnWithTargetEntity: Any
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = YawnEntityInAnotherPackage::class)
+    @JoinColumn
+    lateinit var manyToOneYawnWithTargetEntity: Any
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithXtoManyRelations.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithXtoManyRelations.kt
@@ -10,27 +10,27 @@ import javax.persistence.OneToMany
 
 @YawnEntity
 internal class EntityWithXtoManyRelations {
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "name", referencedColumnName = "reference")
-  var oneToManyNonYawn: List<NonYawnEntityInAnotherPackage> = listOf()
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "name", referencedColumnName = "reference")
+    var oneToManyNonYawn: List<NonYawnEntityInAnotherPackage> = listOf()
 
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "name", referencedColumnName = "reference")
-  var oneToManyYawn: List<YawnEntityInAnotherPackage> = listOf()
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "name", referencedColumnName = "reference")
+    var oneToManyYawn: List<YawnEntityInAnotherPackage> = listOf()
 
-  @ManyToMany(fetch = FetchType.LAZY)
-  @JoinTable(
-      name = "join_table_name",
-      joinColumns = [JoinColumn(name = "join_column")],
-      inverseJoinColumns = [JoinColumn(name = "inverse_join_column")],
-  )
-  var manyToManyYawn: List<YawnEntityInAnotherPackage> = listOf()
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "join_table_name",
+        joinColumns = [JoinColumn(name = "join_column")],
+        inverseJoinColumns = [JoinColumn(name = "inverse_join_column")],
+    )
+    var manyToManyYawn: List<YawnEntityInAnotherPackage> = listOf()
 
-  @ManyToMany(fetch = FetchType.LAZY)
-  @JoinTable(
-      name = "join_table_name",
-      joinColumns = [JoinColumn(name = "join_column")],
-      inverseJoinColumns = [JoinColumn(name = "inverse_join_column")],
-  )
-  var manyToManyNonYawn: List<NonYawnEntityInAnotherPackage> = listOf()
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "join_table_name",
+        joinColumns = [JoinColumn(name = "join_column")],
+        inverseJoinColumns = [JoinColumn(name = "inverse_join_column")],
+    )
+    var manyToManyNonYawn: List<NonYawnEntityInAnotherPackage> = listOf()
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithoutRelations.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithoutRelations.kt
@@ -6,20 +6,20 @@ import javax.persistence.Id
 
 @YawnEntity
 internal class EntityWithoutRelations {
-  @Id
-  var id: Long = 0
-    protected set
+    @Id
+    var id: Long = 0
+        protected set
 
-  @Column
-  var version: Long = 0
-    protected set
+    @Column
+    var version: Long = 0
+        protected set
 
-  @Column
-  var name: String = ""
-    protected set
+    @Column
+    var name: String = ""
+        protected set
 
-  // make sure classes are properly imported in the generated file
-  @Column
-  var token: FakeToken<String> = FakeToken("")
-    protected set
+    // make sure classes are properly imported in the generated file
+    @Column
+    var token: FakeToken<String> = FakeToken("")
+        protected set
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/PublicEmptyEntity.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/PublicEmptyEntity.kt
@@ -6,6 +6,6 @@ package com.faire.yawn
 @YawnEntity
 class PublicEmptyEntity {
 
-  @YawnEntity
-  internal class InternalInsidePublic
+    @YawnEntity
+    internal class InternalInsidePublic
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/anotherPackage/YawnEntityInAnotherPackage.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/anotherPackage/YawnEntityInAnotherPackage.kt
@@ -5,6 +5,6 @@ import javax.persistence.Column
 
 @YawnEntity
 internal class YawnEntityInAnotherPackage {
-  @Column
-  var randomField: String = ""
+    @Column
+    var randomField: String = ""
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/ChildInheritanceEntity.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/ChildInheritanceEntity.kt
@@ -6,9 +6,9 @@ import javax.persistence.Column
 
 @YawnEntity
 internal class ChildInheritanceEntity : ParentInheritanceEntity(), InterfaceInheritanceEntity {
-  @Column
-  var childValue: String = ""
+    @Column
+    var childValue: String = ""
 
-  @Column
-  override var token: FakeToken<ChildInheritanceEntity> = FakeToken.generate()
+    @Column
+    override var token: FakeToken<ChildInheritanceEntity> = FakeToken.generate()
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/GrandParentInheritanceEntity.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/GrandParentInheritanceEntity.kt
@@ -3,6 +3,6 @@ package com.faire.yawn.inheritance
 import javax.persistence.Column
 
 internal open class GrandParentInheritanceEntity {
-  @Column
-  val grandParentValue: Boolean? = null
+    @Column
+    val grandParentValue: Boolean? = null
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/InterfaceInheritanceEntity.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/InterfaceInheritanceEntity.kt
@@ -3,5 +3,5 @@ package com.faire.yawn.inheritance
 import com.faire.yawn.utils.FakeToken
 
 internal interface InterfaceInheritanceEntity {
-  val token: FakeToken<out InterfaceInheritanceEntity>
+    val token: FakeToken<out InterfaceInheritanceEntity>
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/ParentInheritanceEntity.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/inheritance/ParentInheritanceEntity.kt
@@ -3,6 +3,6 @@ package com.faire.yawn.inheritance
 import javax.persistence.Column
 
 internal abstract class ParentInheritanceEntity : GrandParentInheritanceEntity() {
-  @Column
-  var parentValue: Int = 0
+    @Column
+    var parentValue: Int = 0
 }

--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/utils/FakeToken.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/utils/FakeToken.kt
@@ -1,14 +1,14 @@
 package com.faire.yawn.utils
 
-import java.util.UUID
+import java.util.*
 
 /**
  * Fake token class to test column definitions.
  */
 class FakeToken<T>(val value: String) {
-  companion object {
-    fun <T> generate(): FakeToken<T> {
-      return FakeToken(UUID.randomUUID().toString())
+    companion object {
+        fun <T> generate(): FakeToken<T> {
+            return FakeToken(UUID.randomUUID().toString())
+        }
     }
-  }
 }

--- a/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityPathTest.kt
+++ b/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityPathTest.kt
@@ -7,40 +7,40 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class YawnEntityPathTest {
-  val context = YawnCompilationContext(withSubQuery = false)
+    val context = YawnCompilationContext(withSubQuery = false)
 
-  @Test
-  fun `can generate path with an unaliased root`() {
-    val noParentAlias = EntityWithoutRelationsTable.create(parent = RootTableDefParent)
-    assertThat(noParentAlias.token.generatePath(context)).isEqualTo("token")
-  }
+    @Test
+    fun `can generate path with an unaliased root`() {
+        val noParentAlias = EntityWithoutRelationsTable.create(parent = RootTableDefParent)
+        assertThat(noParentAlias.token.generatePath(context)).isEqualTo("token")
+    }
 
-  @Test
-  fun `can generate path with an aliased root for subqueries`() {
-    val subQueryCompilationContext = YawnCompilationContext(withSubQuery = true)
+    @Test
+    fun `can generate path with an aliased root for subqueries`() {
+        val subQueryCompilationContext = YawnCompilationContext(withSubQuery = true)
 
-    val rootAlias = EntityWithoutRelationsTable.create(parent = RootTableDefParent)
-    assertThat(rootAlias.token.generatePath(subQueryCompilationContext)).isEqualTo("r.token")
-  }
+        val rootAlias = EntityWithoutRelationsTable.create(parent = RootTableDefParent)
+        assertThat(rootAlias.token.generatePath(subQueryCompilationContext)).isEqualTo("r.token")
+    }
 
-  @Test
-  fun `join column def path contains whole chain`() {
-    val withParent = EntityWithSimpleRelationsTableDef<EntityWithoutRelations>(parent = RootTableDefParent)
-    val asField = withParent.nonNullOneToOneYawn
-    assertThat(asField.path(context)).isEqualTo("nonNullOneToOneYawn")
+    @Test
+    fun `join column def path contains whole chain`() {
+        val withParent = EntityWithSimpleRelationsTableDef<EntityWithoutRelations>(parent = RootTableDefParent)
+        val asField = withParent.nonNullOneToOneYawn
+        assertThat(asField.path(context)).isEqualTo("nonNullOneToOneYawn")
 
-    val asJoinWithAlias = withParent.nonNullOneToOneYawn.joinTableDef(AssociationTableDefParent(asField))
-    assertThat(asJoinWithAlias.randomField.generatePath(context)).isEqualTo("nnotoy.randomField")
-  }
+        val asJoinWithAlias = withParent.nonNullOneToOneYawn.joinTableDef(AssociationTableDefParent(asField))
+        assertThat(asJoinWithAlias.randomField.generatePath(context)).isEqualTo("nnotoy.randomField")
+    }
 
-  @Test
-  fun `join column def path contains whole chain including root aliases`() {
-    val subQueryCompilationContext = YawnCompilationContext(withSubQuery = true)
-    val withParent = EntityWithSimpleRelationsTableDef<EntityWithoutRelations>(parent = RootTableDefParent)
-    val asField = withParent.nonNullOneToOneYawn
-    assertThat(asField.path(subQueryCompilationContext)).isEqualTo("r.nonNullOneToOneYawn")
+    @Test
+    fun `join column def path contains whole chain including root aliases`() {
+        val subQueryCompilationContext = YawnCompilationContext(withSubQuery = true)
+        val withParent = EntityWithSimpleRelationsTableDef<EntityWithoutRelations>(parent = RootTableDefParent)
+        val asField = withParent.nonNullOneToOneYawn
+        assertThat(asField.path(subQueryCompilationContext)).isEqualTo("r.nonNullOneToOneYawn")
 
-    val asJoinWithAlias = withParent.nonNullOneToOneYawn.joinTableDef(AssociationTableDefParent(asField))
-    assertThat(asJoinWithAlias.randomField.generatePath(subQueryCompilationContext)).isEqualTo("nnotoy.randomField")
-  }
+        val asJoinWithAlias = withParent.nonNullOneToOneYawn.joinTableDef(AssociationTableDefParent(asField))
+        assertThat(asJoinWithAlias.randomField.generatePath(subQueryCompilationContext)).isEqualTo("nnotoy.randomField")
+    }
 }

--- a/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityProcessorTest.kt
+++ b/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityProcessorTest.kt
@@ -9,114 +9,114 @@ import javax.persistence.Transient
 import kotlin.reflect.KVisibility
 
 internal class YawnEntityProcessorTest {
-  @Test
-  fun `generate a tableDef that inherit from a generic YawnTableDef abstract class`() {
-    assertGeneratedEntity<PublicEmptyEntity>()
-  }
-
-  @YawnEntity
-  class PublicInInternal {
-    @YawnEntity
-    class PublicInPublicInInternal
+    @Test
+    fun `generate a tableDef that inherit from a generic YawnTableDef abstract class`() {
+        assertGeneratedEntity<PublicEmptyEntity>()
+    }
 
     @YawnEntity
-    internal class InternalInPublicInInternal
-  }
+    class PublicInInternal {
+        @YawnEntity
+        class PublicInPublicInInternal
 
-  @YawnEntity
-  internal class InternalInInternal
-  // NOTE: private classes are not supported by Yawn
+        @YawnEntity
+        internal class InternalInPublicInInternal
+    }
 
-  @Test
-  fun `match visibility of the original entity`() {
-    assertGeneratedEntity<PublicEmptyEntity>(expectedVisibility = KVisibility.PUBLIC)
-    assertGeneratedEntity<InternalEmptyEntity>(expectedVisibility = KVisibility.INTERNAL)
-
-    // NOTE: local classes are not supported by Yawn
-    assertGeneratedEntity<PublicInInternal>(expectedVisibility = KVisibility.INTERNAL)
-    assertGeneratedEntity<InternalInInternal>(expectedVisibility = KVisibility.INTERNAL)
-    assertGeneratedEntity<PublicInInternal.PublicInPublicInInternal>(expectedVisibility = KVisibility.INTERNAL)
-    assertGeneratedEntity<PublicInInternal.InternalInPublicInInternal>(expectedVisibility = KVisibility.INTERNAL)
-    assertGeneratedEntity<PublicEmptyEntity.InternalInsidePublic>(expectedVisibility = KVisibility.INTERNAL)
-  }
-
-  @YawnEntity
-  class DbParent {
     @YawnEntity
-    class DbChildInDbParent
-  }
+    internal class InternalInInternal
+    // NOTE: private classes are not supported by Yawn
 
-  @Test
-  fun `nested class naming`() {
-    assertGeneratedEntity<DbParent>()
-    assertGeneratedEntity<DbParent.DbChildInDbParent>()
-  }
+    @Test
+    fun `match visibility of the original entity`() {
+        assertGeneratedEntity<PublicEmptyEntity>(expectedVisibility = KVisibility.PUBLIC)
+        assertGeneratedEntity<InternalEmptyEntity>(expectedVisibility = KVisibility.INTERNAL)
 
-  @YawnEntity
-  class DbColumnLess {
-    @Transient
-    val transientField: String = ""
-  }
-
-  @Test
-  fun `ignore transient fields`() {
-    assertGeneratedEntity<DbColumnLess> {
-      hasNoField("transientField")
+        // NOTE: local classes are not supported by Yawn
+        assertGeneratedEntity<PublicInInternal>(expectedVisibility = KVisibility.INTERNAL)
+        assertGeneratedEntity<InternalInInternal>(expectedVisibility = KVisibility.INTERNAL)
+        assertGeneratedEntity<PublicInInternal.PublicInPublicInInternal>(expectedVisibility = KVisibility.INTERNAL)
+        assertGeneratedEntity<PublicInInternal.InternalInPublicInInternal>(expectedVisibility = KVisibility.INTERNAL)
+        assertGeneratedEntity<PublicEmptyEntity.InternalInsidePublic>(expectedVisibility = KVisibility.INTERNAL)
     }
-  }
 
-  @Test
-  fun `can generate column definition for non-relations`() {
-    assertGeneratedEntity<EntityWithoutRelations> {
-      hasTableColumn<EntityWithoutRelations, Long>("id")
-      hasTableColumn<EntityWithoutRelations, Long>("version")
-      hasTableColumn<EntityWithoutRelations, String>("name")
-      hasTableColumn<EntityWithoutRelations, FakeToken<String>>("token")
+    @YawnEntity
+    class DbParent {
+        @YawnEntity
+        class DbChildInDbParent
     }
-  }
 
-  @Test
-  fun `can generate column definition for inheritance`() {
-    assertGeneratedEntity<ChildInheritanceEntity> {
-      // self values
-      hasTableColumn<ChildInheritanceEntity, String>("childValue")
-
-      // overridden interface
-      hasTableColumn<ChildInheritanceEntity, FakeToken<ChildInheritanceEntity>>("token")
-
-      // from parent
-      hasTableColumn<ChildInheritanceEntity, Int>("parentValue")
-
-      // from grandparent
-      hasTableColumn<ChildInheritanceEntity, Boolean?>("grandParentValue")
+    @Test
+    fun `nested class naming`() {
+        assertGeneratedEntity<DbParent>()
+        assertGeneratedEntity<DbParent.DbChildInDbParent>()
     }
-  }
 
-  @Test
-  fun `can generate embedded property definitions and types`() {
-    assertGeneratedEntity<EntityWithEmbeddedProperties> {
-      hasEmbeddedProperty<EntityWithEmbeddedProperties, EmbeddableEntity>("embedded") { embeddedContext ->
-        embeddedContext.hasEmbeddedTableColumn<EntityWithEmbeddedProperties, String>("foo")
-        embeddedContext.hasEmbeddedTableColumn<EntityWithEmbeddedProperties, Int>("bar")
-      }
+    @YawnEntity
+    class DbColumnLess {
+        @Transient
+        val transientField: String = ""
     }
-  }
 
-  @Test
-  fun `can generate column definition for ElementCollection`() {
-    assertGeneratedEntity<EntityWithElementCollection> {
-      hasField<
-          YawnTableDef<SOURCE, EntityWithElementCollection>.JoinColumnDef<
-              String,
-              YawnTableDef<SOURCE, EntityWithElementCollection>.ElementCollectionDef<String>,
-              >,
-          >("strings")
-      hasField<
-          YawnTableDef<SOURCE, EntityWithElementCollection>.JoinColumnDef<
-              Enums,
-              YawnTableDef<SOURCE, EntityWithElementCollection>.ElementCollectionDef<Enums>,
-              >,
-          >("enums")
+    @Test
+    fun `ignore transient fields`() {
+        assertGeneratedEntity<DbColumnLess> {
+            hasNoField("transientField")
+        }
     }
-  }
+
+    @Test
+    fun `can generate column definition for non-relations`() {
+        assertGeneratedEntity<EntityWithoutRelations> {
+            hasTableColumn<EntityWithoutRelations, Long>("id")
+            hasTableColumn<EntityWithoutRelations, Long>("version")
+            hasTableColumn<EntityWithoutRelations, String>("name")
+            hasTableColumn<EntityWithoutRelations, FakeToken<String>>("token")
+        }
+    }
+
+    @Test
+    fun `can generate column definition for inheritance`() {
+        assertGeneratedEntity<ChildInheritanceEntity> {
+            // self values
+            hasTableColumn<ChildInheritanceEntity, String>("childValue")
+
+            // overridden interface
+            hasTableColumn<ChildInheritanceEntity, FakeToken<ChildInheritanceEntity>>("token")
+
+            // from parent
+            hasTableColumn<ChildInheritanceEntity, Int>("parentValue")
+
+            // from grandparent
+            hasTableColumn<ChildInheritanceEntity, Boolean?>("grandParentValue")
+        }
+    }
+
+    @Test
+    fun `can generate embedded property definitions and types`() {
+        assertGeneratedEntity<EntityWithEmbeddedProperties> {
+            hasEmbeddedProperty<EntityWithEmbeddedProperties, EmbeddableEntity>("embedded") { embeddedContext ->
+                embeddedContext.hasEmbeddedTableColumn<EntityWithEmbeddedProperties, String>("foo")
+                embeddedContext.hasEmbeddedTableColumn<EntityWithEmbeddedProperties, Int>("bar")
+            }
+        }
+    }
+
+    @Test
+    fun `can generate column definition for ElementCollection`() {
+        assertGeneratedEntity<EntityWithElementCollection> {
+            hasField<
+                YawnTableDef<SOURCE, EntityWithElementCollection>.JoinColumnDef<
+                    String,
+                    YawnTableDef<SOURCE, EntityWithElementCollection>.ElementCollectionDef<String>,
+                    >,
+                >("strings")
+            hasField<
+                YawnTableDef<SOURCE, EntityWithElementCollection>.JoinColumnDef<
+                    Enums,
+                    YawnTableDef<SOURCE, EntityWithElementCollection>.ElementCollectionDef<Enums>,
+                    >,
+                >("enums")
+        }
+    }
 }

--- a/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnProjectionProcessorTest.kt
+++ b/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnProjectionProcessorTest.kt
@@ -5,21 +5,21 @@ import com.faire.yawn.project.YawnProjection
 import org.junit.jupiter.api.Test
 
 internal class YawnProjectionProcessorTest {
-  @YawnProjection
-  data class SimpleProjection(
-      val string: String,
-      val int: Int,
-      val boolean: Boolean,
-  )
+    @YawnProjection
+    data class SimpleProjection(
+        val string: String,
+        val int: Int,
+        val boolean: Boolean,
+    )
 
-  @Test
-  fun `simple projection is generated`() {
-    assertGeneratedProjection<SimpleProjection> {
-      hasProjectionColumn<SimpleProjection, String>("string")
-      hasProjectionColumn<SimpleProjection, Int>("int")
-      hasProjectionColumn<SimpleProjection, Boolean>("boolean")
+    @Test
+    fun `simple projection is generated`() {
+        assertGeneratedProjection<SimpleProjection> {
+            hasProjectionColumn<SimpleProjection, String>("string")
+            hasProjectionColumn<SimpleProjection, Int>("int")
+            hasProjectionColumn<SimpleProjection, Boolean>("boolean")
 
-      hasCompanionObjectWithCreateFunction()
+            hasCompanionObjectWithCreateFunction()
+        }
     }
-  }
 }

--- a/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnTestUtils.kt
+++ b/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnTestUtils.kt
@@ -12,142 +12,143 @@ import kotlin.reflect.full.memberProperties
 import kotlin.reflect.typeOf
 
 internal object YawnTestUtils {
-  inline fun <reified T : Any> assertGeneratedEntity(
-      expectedVisibility: KVisibility? = null,
-      noinline builder: YawnTestAssertContext.() -> Unit = {},
-  ) {
-    internalAssertGeneratedEntity(
-        expectedSuperClassDef = YawnTableDef::class,
-        expectedSuperClassRef = YawnTableRef::class,
-        sourceClass = T::class,
-        expectedVisibility = expectedVisibility,
-        builder = builder,
-    )
-  }
-
-  inline fun <reified T : Any> assertGeneratedProjection(
-      expectedVisibility: KVisibility? = null,
-      noinline builder: YawnTestAssertContext.() -> Unit = {},
-  ) {
-    internalAssertGeneratedEntity(
-        expectedSuperClassDef = YawnProjectionDef::class,
-        expectedSuperClassRef = YawnProjectionRef::class,
-        sourceClass = T::class,
-        expectedVisibility = expectedVisibility,
-        builder = builder,
-    )
-  }
-
-  fun <T : Any> internalAssertGeneratedEntity(
-      expectedSuperClassDef: KClass<out YawnDef<*, *>>,
-      expectedSuperClassRef: KClass<out YawnRef<*, *>>,
-      sourceClass: KClass<T>,
-      expectedVisibility: KVisibility? = null,
-      builder: YawnTestAssertContext.() -> Unit = {},
-  ) {
-    val generatedClass = getGeneratedDefKClass(sourceClass, expectedSuperClassDef)
-    val generatedObject = getGeneratedDefKClass(sourceClass, expectedSuperClassRef)
-
-    // assert the correct superclass type
-    val superClass = generatedClass.java.genericSuperclass as ParameterizedType
-    assertThat(superClass.rawType).isEqualTo(expectedSuperClassDef.java)
-
-    // assert the generic parameter
-    val genericParameter = superClass.actualTypeArguments.last()
-    assertThat(genericParameter).isEqualTo(sourceClass.java)
-
-    // maybe assert visibility
-    if (expectedVisibility != null) {
-      assertThat(generatedClass.visibility).isEqualTo(expectedVisibility)
-    }
-
-    // asserts from the lambda
-    builder(YawnTestAssertContext(generatedClass, generatedObject))
-  }
-
-  private fun getGeneratedDefKClass(
-      clazz: KClass<*>,
-      expectedSuperClass: KClass<*>,
-  ): KClass<*> {
-    val classPath = clazz.java.packageName
-    val defName = expectedSuperClass.simpleName!!.removePrefix("Yawn").removeSuffix("Ref")
-    val classNamePrefix = clazz.java
-        .getNestingChain()
-        .joinToString(separator = "_") { it.simpleName }
-    val className = "$classNamePrefix$defName"
-    return Class.forName("$classPath.$className").kotlin
-  }
-
-  class YawnTestAssertContext(
-      val generatedClass: KClass<*>,
-      private val generatedObject: KClass<*>,
-  ) {
-    /**
-     * Use as placeholder for the SOURCE generic parameter on the generated class in order to call [hasField].
-     */
-    class SOURCE
-
-    private val sourcePlaceholderName = SOURCE::class.qualifiedName!!
-
-    inline fun <reified T : Any, reified D> hasTableColumn(columnName: String) {
-      hasField<YawnTableDef<SOURCE, T>.ColumnDef<D>>(columnName)
-    }
-
-    inline fun <reified T : Any, reified D> hasProjectionColumn(columnName: String) {
-      hasField<YawnProjectionDef<SOURCE, T>.ProjectionColumnDef<D>>(columnName)
-    }
-
-    inline fun <reified T : Any, reified D : Any> hasEmbeddedProperty(
-        columnName: String,
-        embeddedTypeAssertions: (YawnTestEmbeddableAssertContext) -> Unit,
+    inline fun <reified T : Any> assertGeneratedEntity(
+        expectedVisibility: KVisibility? = null,
+        noinline builder: YawnTestAssertContext.() -> Unit = {},
     ) {
-      val property = generatedClass.memberProperties.single { it.name == columnName }
-      assertThat(property.returnType.isSubtypeOf(typeOf<YawnTableDef<*, T>.EmbeddedDef<D>>())).isTrue()
-
-      val embeddedClass = property.returnType.classifier as KClass<*>
-      embeddedTypeAssertions(YawnTestEmbeddableAssertContext(embeddedClass, sourcePlaceholderName))
+        internalAssertGeneratedEntity(
+            expectedSuperClassDef = YawnTableDef::class,
+            expectedSuperClassRef = YawnTableRef::class,
+            sourceClass = T::class,
+            expectedVisibility = expectedVisibility,
+            builder = builder,
+        )
     }
 
-    inline fun <reified C> hasField(columnName: String) {
-      val properties = generatedClass.memberProperties
-      val expectedTypeAsString = getTypeStringWithSourceReplaced<C>(sourcePlaceholderName)
-      assertThat(properties).anyMatch { it.name == columnName && it.returnType.toString() == expectedTypeAsString }
+    inline fun <reified T : Any> assertGeneratedProjection(
+        expectedVisibility: KVisibility? = null,
+        noinline builder: YawnTestAssertContext.() -> Unit = {},
+    ) {
+        internalAssertGeneratedEntity(
+            expectedSuperClassDef = YawnProjectionDef::class,
+            expectedSuperClassRef = YawnProjectionRef::class,
+            sourceClass = T::class,
+            expectedVisibility = expectedVisibility,
+            builder = builder,
+        )
     }
 
-    fun hasNoField(columnName: String) {
-      val properties = generatedClass.memberProperties
-      assertThat(properties).noneMatch { it.name == columnName }
+    fun <T : Any> internalAssertGeneratedEntity(
+        expectedSuperClassDef: KClass<out YawnDef<*, *>>,
+        expectedSuperClassRef: KClass<out YawnRef<*, *>>,
+        sourceClass: KClass<T>,
+        expectedVisibility: KVisibility? = null,
+        builder: YawnTestAssertContext.() -> Unit = {},
+    ) {
+        val generatedClass = getGeneratedDefKClass(sourceClass, expectedSuperClassDef)
+        val generatedObject = getGeneratedDefKClass(sourceClass, expectedSuperClassRef)
+
+        // assert the correct superclass type
+        val superClass = generatedClass.java.genericSuperclass as ParameterizedType
+        assertThat(superClass.rawType).isEqualTo(expectedSuperClassDef.java)
+
+        // assert the generic parameter
+        val genericParameter = superClass.actualTypeArguments.last()
+        assertThat(genericParameter).isEqualTo(sourceClass.java)
+
+        // maybe assert visibility
+        if (expectedVisibility != null) {
+            assertThat(generatedClass.visibility).isEqualTo(expectedVisibility)
+        }
+
+        // asserts from the lambda
+        builder(YawnTestAssertContext(generatedClass, generatedObject))
     }
 
-    fun hasCompanionObjectWithCreateFunction() {
-      assertThat(generatedObject.functions).anyMatch { it.name == "create" }
+    private fun getGeneratedDefKClass(
+        clazz: KClass<*>,
+        expectedSuperClass: KClass<*>,
+    ): KClass<*> {
+        val classPath = clazz.java.packageName
+        val defName = expectedSuperClass.simpleName!!.removePrefix("Yawn").removeSuffix("Ref")
+        val classNamePrefix = clazz.java
+            .getNestingChain()
+            .joinToString(separator = "_") { it.simpleName }
+        val className = "$classNamePrefix$defName"
+        return Class.forName("$classPath.$className").kotlin
     }
-  }
 
-  class YawnTestEmbeddableAssertContext(
-      private val embeddedClass: KClass<*>,
-      private val sourcePlaceholderName: String,
-  ) {
-    inline fun <reified T : Any, reified D> hasEmbeddedTableColumn(columnName: String) {
-      val properties = embeddedClass.memberProperties
-      val columnType = getTypeStringWithSourceReplaced<YawnTableDef<YawnTestAssertContext.SOURCE, T>.ColumnDef<D>>(
-          sourcePlaceholderName,
-      )
-      assertThat(properties).anyMatch { it.name == columnName && it.returnType.toString() == columnType }
+    class YawnTestAssertContext(
+        val generatedClass: KClass<*>,
+        private val generatedObject: KClass<*>,
+    ) {
+        /**
+         * Use as placeholder for the SOURCE generic parameter on the generated class in order to call [hasField].
+         */
+        class SOURCE
+
+        private val sourcePlaceholderName = SOURCE::class.qualifiedName!!
+
+        inline fun <reified T : Any, reified D> hasTableColumn(columnName: String) {
+            hasField<YawnTableDef<SOURCE, T>.ColumnDef<D>>(columnName)
+        }
+
+        inline fun <reified T : Any, reified D> hasProjectionColumn(columnName: String) {
+            hasField<YawnProjectionDef<SOURCE, T>.ProjectionColumnDef<D>>(columnName)
+        }
+
+        inline fun <reified T : Any, reified D : Any> hasEmbeddedProperty(
+            columnName: String,
+            embeddedTypeAssertions: (YawnTestEmbeddableAssertContext) -> Unit,
+        ) {
+            val property = generatedClass.memberProperties.single { it.name == columnName }
+            assertThat(property.returnType.isSubtypeOf(typeOf<YawnTableDef<*, T>.EmbeddedDef<D>>())).isTrue()
+
+            val embeddedClass = property.returnType.classifier as KClass<*>
+            embeddedTypeAssertions(YawnTestEmbeddableAssertContext(embeddedClass, sourcePlaceholderName))
+        }
+
+        inline fun <reified C> hasField(columnName: String) {
+            val properties = generatedClass.memberProperties
+            val expectedTypeAsString = getTypeStringWithSourceReplaced<C>(sourcePlaceholderName)
+            assertThat(properties).anyMatch { it.name == columnName && it.returnType.toString() == expectedTypeAsString }
+        }
+
+        fun hasNoField(columnName: String) {
+            val properties = generatedClass.memberProperties
+            assertThat(properties).noneMatch { it.name == columnName }
+        }
+
+        fun hasCompanionObjectWithCreateFunction() {
+            assertThat(generatedObject.functions).anyMatch { it.name == "create" }
+        }
     }
-  }
+
+    class YawnTestEmbeddableAssertContext(
+        private val embeddedClass: KClass<*>,
+        private val sourcePlaceholderName: String,
+    ) {
+        inline fun <reified T : Any, reified D> hasEmbeddedTableColumn(columnName: String) {
+            val properties = embeddedClass.memberProperties
+            val columnType =
+                getTypeStringWithSourceReplaced<YawnTableDef<YawnTestAssertContext.SOURCE, T>.ColumnDef<D>>(
+                    sourcePlaceholderName,
+                )
+            assertThat(properties).anyMatch { it.name == columnName && it.returnType.toString() == columnType }
+        }
+    }
 }
 
 private fun Class<*>.getNestingChain(): List<Class<*>> {
-  val chain = mutableListOf<Class<*>>()
-  var currentClass: Class<*>? = this
-  while (currentClass != null) {
-    chain.add(currentClass)
-    currentClass = currentClass.enclosingClass
-  }
-  return chain.reversed()
+    val chain = mutableListOf<Class<*>>()
+    var currentClass: Class<*>? = this
+    while (currentClass != null) {
+        chain.add(currentClass)
+        currentClass = currentClass.enclosingClass
+    }
+    return chain.reversed()
 }
 
 private inline fun <reified C> getTypeStringWithSourceReplaced(replacement: String): String {
-  return typeOf<C>().toString().replace(replacement, "SOURCE")
+    return typeOf<C>().toString().replace(replacement, "SOURCE")
 }

--- a/yawn-processor/build.gradle.kts
+++ b/yawn-processor/build.gradle.kts
@@ -14,11 +14,11 @@ dependencies {
 
     // KSP dependencies for the processor itself
     implementation("com.google.devtools.ksp:symbol-processing-api:2.0.21-1.0.27")
-    
+
     // KotlinPoet for code generation
     implementation("com.squareup:kotlinpoet:1.18.1")
     implementation("com.squareup:kotlinpoet-ksp:1.18.1")
-    
+
     // Additional KSP utilities (might provide missing extension functions)
     implementation("com.google.devtools.ksp:symbol-processing-common-deps:2.0.21-1.0.27")
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/TypeSpecBuilderExtensions.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/TypeSpecBuilderExtensions.kt
@@ -6,23 +6,23 @@ import com.squareup.kotlinpoet.TypeSpec
 import kotlin.reflect.KClass
 
 internal fun TypeSpec.Builder.addGeneratedAnnotation(generator: KClass<*>): TypeSpec.Builder {
-  val generatedAnnotationName = ClassName("javax.annotation.processing", "Generated")
+    val generatedAnnotationName = ClassName("javax.annotation.processing", "Generated")
 
-  val annotationSpec = AnnotationSpec.builder(generatedAnnotationName)
-      // Do **not** specify `dateTime` property. This causes build cache misses as the time changes.
-      .addMember("%S", generator.qualifiedName!!)
-      .build()
+    val annotationSpec = AnnotationSpec.builder(generatedAnnotationName)
+        // Do **not** specify `dateTime` property. This causes build cache misses as the time changes.
+        .addMember("%S", generator.qualifiedName!!)
+        .build()
 
-  return addAnnotation(annotationSpec)
+    return addAnnotation(annotationSpec)
 }
 
 internal fun ClassName.makeNonNullable(): ClassName {
-  // NOTE: due to a lack of default parameter values on the ClassName override for copy,
-  //       we need to specify all args to avoid falling back to the TypeName super version,
-  //       which returns TypeName
-  return copy(
-      nullable = false,
-      annotations = annotations,
-      tags = tags,
-  )
+    // NOTE: due to a lack of default parameter values on the ClassName override for copy,
+    //       we need to specify all args to avoid falling back to the TypeName super version,
+    //       which returns TypeName
+    return copy(
+        nullable = false,
+        annotations = annotations,
+        tags = tags,
+    )
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/object/YawnReferenceObjectGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/object/YawnReferenceObjectGenerator.kt
@@ -8,5 +8,5 @@ import com.squareup.kotlinpoet.TypeSpec
  * These reference objects are accessed by the user to perform queries.
  */
 internal interface YawnReferenceObjectGenerator {
-  fun generate(yawnContext: YawnContext): TypeSpec
+    fun generate(yawnContext: YawnContext): TypeSpec
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/object/YawnTableRefObjectGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/object/YawnTableRefObjectGenerator.kt
@@ -22,86 +22,86 @@ import com.squareup.kotlinpoet.ksp.toClassName
 import javax.persistence.Table
 
 internal object YawnTableRefObjectGenerator : YawnReferenceObjectGenerator {
-  /**
-   * Generate a [com.faire.yawn.YawnTableRef] object for the generated [com.faire.yawn.YawnTableRef].
-   * This acts as a singleton for the top level (non-aliased) table and is referenced by the user to perform queries.
-   *
-   * The output code will look like:
-   * object FooTable : YawnTableRef<DbFoo, FooTableDef<DbFoo>> {
-   *   override fun create(parent: YawnTableDefParent): FooTableDef<DbFoo> = FooTableDef(parent)
-   * }
-   */
-  override fun generate(yawnContext: YawnContext): TypeSpec {
-    val classDeclaration = yawnContext.classDeclaration
-    val newClassName = yawnContext.newClassName.simpleName
+    /**
+     * Generate a [com.faire.yawn.YawnTableRef] object for the generated [com.faire.yawn.YawnTableRef].
+     * This acts as a singleton for the top level (non-aliased) table and is referenced by the user to perform queries.
+     *
+     * The output code will look like:
+     * object FooTable : YawnTableRef<DbFoo, FooTableDef<DbFoo>> {
+     *   override fun create(parent: YawnTableDefParent): FooTableDef<DbFoo> = FooTableDef(parent)
+     * }
+     */
+    override fun generate(yawnContext: YawnContext): TypeSpec {
+        val classDeclaration = yawnContext.classDeclaration
+        val newClassName = yawnContext.newClassName.simpleName
 
-    val originalClassName = classDeclaration.toClassName()
-    val objectName = generateTableObjectName(originalClassName)
+        val originalClassName = classDeclaration.toClassName()
+        val objectName = generateTableObjectName(originalClassName)
 
-    val typeParameter = ClassName(originalClassName.packageName, newClassName).parameterizedBy(originalClassName)
-    val superInterface = YawnTableRef::class.asClassName().parameterizedBy(originalClassName, typeParameter)
+        val typeParameter = ClassName(originalClassName.packageName, newClassName).parameterizedBy(originalClassName)
+        val superInterface = YawnTableRef::class.asClassName().parameterizedBy(originalClassName, typeParameter)
 
-    return TypeSpec.objectBuilder(objectName)
-        .addGeneratedAnnotation(YawnTableRefObjectGenerator::class)
-        .addSuperinterface(superInterface)
-        .addModifiers(classDeclaration.getEffectiveVisibility())
-        .addFunctions(generateFactoryFunctions(classDeclaration, originalClassName, yawnContext.newClassName))
-        .build()
-  }
+        return TypeSpec.objectBuilder(objectName)
+            .addGeneratedAnnotation(YawnTableRefObjectGenerator::class)
+            .addSuperinterface(superInterface)
+            .addModifiers(classDeclaration.getEffectiveVisibility())
+            .addFunctions(generateFactoryFunctions(classDeclaration, originalClassName, yawnContext.newClassName))
+            .build()
+    }
 
-  private fun generateFactoryFunctions(
-      classDeclaration: KSClassDeclaration,
-      originalClassName: ClassName,
-      newClassName: ClassName,
-  ): List<FunSpec> {
-    val returnType = ClassName(originalClassName.packageName, newClassName.simpleName)
+    private fun generateFactoryFunctions(
+        classDeclaration: KSClassDeclaration,
+        originalClassName: ClassName,
+        newClassName: ClassName,
+    ): List<FunSpec> {
+        val returnType = ClassName(originalClassName.packageName, newClassName.simpleName)
 
-    return listOf(
-        generateCreateFunction(
-            originalClassName = originalClassName,
-            newClassName = newClassName,
-            returnType = returnType,
-        ),
-        generateForSubQueryFunction(
-            classDeclaration = classDeclaration,
-            newClassName = newClassName,
-            returnType = returnType,
-        ),
-    )
-  }
+        return listOf(
+            generateCreateFunction(
+                originalClassName = originalClassName,
+                newClassName = newClassName,
+                returnType = returnType,
+            ),
+            generateForSubQueryFunction(
+                classDeclaration = classDeclaration,
+                newClassName = newClassName,
+                returnType = returnType,
+            ),
+        )
+    }
 
-  private fun generateCreateFunction(
-      originalClassName: ClassName,
-      newClassName: ClassName,
-      returnType: ClassName,
-  ): FunSpec {
-    return FunSpec.builder("create")
-        .addModifiers(KModifier.OVERRIDE)
-        .addParameter(PARENT_PARAMETER_NAME, parentType)
-        .returns(returnType.parameterizedBy(originalClassName))
-        .addCode("return %T(%N)", newClassName, PARENT_PARAMETER_NAME)
-        .build()
-  }
+    private fun generateCreateFunction(
+        originalClassName: ClassName,
+        newClassName: ClassName,
+        returnType: ClassName,
+    ): FunSpec {
+        return FunSpec.builder("create")
+            .addModifiers(KModifier.OVERRIDE)
+            .addParameter(PARENT_PARAMETER_NAME, parentType)
+            .returns(returnType.parameterizedBy(originalClassName))
+            .addCode("return %T(%N)", newClassName, PARENT_PARAMETER_NAME)
+            .build()
+    }
 
-  private fun generateForSubQueryFunction(
-      classDeclaration: KSClassDeclaration,
-      newClassName: ClassName,
-      returnType: ClassName,
-  ): FunSpec {
-    val entityName = classDeclaration.getAnnotationsByType<Table>()
-        .singleOrNull()
-        ?.arguments
-        ?.singleOrNull { it.name?.asString() == "name" }
-        ?.value
-        as? String
-        ?: "detached"
-    val parentSourceType = TypeVariableName("PARENT_SOURCE", Any::class.asTypeName())
+    private fun generateForSubQueryFunction(
+        classDeclaration: KSClassDeclaration,
+        newClassName: ClassName,
+        returnType: ClassName,
+    ): FunSpec {
+        val entityName = classDeclaration.getAnnotationsByType<Table>()
+            .singleOrNull()
+            ?.arguments
+            ?.singleOrNull { it.name?.asString() == "name" }
+            ?.value
+            as? String
+            ?: "detached"
+        val parentSourceType = TypeVariableName("PARENT_SOURCE", Any::class.asTypeName())
 
-    return FunSpec.builder("forSubQuery")
-        .addTypeVariable(parentSourceType)
-        .addModifiers(KModifier.OVERRIDE)
-        .returns(returnType.parameterizedBy(parentSourceType))
-        .addStatement("return %T(%T(%S))", newClassName, SubqueryTableDefParent::class.asClassName(), entityName)
-        .build()
-  }
+        return FunSpec.builder("forSubQuery")
+            .addTypeVariable(parentSourceType)
+            .addModifiers(KModifier.OVERRIDE)
+            .returns(returnType.parameterizedBy(parentSourceType))
+            .addStatement("return %T(%T(%S))", newClassName, SubqueryTableDefParent::class.asClassName(), entityName)
+            .build()
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/ColumnDefGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/ColumnDefGenerator.kt
@@ -9,7 +9,6 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.ksp.toTypeName
-import kotlin.collections.plus
 
 /**
  * This generates a meta-property using the "raw" [com.faire.yawn.YawnTableDef.ColumnDef] class.
@@ -29,52 +28,52 @@ import kotlin.collections.plus
  * ```
  */
 internal object ColumnDefGenerator : YawnPropertyGenerator() {
-  override val generatedType = YawnTableDef.ColumnDef::class
+    override val generatedType = YawnTableDef.ColumnDef::class
 
-  override fun generate(
-      yawnContext: YawnContext,
-      fieldName: String,
-      fieldType: KSType,
-      foreignKeyRef: ForeignKeyReference?, // always ignored
-  ): PropertySpec {
-    return generate(yawnContext, fieldName, fieldType)
-  }
-
-  fun generate(
-      yawnContext: YawnContext,
-      propertyDeclaration: KSPropertyDeclaration,
-      // the ColumnDef constructor can take a list of prefixes before the actual field name
-      pathPrefixes: List<YawnParameter> = listOf(),
-  ): PropertySpec {
-    return generate(
-        yawnContext = yawnContext,
-        fieldName = propertyDeclaration.simpleName.asString(),
-        fieldType = propertyDeclaration.type.resolve(),
-        pathPrefixes = pathPrefixes,
-    )
-  }
-
-  private fun generate(
-      yawnContext: YawnContext,
-      fieldName: String, // in this example, `token`
-      fieldType: KSType, // in this example, `Token<FOO>`
-      // the ColumnDef constructor can take a list of prefixes before the actual field name
-      pathPrefixes: List<YawnParameter> = listOf(),
-  ): PropertySpec {
-    val typeArguments = try {
-      listOf(fieldType.toTypeName()) // Token<FOO>
-    } catch (e: IllegalArgumentException) {
-      throw YawnProcessorException("Failed to get type name for ${yawnContext.superClassName}.$fieldName", e)
+    override fun generate(
+        yawnContext: YawnContext,
+        fieldName: String,
+        fieldType: KSType,
+        foreignKeyRef: ForeignKeyReference?, // always ignored
+    ): PropertySpec {
+        return generate(yawnContext, fieldName, fieldType)
     }
-    val parameters = pathPrefixes + listOf(
-        YawnParameter.string(fieldName), // "token"
-    )
 
-    return generatePropertySpec(
-        yawnContext,
-        fieldName,
-        parameters,
-        typeArguments,
-    )
-  }
+    fun generate(
+        yawnContext: YawnContext,
+        propertyDeclaration: KSPropertyDeclaration,
+        // the ColumnDef constructor can take a list of prefixes before the actual field name
+        pathPrefixes: List<YawnParameter> = listOf(),
+    ): PropertySpec {
+        return generate(
+            yawnContext = yawnContext,
+            fieldName = propertyDeclaration.simpleName.asString(),
+            fieldType = propertyDeclaration.type.resolve(),
+            pathPrefixes = pathPrefixes,
+        )
+    }
+
+    private fun generate(
+        yawnContext: YawnContext,
+        fieldName: String, // in this example, `token`
+        fieldType: KSType, // in this example, `Token<FOO>`
+        // the ColumnDef constructor can take a list of prefixes before the actual field name
+        pathPrefixes: List<YawnParameter> = listOf(),
+    ): PropertySpec {
+        val typeArguments = try {
+            listOf(fieldType.toTypeName()) // Token<FOO>
+        } catch (e: IllegalArgumentException) {
+            throw YawnProcessorException("Failed to get type name for ${yawnContext.superClassName}.$fieldName", e)
+        }
+        val parameters = pathPrefixes + listOf(
+            YawnParameter.string(fieldName), // "token"
+        )
+
+        return generatePropertySpec(
+            yawnContext,
+            fieldName,
+            parameters,
+            typeArguments,
+        )
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/ElementCollectionColumnDefGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/ElementCollectionColumnDefGenerator.kt
@@ -36,40 +36,40 @@ import com.squareup.kotlinpoet.ksp.toTypeName
  * ```
  */
 internal object ElementCollectionColumnDefGenerator : YawnPropertyGenerator() {
-  override val generatedType = YawnTableDef.JoinColumnDef::class
-  private val elementCollectionDefName = YawnTableDef.ElementCollectionDef::class.asClassName().simpleName
+    override val generatedType = YawnTableDef.JoinColumnDef::class
+    private val elementCollectionDefName = YawnTableDef.ElementCollectionDef::class.asClassName().simpleName
 
-  override fun generate(
-      yawnContext: YawnContext,
-      fieldName: String, // in this example, `genres`
-      fieldType: KSType, // in this example, `Set<Genre>`
-      foreignKeyRef: ForeignKeyReference?, // always null
-  ): PropertySpec {
-    check(foreignKeyRef == null)
+    override fun generate(
+        yawnContext: YawnContext,
+        fieldName: String, // in this example, `genres`
+        fieldType: KSType, // in this example, `Set<Genre>`
+        foreignKeyRef: ForeignKeyReference?, // always null
+    ): PropertySpec {
+        check(foreignKeyRef == null)
 
-    // in this example, `Genre`
-    val elementType = fieldType.arguments.first().type!!.resolve()
-    val elementTypeName = elementType.toTypeName()
+        // in this example, `Genre`
+        val elementType = fieldType.arguments.first().type!!.resolve()
+        val elementTypeName = elementType.toTypeName()
 
-    // These are the 2 type arguments that ElementCollectionColumnDef takes:
-    val typeArguments = listOf(
-        elementTypeName, // T = Genre
-        // DEF = ElementCollectionDef<Genre>
-        yawnContext.superClassName.nestedClass(
-            elementCollectionDefName,
-            listOf(elementTypeName),
-        ),
-    )
+        // These are the 2 type arguments that ElementCollectionColumnDef takes:
+        val typeArguments = listOf(
+            elementTypeName, // T = Genre
+            // DEF = ElementCollectionDef<Genre>
+            yawnContext.superClassName.nestedClass(
+                elementCollectionDefName,
+                listOf(elementTypeName),
+            ),
+        )
 
-    val parameters = listOf(
-        // parentPath = path
-        YawnParameter.literal(PARENT_PARAMETER_NAME),
-        // name = "genre"
-        YawnParameter.string(fieldName),
-        // tableDefProvider = { ElementCollectionDef(it) }
-        YawnParameter("{ ElementCollectionDef(it) }"),
-    )
+        val parameters = listOf(
+            // parentPath = path
+            YawnParameter.literal(PARENT_PARAMETER_NAME),
+            // name = "genre"
+            YawnParameter.string(fieldName),
+            // tableDefProvider = { ElementCollectionDef(it) }
+            YawnParameter("{ ElementCollectionDef(it) }"),
+        )
 
-    return generatePropertySpec(yawnContext, fieldName, parameters, typeArguments)
-  }
+        return generatePropertySpec(yawnContext, fieldName, parameters, typeArguments)
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/EmbeddedDefGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/EmbeddedDefGenerator.kt
@@ -28,23 +28,23 @@ import com.squareup.kotlinpoet.ksp.toClassName
  * Note that `FooDef` extends [YawnTableDef.EmbeddedDef].
  */
 internal object EmbeddedDefGenerator : YawnPropertyGenerator() {
-  override val generatedType = YawnTableDef.EmbeddedDef::class
+    override val generatedType = YawnTableDef.EmbeddedDef::class
 
-  override fun generate(
-      yawnContext: YawnContext,
-      fieldName: String, // in this example, `foo`
-      fieldType: KSType, // in this example, `Foo`
-      foreignKeyRef: ForeignKeyReference?, // always null
-  ): PropertySpec {
-    check(foreignKeyRef == null)
+    override fun generate(
+        yawnContext: YawnContext,
+        fieldName: String, // in this example, `foo`
+        fieldType: KSType, // in this example, `Foo`
+        foreignKeyRef: ForeignKeyReference?, // always null
+    ): PropertySpec {
+        check(foreignKeyRef == null)
 
-    // in this example, `FooDef`
-    val typeName = yawnContext.newClassName
-        .nestedClass(generateEmbeddedDefClassName(fieldType.toClassName()))
+        // in this example, `FooDef`
+        val typeName = yawnContext.newClassName
+            .nestedClass(generateEmbeddedDefClassName(fieldType.toClassName()))
 
-    // val foo: FooDef = FooDef()
-    return PropertySpec.builder(fieldName, typeName)
-        .initializer("%T()", typeName)
-        .build()
-  }
+        // val foo: FooDef = FooDef()
+        return PropertySpec.builder(fieldName, typeName)
+            .initializer("%T()", typeName)
+            .build()
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/EmbeddedIdDefGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/EmbeddedIdDefGenerator.kt
@@ -30,23 +30,23 @@ import com.squareup.kotlinpoet.ksp.toClassName
  * Note that `FooCompositeIdDef` extends [YawnTableDef.EmbeddedDef].
  */
 internal object EmbeddedIdDefGenerator : YawnPropertyGenerator() {
-  override val generatedType = YawnTableDef.EmbeddedDef::class
+    override val generatedType = YawnTableDef.EmbeddedDef::class
 
-  override fun generate(
-      yawnContext: YawnContext,
-      fieldName: String, // in this example, `cid`
-      fieldType: KSType, // in this example, `FooCompositeId`
-      foreignKeyRef: ForeignKeyReference?, // always null
-  ): PropertySpec {
-    check(foreignKeyRef == null)
+    override fun generate(
+        yawnContext: YawnContext,
+        fieldName: String, // in this example, `cid`
+        fieldType: KSType, // in this example, `FooCompositeId`
+        foreignKeyRef: ForeignKeyReference?, // always null
+    ): PropertySpec {
+        check(foreignKeyRef == null)
 
-    // in this example, `FooCompositeIdDef`
-    val typeName = yawnContext.newClassName
-        .nestedClass(generateEmbeddedDefClassName(fieldType.toClassName()))
+        // in this example, `FooCompositeIdDef`
+        val typeName = yawnContext.newClassName
+            .nestedClass(generateEmbeddedDefClassName(fieldType.toClassName()))
 
-    // val cid: FooCompositeIdDef = FooCompositeIdDef()
-    return PropertySpec.builder(fieldName, typeName)
-        .initializer("%T()", typeName)
-        .build()
-  }
+        // val cid: FooCompositeIdDef = FooCompositeIdDef()
+        return PropertySpec.builder(fieldName, typeName)
+            .initializer("%T()", typeName)
+            .build()
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/JoinColumnDefGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/JoinColumnDefGenerator.kt
@@ -41,38 +41,38 @@ import com.squareup.kotlinpoet.ksp.toClassName
  * by Hibernate.
  */
 internal object JoinColumnDefGenerator : YawnPropertyGenerator() {
-  override val generatedType = YawnTableDef.JoinColumnDef::class
+    override val generatedType = YawnTableDef.JoinColumnDef::class
 
-  override fun generate(
-      yawnContext: YawnContext,
-      fieldName: String, // in this example, `nullableOneToOneYawn`
-      fieldType: KSType, // in this example, `YawnEntityInAnotherPackage?`
-      foreignKeyRef: ForeignKeyReference?,
-  ): PropertySpec {
-    check(foreignKeyRef == null)
+    override fun generate(
+        yawnContext: YawnContext,
+        fieldName: String, // in this example, `nullableOneToOneYawn`
+        fieldType: KSType, // in this example, `YawnEntityInAnotherPackage?`
+        foreignKeyRef: ForeignKeyReference?,
+    ): PropertySpec {
+        check(foreignKeyRef == null)
 
-    val fieldTypeClassName = fieldType.toClassName() // reference to YawnEntityInAnotherPackage
+        val fieldTypeClassName = fieldType.toClassName() // reference to YawnEntityInAnotherPackage
 
-    // reference to YawnEntityInAnotherPackageTableDef
-    val fieldYawnTableDef = tableDefForType(fieldTypeClassName)
+        // reference to YawnEntityInAnotherPackageTableDef
+        val fieldYawnTableDef = tableDefForType(fieldTypeClassName)
 
-    // These are the 2 type arguments that JoinColumnDef takes:
-    val typeArguments = listOf(
-        // T = YawnEntityInAnotherPackage
-        fieldTypeClassName,
-        // DEF = YawnEntityInAnotherPackageTableDef<SOURCE>
-        fieldYawnTableDef.parameterizedBy(yawnContext.sourceTypeVariable),
-    )
+        // These are the 2 type arguments that JoinColumnDef takes:
+        val typeArguments = listOf(
+            // T = YawnEntityInAnotherPackage
+            fieldTypeClassName,
+            // DEF = YawnEntityInAnotherPackageTableDef<SOURCE>
+            fieldYawnTableDef.parameterizedBy(yawnContext.sourceTypeVariable),
+        )
 
-    val parameters = listOf(
-        // tableDefParent = parent
-        YawnParameter.literal(PARENT_PARAMETER_NAME),
-        // name = "nullableOneToOneYawn"
-        YawnParameter.string(fieldName),
-        // tableDefProvider = { YawnEntityInAnotherPackageTableDef(it) }
-        YawnParameter.simple("{ %T(it) }", fieldYawnTableDef),
-    )
+        val parameters = listOf(
+            // tableDefParent = parent
+            YawnParameter.literal(PARENT_PARAMETER_NAME),
+            // name = "nullableOneToOneYawn"
+            YawnParameter.string(fieldName),
+            // tableDefProvider = { YawnEntityInAnotherPackageTableDef(it) }
+            YawnParameter.simple("{ %T(it) }", fieldYawnTableDef),
+        )
 
-    return generatePropertySpec(yawnContext, fieldName, parameters, typeArguments)
-  }
+        return generatePropertySpec(yawnContext, fieldName, parameters, typeArguments)
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/JoinColumnDefWithForeignKeyGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/JoinColumnDefWithForeignKeyGenerator.kt
@@ -39,47 +39,47 @@ import com.squareup.kotlinpoet.ksp.toClassName
  * ```
  */
 internal object JoinColumnDefWithForeignKeyGenerator : YawnPropertyGenerator() {
-  override val generatedType = YawnTableDef.JoinColumnDefWithForeignKey::class
+    override val generatedType = YawnTableDef.JoinColumnDefWithForeignKey::class
 
-  override fun generate(
-      yawnContext: YawnContext,
-      fieldName: String, // in this example, `foo`
-      fieldType: KSType, // in this example,  `DbFoo`
-      foreignKeyRef: ForeignKeyReference?, // pre-parsed info from the FK matching on the other side
-  ): PropertySpec {
-    checkNotNull(foreignKeyRef)
+    override fun generate(
+        yawnContext: YawnContext,
+        fieldName: String, // in this example, `foo`
+        fieldType: KSType, // in this example,  `DbFoo`
+        foreignKeyRef: ForeignKeyReference?, // pre-parsed info from the FK matching on the other side
+    ): PropertySpec {
+        checkNotNull(foreignKeyRef)
 
-    val fieldTypeClassName: ClassName = fieldType
-        .toClassName() // reference to DbFoo
-        // TODO(yawn): we should make JoinColumnDefWithCompositeKey null-aware;
-        //             check faire.link/yawn-nullability for more details.
-        .makeNonNullable()
+        val fieldTypeClassName: ClassName = fieldType
+            .toClassName() // reference to DbFoo
+            // TODO(yawn): we should make JoinColumnDefWithCompositeKey null-aware;
+            //             check faire.link/yawn-nullability for more details.
+            .makeNonNullable()
 
-    // reference to FooTableDef
-    val fieldYawnTableDef = tableDefForType(fieldTypeClassName)
+        // reference to FooTableDef
+        val fieldYawnTableDef = tableDefForType(fieldTypeClassName)
 
-    // These are the 3 type arguments that JoinColumnDefWithForeignKey takes:
-    val typeArguments = listOf(
-        // T = DbFoo
-        fieldTypeClassName,
-        // DEF = FooTableDef<SOURCE>
-        fieldYawnTableDef
-            .parameterizedBy(yawnContext.sourceTypeVariable),
-        // ID = Id<DbFoo>
-        foreignKeyRef.toTypeName(),
-    )
+        // These are the 3 type arguments that JoinColumnDefWithForeignKey takes:
+        val typeArguments = listOf(
+            // T = DbFoo
+            fieldTypeClassName,
+            // DEF = FooTableDef<SOURCE>
+            fieldYawnTableDef
+                .parameterizedBy(yawnContext.sourceTypeVariable),
+            // ID = Id<DbFoo>
+            foreignKeyRef.toTypeName(),
+        )
 
-    val parameters = listOf(
-        // tableDefParent = parent
-        YawnParameter.literal(PARENT_PARAMETER_NAME),
-        // name = "foo"
-        YawnParameter.string(fieldName),
-        // foreignKeyName = "id"
-        YawnParameter.string(foreignKeyRef.columnName),
-        // tableDefProvider = { FooTableDef(it) }
-        YawnParameter.simple("{ %T(it) }", fieldYawnTableDef),
-    )
+        val parameters = listOf(
+            // tableDefParent = parent
+            YawnParameter.literal(PARENT_PARAMETER_NAME),
+            // name = "foo"
+            YawnParameter.string(fieldName),
+            // foreignKeyName = "id"
+            YawnParameter.string(foreignKeyRef.columnName),
+            // tableDefProvider = { FooTableDef(it) }
+            YawnParameter.simple("{ %T(it) }", fieldYawnTableDef),
+        )
 
-    return generatePropertySpec(yawnContext, fieldName, parameters, typeArguments)
-  }
+        return generatePropertySpec(yawnContext, fieldName, parameters, typeArguments)
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/ProjectionColumnDefGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/ProjectionColumnDefGenerator.kt
@@ -35,25 +35,25 @@ import com.squareup.kotlinpoet.ksp.toTypeName
  * ```
  */
 internal object ProjectionColumnDefGenerator : YawnPropertyGenerator() {
-  override val generatedType = YawnProjectionDef.ProjectionColumnDef::class
+    override val generatedType = YawnProjectionDef.ProjectionColumnDef::class
 
-  override fun generate(
-      yawnContext: YawnContext,
-      fieldName: String,
-      fieldType: KSType,
-      foreignKeyRef: ForeignKeyReference?, // always ignored
-  ): PropertySpec {
-    val parameters = listOf(
-        YawnParameter.string(fieldName), // in the example, "field"
-    )
-    val typeArguments = listOf(
-        fieldType.toTypeName(), // in the example, `Type`
-    )
-    return generatePropertySpec(
-        yawnContext,
-        fieldName,
-        parameters,
-        typeArguments,
-    )
-  }
+    override fun generate(
+        yawnContext: YawnContext,
+        fieldName: String,
+        fieldType: KSType,
+        foreignKeyRef: ForeignKeyReference?, // always ignored
+    ): PropertySpec {
+        val parameters = listOf(
+            YawnParameter.string(fieldName), // in the example, "field"
+        )
+        val typeArguments = listOf(
+            fieldType.toTypeName(), // in the example, `Type`
+        )
+        return generatePropertySpec(
+            yawnContext,
+            fieldName,
+            parameters,
+            typeArguments,
+        )
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/YawnPropertyGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/property/YawnPropertyGenerator.kt
@@ -10,9 +10,6 @@ import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
-import kotlin.collections.flatMap
-import kotlin.collections.joinToString
-import kotlin.collections.toTypedArray
 import kotlin.reflect.KClass
 
 /**
@@ -35,65 +32,65 @@ import kotlin.reflect.KClass
  * To be used when constructing the meta-definition classes.
  */
 internal abstract class YawnPropertyGenerator {
-  protected abstract val generatedType: KClass<*>
+    protected abstract val generatedType: KClass<*>
 
-  private val generatedTypeName
-    get() = generatedType.simpleName!!
+    private val generatedTypeName
+        get() = generatedType.simpleName!!
 
-  fun generate(
-      yawnContext: YawnContext,
-      property: KSPropertyDeclaration,
-      foreignKeyRef: ForeignKeyReference? = null,
-  ): PropertySpec? {
-    return generate(
-        yawnContext = yawnContext,
-        fieldName = property.simpleName.asString(),
-        fieldType = property.resolveTargetType(),
-        foreignKeyRef = foreignKeyRef,
-    )
-  }
+    fun generate(
+        yawnContext: YawnContext,
+        property: KSPropertyDeclaration,
+        foreignKeyRef: ForeignKeyReference? = null,
+    ): PropertySpec? {
+        return generate(
+            yawnContext = yawnContext,
+            fieldName = property.simpleName.asString(),
+            fieldType = property.resolveTargetType(),
+            foreignKeyRef = foreignKeyRef,
+        )
+    }
 
-  abstract fun generate(
-      yawnContext: YawnContext,
-      fieldName: String,
-      fieldType: KSType,
-      foreignKeyRef: ForeignKeyReference?,
-  ): PropertySpec?
+    abstract fun generate(
+        yawnContext: YawnContext,
+        fieldName: String,
+        fieldType: KSType,
+        foreignKeyRef: ForeignKeyReference?,
+    ): PropertySpec?
 
-  protected fun tableDefForType(type: ClassName): ClassName {
-    return ClassName(
-        type.packageName,
-        generateTableDefClassName(type),
-    )
-  }
+    protected fun tableDefForType(type: ClassName): ClassName {
+        return ClassName(
+            type.packageName,
+            generateTableDefClassName(type),
+        )
+    }
 
-  /**
-   * Builds a property following the template:
-   *
-   * ```
-   *    val fieldName: Type<typeArguments...> = Type(parameters...)
-   * ```
-   *
-   * The type is controlled by the `generatedType` property.
-   * This makes sure that types are properly imported and correctly referenced.
-   */
-  protected fun generatePropertySpec(
-      yawnContext: YawnContext,
-      fieldName: String,
-      parameters: List<YawnParameter>,
-      typeArguments: List<TypeName> = listOf(),
-  ): PropertySpec {
-    val fieldType = yawnContext.superClassName.nestedClass(generatedTypeName, typeArguments)
+    /**
+     * Builds a property following the template:
+     *
+     * ```
+     *    val fieldName: Type<typeArguments...> = Type(parameters...)
+     * ```
+     *
+     * The type is controlled by the `generatedType` property.
+     * This makes sure that types are properly imported and correctly referenced.
+     */
+    protected fun generatePropertySpec(
+        yawnContext: YawnContext,
+        fieldName: String,
+        parameters: List<YawnParameter>,
+        typeArguments: List<TypeName> = listOf(),
+    ): PropertySpec {
+        val fieldType = yawnContext.superClassName.nestedClass(generatedTypeName, typeArguments)
 
-    val parameterFormats = parameters.joinToString(", ") { it.format }
-    val parameterValues = parameters.flatMap { it.arguments }
+        val parameterFormats = parameters.joinToString(", ") { it.format }
+        val parameterValues = parameters.flatMap { it.arguments }
 
-    return PropertySpec.builder(
-        fieldName,
-        fieldType,
-    ).initializer(
-        "$generatedTypeName($parameterFormats)",
-        *parameterValues.toTypedArray(),
-    ).build()
-  }
+        return PropertySpec.builder(
+            fieldName,
+            fieldType,
+        ).initializer(
+            "$generatedTypeName($parameterFormats)",
+            *parameterValues.toTypedArray(),
+        ).build()
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/type/EmbeddedIdTypeGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/type/EmbeddedIdTypeGenerator.kt
@@ -51,14 +51,14 @@ import com.squareup.kotlinpoet.TypeSpec
  * type.
  */
 internal object EmbeddedIdTypeGenerator : YawnEmbeddableTypeGenerator {
-  private val superClassType = YawnTableDef.EmbeddedDef::class
-  private val superClassTypeName = superClassType.simpleName!!
+    private val superClassType = YawnTableDef.EmbeddedDef::class
+    private val superClassTypeName = superClassType.simpleName!!
 
-  override fun generate(
-      yawnContext: YawnContext,
-      /** This will be the property `var cid: FooCompositeId` from the example above */
-      propertyDeclaration: KSPropertyDeclaration,
-  ): TypeSpec {
-    return EmbeddedTypeGenerator.generate(yawnContext, propertyDeclaration, superClassTypeName)
-  }
+    override fun generate(
+        yawnContext: YawnContext,
+        /** This will be the property `var cid: FooCompositeId` from the example above */
+        propertyDeclaration: KSPropertyDeclaration,
+    ): TypeSpec {
+        return EmbeddedTypeGenerator.generate(yawnContext, propertyDeclaration, superClassTypeName)
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/generators/type/YawnEmbeddableTypeGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/generators/type/YawnEmbeddableTypeGenerator.kt
@@ -12,8 +12,8 @@ import com.squareup.kotlinpoet.TypeSpec
  * contain the properties of the embedded class.
  */
 internal interface YawnEmbeddableTypeGenerator {
-  fun generate(
-      yawnContext: YawnContext,
-      propertyDeclaration: KSPropertyDeclaration,
-  ): TypeSpec?
+    fun generate(
+        yawnContext: YawnContext,
+        propertyDeclaration: KSPropertyDeclaration,
+    ): TypeSpec?
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/processors/YawnEntityProcessor.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/processors/YawnEntityProcessor.kt
@@ -44,75 +44,75 @@ import kotlin.reflect.KClass
  * Implementation of [BaseYawnProcessor] for [YawnEntity] annotated classes.
  */
 internal class YawnEntityProcessor(codeGenerator: CodeGenerator) : BaseYawnProcessor(codeGenerator) {
-  override val annotationClass: KClass<out Annotation> = YawnEntity::class
-  override val yawnDefClass: KClass<out YawnDef<*, *>> = YawnTableDef::class
+    override val annotationClass: KClass<out Annotation> = YawnEntity::class
+    override val yawnDefClass: KClass<out YawnDef<*, *>> = YawnTableDef::class
 
-  override fun generateYawnDefClassName(originalClassName: ClassName): String {
-    return generateTableDefClassName(originalClassName)
-  }
-
-  override val objectRefGenerator = YawnTableRefObjectGenerator
-
-  override fun generateProperty(
-      yawnContext: YawnContext,
-      property: KSPropertyDeclaration,
-  ): PropertySpec? {
-    val foreignKeyRef = property.getHibernateForeignKeyReference()
-    val generator = when {
-      property.isTransient() -> null
-
-      (property.isOneToOneJoin() || property.isManyToOneJoin()) -> {
-        when {
-          !property.isYawnEntity() -> ColumnDefGenerator
-          foreignKeyRef == null -> JoinColumnDefGenerator
-          foreignKeyRef.isCompositeKey -> JoinColumnDefWithCompositeKeyGenerator
-          else -> JoinColumnDefWithForeignKeyGenerator
-        }
-      }
-
-      (property.isOneToManyJoin() || property.isManyToManyJoin()) -> CollectionJoinColumnDefGenerator
-      property.isEmbeddedId() -> EmbeddedIdDefGenerator
-      property.isEmbedded() -> EmbeddedDefGenerator
-      property.isElementCollection() -> ElementCollectionColumnDefGenerator
-
-      property.isColumn() || property.isId() || property.isFormula() -> ColumnDefGenerator
-      else -> null
+    override fun generateYawnDefClassName(originalClassName: ClassName): String {
+        return generateTableDefClassName(originalClassName)
     }
 
-    return generator?.generate(
-        yawnContext = yawnContext,
-        property = property,
-        foreignKeyRef = foreignKeyRef,
-    )
-  }
+    override val objectRefGenerator = YawnTableRefObjectGenerator
 
-  override fun additionalClassBuilder(
-      yawnContext: YawnContext,
-      classBuilder: TypeSpec.Builder,
-  ): TypeSpec.Builder {
-    return classBuilder
-        .addSuperclassConstructorParameter(PARENT_PARAMETER_NAME)
-        .addTypes(generateEmbeddedDefinitions(yawnContext))
-  }
+    override fun generateProperty(
+        yawnContext: YawnContext,
+        property: KSPropertyDeclaration,
+    ): PropertySpec? {
+        val foreignKeyRef = property.getHibernateForeignKeyReference()
+        val generator = when {
+            property.isTransient() -> null
 
-  /**
-   * Within the generated table definition, we might need to define subclasses to represent embedded definitions.
-   * This will be either fields tagged with @Embedded or composite primary keys tagged with @EmbeddedId.
-   */
-  private fun generateEmbeddedDefinitions(
-      yawnContext: YawnContext,
-  ): List<TypeSpec> {
-    return yawnContext.classDeclaration.getAllProperties()
-        .mapNotNull { property ->
-          val generator = when {
-            property.isEmbeddedId() -> EmbeddedIdTypeGenerator
-            property.isEmbedded() -> EmbeddedTypeGenerator
+            (property.isOneToOneJoin() || property.isManyToOneJoin()) -> {
+                when {
+                    !property.isYawnEntity() -> ColumnDefGenerator
+                    foreignKeyRef == null -> JoinColumnDefGenerator
+                    foreignKeyRef.isCompositeKey -> JoinColumnDefWithCompositeKeyGenerator
+                    else -> JoinColumnDefWithForeignKeyGenerator
+                }
+            }
+
+            (property.isOneToManyJoin() || property.isManyToManyJoin()) -> CollectionJoinColumnDefGenerator
+            property.isEmbeddedId() -> EmbeddedIdDefGenerator
+            property.isEmbedded() -> EmbeddedDefGenerator
+            property.isElementCollection() -> ElementCollectionColumnDefGenerator
+
+            property.isColumn() || property.isId() || property.isFormula() -> ColumnDefGenerator
             else -> null
-          }
-          generator?.generate(yawnContext, property)
         }
-        .toList()
-  }
+
+        return generator?.generate(
+            yawnContext = yawnContext,
+            property = property,
+            foreignKeyRef = foreignKeyRef,
+        )
+    }
+
+    override fun additionalClassBuilder(
+        yawnContext: YawnContext,
+        classBuilder: TypeSpec.Builder,
+    ): TypeSpec.Builder {
+        return classBuilder
+            .addSuperclassConstructorParameter(PARENT_PARAMETER_NAME)
+            .addTypes(generateEmbeddedDefinitions(yawnContext))
+    }
+
+    /**
+     * Within the generated table definition, we might need to define subclasses to represent embedded definitions.
+     * This will be either fields tagged with @Embedded or composite primary keys tagged with @EmbeddedId.
+     */
+    private fun generateEmbeddedDefinitions(
+        yawnContext: YawnContext,
+    ): List<TypeSpec> {
+        return yawnContext.classDeclaration.getAllProperties()
+            .mapNotNull { property ->
+                val generator = when {
+                    property.isEmbeddedId() -> EmbeddedIdTypeGenerator
+                    property.isEmbedded() -> EmbeddedTypeGenerator
+                    else -> null
+                }
+                generator?.generate(yawnContext, property)
+            }
+            .toList()
+    }
 }
 
 /**
@@ -120,9 +120,9 @@ internal class YawnEntityProcessor(codeGenerator: CodeGenerator) : BaseYawnProce
  */
 @AutoService(SymbolProcessorProvider::class)
 internal class YawnEntityProcessorProvider : SymbolProcessorProvider {
-  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
-    return YawnEntityProcessor(
-        codeGenerator = environment.codeGenerator,
-    )
-  }
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return YawnEntityProcessor(
+            codeGenerator = environment.codeGenerator,
+        )
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/processors/YawnProjectionProcessor.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/processors/YawnProjectionProcessor.kt
@@ -18,24 +18,24 @@ import com.squareup.kotlinpoet.PropertySpec
 import kotlin.reflect.KClass
 
 internal class YawnProjectionProcessor(codeGenerator: CodeGenerator) : BaseYawnProcessor(codeGenerator) {
-  override val annotationClass: KClass<out Annotation> = YawnProjection::class
-  override val yawnDefClass: KClass<out YawnDef<*, *>> = YawnProjectionDef::class
+    override val annotationClass: KClass<out Annotation> = YawnProjection::class
+    override val yawnDefClass: KClass<out YawnDef<*, *>> = YawnProjectionDef::class
 
-  override fun generateYawnDefClassName(originalClassName: ClassName): String {
-    return generateProjectionDefClassName(originalClassName)
-  }
+    override fun generateYawnDefClassName(originalClassName: ClassName): String {
+        return generateProjectionDefClassName(originalClassName)
+    }
 
-  override val objectRefGenerator = YawnProjectionRefObjectGenerator
+    override val objectRefGenerator = YawnProjectionRefObjectGenerator
 
-  override fun generateProperty(
-      yawnContext: YawnContext,
-      property: KSPropertyDeclaration,
-  ): PropertySpec? {
-    return ProjectionColumnDefGenerator.generate(
-        yawnContext = yawnContext,
-        property = property,
-    )
-  }
+    override fun generateProperty(
+        yawnContext: YawnContext,
+        property: KSPropertyDeclaration,
+    ): PropertySpec? {
+        return ProjectionColumnDefGenerator.generate(
+            yawnContext = yawnContext,
+            property = property,
+        )
+    }
 }
 
 /**
@@ -43,9 +43,9 @@ internal class YawnProjectionProcessor(codeGenerator: CodeGenerator) : BaseYawnP
  */
 @AutoService(SymbolProcessorProvider::class)
 internal class YawnProjectionProcessorProvider : SymbolProcessorProvider {
-  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
-    return YawnProjectionProcessor(
-        codeGenerator = environment.codeGenerator,
-    )
-  }
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return YawnProjectionProcessor(
+            codeGenerator = environment.codeGenerator,
+        )
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/util/KspSymbolExtensions.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/util/KspSymbolExtensions.kt
@@ -27,62 +27,62 @@ import javax.persistence.OneToOne
 import javax.persistence.Transient
 
 internal fun KSPropertyDeclaration.isTransient(): Boolean {
-  return isAnnotationPresent<Transient>()
+    return isAnnotationPresent<Transient>()
 }
 
 internal fun KSPropertyDeclaration.isEmbeddedId(): Boolean {
-  return isAnnotationPresent<EmbeddedId>()
+    return isAnnotationPresent<EmbeddedId>()
 }
 
 internal fun KSPropertyDeclaration.isEmbedded(): Boolean {
-  return isAnnotationPresent<Embedded>()
+    return isAnnotationPresent<Embedded>()
 }
 
 internal fun KSPropertyDeclaration.isElementCollection(): Boolean {
-  return isAnnotationPresent<ElementCollection>()
+    return isAnnotationPresent<ElementCollection>()
 }
 
 internal fun KSPropertyDeclaration.isColumn(): Boolean {
-  return isAnnotationPresent<Column>()
+    return isAnnotationPresent<Column>()
 }
 
 internal fun KSPropertyDeclaration.isId(): Boolean {
-  return isAnnotationPresent<Id>()
+    return isAnnotationPresent<Id>()
 }
 
 internal fun KSPropertyDeclaration.isFormula(): Boolean {
-  return isAnnotationPresent<Formula>()
+    return isAnnotationPresent<Formula>()
 }
 
 internal fun KSPropertyDeclaration.isOneToOneJoin(): Boolean {
-  return isAnnotationPresent<OneToOne>()
+    return isAnnotationPresent<OneToOne>()
 }
 
 internal fun KSPropertyDeclaration.isManyToOneJoin(): Boolean {
-  return isAnnotationPresent<ManyToOne>()
+    return isAnnotationPresent<ManyToOne>()
 }
 
 internal fun KSPropertyDeclaration.isManyToManyJoin(): Boolean {
-  return isAnnotationPresent<ManyToMany>()
+    return isAnnotationPresent<ManyToMany>()
 }
 
 internal fun KSPropertyDeclaration.isOneToManyJoin(): Boolean {
-  return isAnnotationPresent<OneToMany>()
+    return isAnnotationPresent<OneToMany>()
 }
 
 internal fun KSPropertyDeclaration.resolveTargetType(): KSType {
-  val targetAnnotation = getAnnotationsByType<OneToOne>().singleOrNull()
-      ?: getAnnotationsByType<ManyToOne>().singleOrNull()
-  val targetEntity = targetAnnotation?.arguments?.firstOrNull { it.name?.asString() == "targetEntity" }?.value
-  val typeReference = targetEntity as? KSType ?: (targetEntity as? KSClassDeclaration)?.asType(listOf())
-  if (typeReference != null && typeReference.declaration.qualifiedName?.asString() != "kotlin.Unit") {
-    return typeReference
-  }
-  return type.resolve()
+    val targetAnnotation = getAnnotationsByType<OneToOne>().singleOrNull()
+        ?: getAnnotationsByType<ManyToOne>().singleOrNull()
+    val targetEntity = targetAnnotation?.arguments?.firstOrNull { it.name?.asString() == "targetEntity" }?.value
+    val typeReference = targetEntity as? KSType ?: (targetEntity as? KSClassDeclaration)?.asType(listOf())
+    if (typeReference != null && typeReference.declaration.qualifiedName?.asString() != "kotlin.Unit") {
+        return typeReference
+    }
+    return type.resolve()
 }
 
 internal fun KSPropertyDeclaration.isYawnEntity(): Boolean {
-  return resolveTargetType().declaration.isYawnEntity()
+    return resolveTargetType().declaration.isYawnEntity()
 }
 
 internal data class ForeignKeyReference(
@@ -90,66 +90,67 @@ internal data class ForeignKeyReference(
     val typeReference: KSTypeReference,
     val isCompositeKey: Boolean,
 ) {
-  private val type = typeReference.resolve()
+    private val type = typeReference.resolve()
 
-  fun toTypeName(): TypeName {
-    return type.toTypeName()
-  }
+    fun toTypeName(): TypeName {
+        return type.toTypeName()
+    }
 
-  fun toClassName(): ClassName {
-    return type.toClassName()
-  }
+    fun toClassName(): ClassName {
+        return type.toClassName()
+    }
 }
 
 private fun KSAnnotation.getStringValue(name: String): String? {
-  return arguments
-      .firstOrNull { it.name?.asString() == name }
-      ?.value
-      ?.toString()
-      ?.takeUnless { it.isEmpty() }
+    return arguments
+        .firstOrNull { it.name?.asString() == name }
+        ?.value
+        ?.toString()
+        ?.takeUnless { it.isEmpty() }
 }
 
 private fun KSPropertyDeclaration.maybeGetAnnotatedColumnName(): String? {
-  return getAnnotationsByType<Column>().singleOrNull()?.getStringValue("name")
+    return getAnnotationsByType<Column>().singleOrNull()?.getStringValue("name")
 }
 
 internal fun KSPropertyDeclaration.typeAsClassDeclaration(): KSClassDeclaration? {
-  return resolveTargetType().declaration as? KSClassDeclaration
+    return resolveTargetType().declaration as? KSClassDeclaration
 }
 
 internal fun KSPropertyDeclaration.getHibernateForeignKeyReference(): ForeignKeyReference? {
-  val declaration = typeAsClassDeclaration() ?: return null
+    val declaration = typeAsClassDeclaration() ?: return null
 
-  // first, let's see if there are @JoinColumn annotation with a referencedColumnName attribute
-  val joinColumns = getAnnotationsByType<JoinColumn>()
-      .map { it.getStringValue("name") to it.getStringValue("referencedColumnName") }
-      .toList()
-  val referencedColumnName = joinColumns.map { it.second }.singleOrNull()
+    // first, let's see if there are @JoinColumn annotation with a referencedColumnName attribute
+    val joinColumns = getAnnotationsByType<JoinColumn>()
+        .map { it.getStringValue("name") to it.getStringValue("referencedColumnName") }
+        .toList()
+    val referencedColumnName = joinColumns.map { it.second }.singleOrNull()
 
-  // if it is a composite key we just assume it is the PK on the other end
-  val isCompositeKey = joinColumns.size > 1
+    // if it is a composite key we just assume it is the PK on the other end
+    val isCompositeKey = joinColumns.size > 1
 
-  return declaration.getAllProperties()
-      .filter { property ->
-        when {
-          isCompositeKey -> property.isAnnotationPresent<EmbeddedId>()
-          referencedColumnName != null -> {
-            val name = property.maybeGetAnnotatedColumnName() ?: property.simpleName.asString()
-            name == referencedColumnName
-          }
-          else -> property.isAnnotationPresent<Id>()
+    return declaration.getAllProperties()
+        .filter { property ->
+            when {
+                isCompositeKey -> property.isAnnotationPresent<EmbeddedId>()
+                referencedColumnName != null -> {
+                    val name = property.maybeGetAnnotatedColumnName() ?: property.simpleName.asString()
+                    name == referencedColumnName
+                }
+
+                else -> property.isAnnotationPresent<Id>()
+            }
         }
-      }
-      .map { property ->
-        ForeignKeyReference(
-            columnName = property.simpleName.asString(),
-            typeReference = property.type,
-            isCompositeKey = isCompositeKey,
-        )
-      }
-      .singleOrNull()
+        .map { property ->
+            ForeignKeyReference(
+                columnName = property.simpleName.asString(),
+                typeReference = property.type,
+                isCompositeKey = isCompositeKey,
+            )
+        }
+        .singleOrNull()
 }
 
 internal fun KSDeclaration.isYawnEntity(): Boolean {
-  return isAnnotationPresent<YawnEntity>()
+    return isAnnotationPresent<YawnEntity>()
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/util/YawnNamesGenerator.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/util/YawnNamesGenerator.kt
@@ -11,51 +11,51 @@ import com.squareup.kotlinpoet.ClassName
  * naming collisions (see [getUniqueSimpleName] for more details).
  */
 internal object YawnNamesGenerator {
-  /**
-   * For entities annotated with @YawnEntity
-   * For example: DbBook -> DbBookTableDef
-   */
-  fun generateTableDefClassName(originalClassName: ClassName): String {
-    return "${originalClassName.getUniqueSimpleName()}TableDef"
-  }
+    /**
+     * For entities annotated with @YawnEntity
+     * For example: DbBook -> DbBookTableDef
+     */
+    fun generateTableDefClassName(originalClassName: ClassName): String {
+        return "${originalClassName.getUniqueSimpleName()}TableDef"
+    }
 
-  /**
-   * For entities annotated with @YawnEntity
-   * For example: DbBook -> DbBookTable
-   */
-  fun generateTableObjectName(originalClassName: ClassName): String {
-    return "${originalClassName.getUniqueSimpleName()}Table"
-  }
+    /**
+     * For entities annotated with @YawnEntity
+     * For example: DbBook -> DbBookTable
+     */
+    fun generateTableObjectName(originalClassName: ClassName): String {
+        return "${originalClassName.getUniqueSimpleName()}Table"
+    }
 
-  /**
-   * For classes annotated with @Embedded or @EmbeddedId
-   * For example: FooCompositeId -> FooCompositeIdDef
-   */
-  fun generateEmbeddedDefClassName(originalClassName: ClassName): String {
-    return "${originalClassName.getUniqueSimpleName()}Def"
-  }
+    /**
+     * For classes annotated with @Embedded or @EmbeddedId
+     * For example: FooCompositeId -> FooCompositeIdDef
+     */
+    fun generateEmbeddedDefClassName(originalClassName: ClassName): String {
+        return "${originalClassName.getUniqueSimpleName()}Def"
+    }
 
-  /**
-   * For projections annotated with @YawnProjection
-   * For example: YawnProjectionTest.SimpleBook -> YawnProjectionTest_SimpleBookProjectionDef
-   */
-  fun generateProjectionDefClassName(originalClassName: ClassName): String {
-    return "${originalClassName.getUniqueSimpleName()}ProjectionDef"
-  }
+    /**
+     * For projections annotated with @YawnProjection
+     * For example: YawnProjectionTest.SimpleBook -> YawnProjectionTest_SimpleBookProjectionDef
+     */
+    fun generateProjectionDefClassName(originalClassName: ClassName): String {
+        return "${originalClassName.getUniqueSimpleName()}ProjectionDef"
+    }
 
-  /**
-   * For projections annotated with @YawnProjection
-   * For example: YawnProjectionTest.SimpleBook -> YawnProjectionTest_SimpleBookProjection
-   */
-  fun generateProjectionObjectName(originalClassName: ClassName): String {
-    return "${originalClassName.getUniqueSimpleName()}Projection"
-  }
+    /**
+     * For projections annotated with @YawnProjection
+     * For example: YawnProjectionTest.SimpleBook -> YawnProjectionTest_SimpleBookProjection
+     */
+    fun generateProjectionObjectName(originalClassName: ClassName): String {
+        return "${originalClassName.getUniqueSimpleName()}Projection"
+    }
 
-  /**
-   * For embedded properties, we need to create an internal field to store the current path, and we need it to
-   * not clash with any user defined values.
-   */
-  fun generateInternalPathName(): String {
-    return "_yawnPath"
-  }
+    /**
+     * For embedded properties, we need to create an internal field to store the current path, and we need it to
+     * not clash with any user defined values.
+     */
+    fun generateInternalPathName(): String {
+        return "_yawnPath"
+    }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/util/YawnParameter.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/util/YawnParameter.kt
@@ -8,17 +8,17 @@ internal data class YawnParameter(
     val format: String, // %N, %S, %T, etc., or combinations thereof
     val arguments: List<Any> = listOf(),
 ) {
-  companion object {
-    fun simple(format: String, value: Any): YawnParameter {
-      return YawnParameter(format, listOf(value))
-    }
+    companion object {
+        fun simple(format: String, value: Any): YawnParameter {
+            return YawnParameter(format, listOf(value))
+        }
 
-    fun literal(value: String): YawnParameter {
-      return simple("%N", value)
-    }
+        fun literal(value: String): YawnParameter {
+            return simple("%N", value)
+        }
 
-    fun string(value: String): YawnParameter {
-      return simple("%S", value)
+        fun string(value: String): YawnParameter {
+            return simple("%S", value)
+        }
     }
-  }
 }


### PR DESCRIPTION
This updates the entire codebase to use Faire's newer indent standard of 4 spaces.

This also adds our standard `.editorconfig` file (to make sure IntelliJ respects the 4-space indent) and updates the detekt file to correctly configure and enforce the indentation rule. I am also bumping the line width (again in line with what we established for other repositories).

Other than those two changes, everything else in this PR was applying a dose of IJ auto-format and optmize imports followed by a dash of detekt's auto-fix.