### PR TITLE
chore: Fix kotlin and ksp version incompatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.0.21"
-ksp = "2.0.21-1.0.27"
+kotlin = "2.0.10"
+ksp = "2.0.10-1.0.24"
 dokka = "1.9.20"
 hibernate = "5.6.15.Final"
 javax-persistence = "2.2"


### PR DESCRIPTION
We need to figure out a way to make this version agnostic - for now, it will not work with our codebase if we don't specify the correct version.