### PR TITLE
ci: Update go to fix actionlint go install during yaml CI check, and lock versions

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -16,5 +16,5 @@ jobs:
           node-version: 22
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - run: scripts/yaml-lint-run.sh

--- a/scripts/yaml-lint-run.sh
+++ b/scripts/yaml-lint-run.sh
@@ -21,7 +21,7 @@ if ! command -v actionlint &> /dev/null; then
         echo "Error: Go is required to install actionlint. Please install Go first."
         exit 1
     fi
-    go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+    go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.8
 fi
 
 # Run YAML formatting check or fix


### PR DESCRIPTION
For some reason the latest version `v1.7.8` causes a catastrophic crash on CI:
https://github.com/Faire/yawn/actions/runs/18478828180/job/52733244070

Update: I am trying to just update go instead of downgrade actionlint. Either way I will lock the versions for build stability.