### PR TITLE
docs: Fix markdown list nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ There are two sets of dependencies you must add to your project to use Yawn.
 
 1. The `yawn-processor` dependency is what generates the definitions for your entities annotated with `@YawnEntity`.
 
-That needs to be added as a `compileOnly` and also `ksp` dependency:
+    That needs to be added as a `compileOnly` and also `ksp` dependency:
 
-```kotlin
+    ```kotlin
     compileOnly("com.faire.yawn:yawn-processor:$version")
     ksp("com.faire.yawn:yawn-processor:$version")
-```
+    ```
 
-As an alternative, you can use the Yawn Gradle plugin to automatically add the processor for you - see the
-[Yawn Gradle Plugin readme][yawn-gradle-plugin-readme] for more details. This is recommended for multi-module Gradle projects.
+    As an alternative, you can use the Yawn Gradle plugin to automatically add the processor for you - see the
+    [Yawn Gradle Plugin readme][yawn-gradle-plugin-readme] for more details. This is recommended for multi-module Gradle projects.
 
 1. The `yawn-api` as a regular dependency in order to actually make queries:
 
-```kotlin
+    ```kotlin
     implementation("com.faire.yawn:yawn-api:$version")
-```
+    ```
 
 ### Annotate your Entities
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,24 +8,27 @@ Getting started with **Yawn** is **as simple as 4 steps**!
 
 ## Adding the Dependencies
 
-There are two sets of dependencies you must add to your project to use Yawn; the `yawn-processor` dependency is what generates the definitions for your entities
-annotated with `@YawnEntity`.
+There are two sets of dependencies you must add to your project to use Yawn.
 
-That needs to be added as a `compileOnly` and also `ksp` dependency:
+1. The `yawn-processor` dependency generates the definitions for your entities annotated with `@YawnEntity`.
 
-```kotlin
+    That needs to be added as a `compileOnly` and also `ksp` dependency:
+
+    ```kotlin
     compileOnly("com.faire.yawn:yawn-processor:$version")
     ksp("com.faire.yawn:yawn-processor:$version")
-```
+    ```
 
-As an alternative, you can use the Yawn Gradle plugin to automatically add the processor for you - see the
-[Yawn Gradle Plugin readme][yawn-gradle-plugin-readme] for more details. This is recommended for multi-module Gradle projects.
+    As an alternative, you can use the Yawn Gradle plugin to automatically add the processor for you - see the
+    [Yawn Gradle Plugin readme][yawn-gradle-plugin-readme] for more details. This is recommended for multi-module Gradle projects.
 
-Then, you need to add `yawn-api` as a regular dependency in order to actually make queries:
+1. And the `yawn-api` allows you access to Yawn classes to actually perform queries.
 
-```kotlin
+   That is added as a regular dependency:
+
+    ```kotlin
     implementation("com.faire.yawn:yawn-api:$version")
-```
+    ```
 
 ## Annotate your Entities
 


### PR DESCRIPTION
Fix some markdown lists on readme and docs not being properly indented, causing the items to be numbered incorrectly.
<img width="1846" height="972" alt="image" src="https://github.com/user-attachments/assets/e787eb6b-8905-451b-8a84-88a062a0543f" />
