### PR TITLE
ci: Unify and standardize github actions names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
-name: CI
+name: ci
 
 on:
-    push:
-        branches: [main, develop]
-    pull_request:
-        branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-    test:
+    ci:
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,20 +1,18 @@
 name: markdown-lint
 
 on:
-    push:
-        branches:
-            - main
-    pull_request:
-        types: [opened, reopened, synchronize]
-
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
     markdown-lint:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
-            -   uses: actions/setup-node@v4
-                with:
-                    node-version: 22
-            -   run: npm install -g markdownlint-cli
-            -   run: markdownlint . -p .github/markdown-lint/.markdownlintignore -c  .github/markdown-lint/.markdownlint.yaml
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+            - run: npm install -g markdownlint-cli
+            - run: markdownlint . -p .github/markdown-lint/.markdownlintignore -c  .github/markdown-lint/.markdownlint.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: publish
 
 on:
     workflow_dispatch:
@@ -10,35 +10,34 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   name: Checkout code
-                uses: actions/checkout@v4
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-            -   name: Set up JDK
-                uses: actions/setup-java@v4
-                with:
-                    java-version: 21
-                    distribution: "temurin"
+            - name: Set up JDK
+              uses: actions/setup-java@v4
+              with:
+                  java-version: 21
+                  distribution: "temurin"
 
-            -   name: Setup Gradle
-                uses: gradle/actions/setup-gradle@v4
-                with:
-                    gradle-home-cache-cleanup: true
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v4
+              with:
+                  gradle-home-cache-cleanup: true
 
-            -   name: Verify build
-                run: ./gradlew check
+            - name: Verify build
+              run: ./gradlew check
 
-            -   name: Extract version from tag
-                id: extract_version
-                run: |
-                    echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            - name: Extract version from tag
+              id: extract_version
+              run: |
+                  echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-            -   name: Publish the artifacts
-                env:
-                    ORG_GRADLE_PROJECT_version: ${{ steps.extract_version.outputs.VERSION }}
-                    ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-                    ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-                    ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-                    ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
-                run: |
-                    ./gradlew publishAndReleaseToMavenCentral --no-parallel --no-configuration-cache
-
+            - name: Publish the artifacts
+              env:
+                  ORG_GRADLE_PROJECT_version: ${{ steps.extract_version.outputs.VERSION }}
+                  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+                  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+                  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+                  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
+              run: |
+                  ./gradlew publishAndReleaseToMavenCentral --no-parallel --no-configuration-cache

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,17 +1,17 @@
-name: spell_checker
+name: spell-check
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  test:
+  spell-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/title-validation.yml
+++ b/.github/workflows/title-validation.yml
@@ -1,5 +1,5 @@
 # See https://github.com/amannn/action-semantic-pull-request
-name: 'PR Title is Conventional'
+name: title-validation
 
 on:
   pull_request_target:
@@ -9,8 +9,7 @@ on:
       - synchronize
 
 jobs:
-  main:
-    name: Validate PR title
+  title-validation:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v6


### PR DESCRIPTION
Apparently there are 3 "identifiers" for the GitHub Action:

* the file name
* the name at the top of the file
* the name of each "job" (we only ever have one job per action)

This standardizes everything to be the same, and in the format `foo-bar-baz`.
That will make it clearer when setting up branch protections; right now it is quite confusing:
<img width="1452" height="690" alt="image" src="https://github.com/user-attachments/assets/47a9f5ee-4f74-4426-bf13-f74b4cc65b90" />

---

This also formats all yaml files (I will add a yaml check as well in a bit)