### PR TITLE
docs: Update yawn plugin description

### DIFF
--- a/build-logic/src/main/kotlin/yawn.library.gradle.kts
+++ b/build-logic/src/main/kotlin/yawn.library.gradle.kts
@@ -20,7 +20,12 @@ extensions.configure<MavenPublishBaseExtension> {
 
     pom {
         name.set("${project.group}:${project.name}")
-        description.set("Yawn - Hibernate ORM type-safe wrapper")
+        description.set(
+            """
+            Yawn is a Kotlin ORM-wrapper that provides a type-safe, expressive, Criteria-style query 
+            syntax using custom KSP-generated entity metadata.
+            """.trimIndent()
+        )
         url.set("https://github.com/faire/yawn")
 
         licenses {

--- a/yawn-gradle-plugin/build.gradle.kts
+++ b/yawn-gradle-plugin/build.gradle.kts
@@ -71,7 +71,11 @@ gradlePlugin {
     plugins {
         named("com.faire.yawn") {
             displayName = "yawn"
-            description = "Automatically configures Yawn's KSP processor to generate Yawn models."
+            description = """
+                Yawn is a Kotlin ORM-wrapper that provides a type-safe, expressive, Criteria-style query 
+                syntax using KSP-generated entity metadata. This plugin automatically configures Yawn's 
+                KSP processor to generate Yawn models.
+            """.trimIndent()
             tags = listOf("yawn", "ksp", "model", "orm", "database", "faire")
         }
     }


### PR DESCRIPTION
The [plugin's description on the Gradle plugins portal is too vague](https://plugins.gradle.org/plugin/com.faire.yawn) as are [the module descriptions on Maven Central](https://central.sonatype.com/search?q=com.faire.yawn). This adds more information to them all, based on our GitHub description.