### PR TITLE
refactor: Centralize pagination logic on BaseTypeSafeCriteriaBuilder

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
@@ -123,6 +123,29 @@ abstract class BaseTypeSafeCriteriaBuilder<
             .maxResults(pageSize)
     }
 
+    fun listPaginatedZeroIndexed(
+        pageNumber: Int,
+        pageSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+    ): List<RETURNS> {
+        return paginateZeroIndexed(pageNumber, pageSize, orders).list()
+    }
+
+    inline fun doPaginated(
+        pageSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+        action: (List<RETURNS>) -> Unit,
+    ) {
+        // only apply the orders once
+        applyOrders(orders)
+
+        var pageNumber = 0
+        do {
+            val results = listPaginatedZeroIndexed(pageNumber++, pageSize, listOf())
+            action(results)
+        } while (results.size == pageSize)
+    }
+
     fun applyOrders(orders: List<DEF.() -> YawnQueryOrder<T>>): CRITERIA {
         query.orders.addAll(orders.map { it(tableDef) })
         return builderReturn()

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/ProjectedTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/ProjectedTypeSafeCriteriaBuilder.kt
@@ -6,7 +6,6 @@ import com.faire.yawn.criteria.query.ProjectedTypeSafeCriteriaQuery
 import com.faire.yawn.project.YawnQueryProjection
 import com.faire.yawn.query.YawnQuery
 import com.faire.yawn.query.YawnQueryFactory
-import com.faire.yawn.query.YawnQueryOrder
 
 /**
  * A type-safe builder for Yawn queries with projections.
@@ -47,21 +46,6 @@ class ProjectedTypeSafeCriteriaBuilder<T : Any, DEF : YawnTableDef<T, T>, RETURN
             query.projection = projection
             mapper = { projection.project(it) }
         }
-    }
-
-    inline fun doPaginated(
-        pageSize: Int,
-        orders: List<DEF.() -> YawnQueryOrder<T>>,
-        action: (List<RETURNS>) -> Unit,
-    ) {
-        // only apply the orders once
-        applyOrders(orders)
-
-        var pageNumber = 0
-        do {
-            val results = paginateZeroIndexed(pageNumber++, pageSize, orders = listOf()).list()
-            action(results)
-        } while (results.size == pageSize)
     }
 
     companion object {

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/TypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/TypeSafeCriteriaBuilder.kt
@@ -75,20 +75,6 @@ class TypeSafeCriteriaBuilder<T : Any, DEF : YawnTableDef<T, T>>(
         return results
     }
 
-    fun listPaginatedZeroIndexed(
-        pageNumber: Int,
-        pageSize: Int,
-        orders: List<DEF.() -> YawnQueryOrder<T>>,
-    ): List<T> {
-        check(pageSize >= 1) { "$pageSize is not a valid page size" }
-        check(pageNumber >= 0) { "$pageNumber is not a valid page number" }
-
-        return applyOrders(orders)
-            .offset(pageNumber * pageSize)
-            .maxResults(pageSize)
-            .list()
-    }
-
     fun countDistinct(
         uniqueColumn: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
     ): Long {
@@ -115,21 +101,6 @@ class TypeSafeCriteriaBuilder<T : Any, DEF : YawnTableDef<T, T>>(
         )
 
         return Pair(totalResults, entities)
-    }
-
-    inline fun doPaginated(
-        pageSize: Int,
-        orders: List<DEF.() -> YawnQueryOrder<T>>,
-        action: (List<T>) -> Unit,
-    ) {
-        // only apply the orders once
-        applyOrders(orders)
-
-        var pageNumber = 0
-        do {
-            val results = listPaginatedZeroIndexed(pageNumber++, pageSize, listOf())
-            action(results)
-        } while (results.size == pageSize)
     }
 
     fun rowCount(): Long {


### PR DESCRIPTION
We currently have some inconsistency / duplication of paginated related functions (notably `listPaginatedZeroIndexed` and `doPaginated`) between `ProjectedTypeSafeCriteriaBuilder` and `TypeSafeCriteriaBuilder`.

These functions are entirely projection-agnostic and should have the exact same implementation (and API) for both projected and non-projected queries. So I am centralizing them on the superclass.

No this should be entirely no-op in terms of implementation and user-facing API.