### PR TITLE
ci: Add conventional commits validation to CI

### DIFF
--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -1,0 +1,34 @@
+# See https://github.com/amannn/action-semantic-pull-request
+name: 'PR Title is Conventional'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          subjectPattern: ^[^a-z].+$
+          subjectPatternError: |
+            The subject of the PR can't begin with a lowercase letter.


### PR DESCRIPTION
Uses the established standard used on many OSS repos:

https://www.conventionalcommits.org/en/v1.0.0/

Nicely implemented through this github action:

https://github.com/amannn/action-semantic-pull-request