### PR TITLE
feat: Hoist listBatched to BaseTypeSafeCriteriaBuilde

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
@@ -146,6 +146,19 @@ abstract class BaseTypeSafeCriteriaBuilder<
         } while (results.size == pageSize)
     }
 
+    fun listBatched(
+        batchSize: Int,
+        orders: List<DEF.() -> YawnQueryOrder<T>>,
+    ): List<RETURNS> {
+        val results = mutableListOf<RETURNS>()
+        doPaginated(
+            pageSize = batchSize,
+            orders = orders,
+            action = { results.addAll(it) },
+        )
+        return results
+    }
+
     fun applyOrders(orders: List<DEF.() -> YawnQueryOrder<T>>): CRITERIA {
         query.orders.addAll(orders.map { it(tableDef) })
         return builderReturn()

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/TypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/TypeSafeCriteriaBuilder.kt
@@ -62,19 +62,6 @@ class TypeSafeCriteriaBuilder<T : Any, DEF : YawnTableDef<T, T>>(
         return ProjectedTypeSafeCriteriaBuilder.create(tableDef, queryFactory, query, lambda)
     }
 
-    fun listBatched(
-        batchSize: Int,
-        orders: List<DEF.() -> YawnQueryOrder<T>>,
-    ): List<T> {
-        val results = mutableListOf<T>()
-        doPaginated(
-            pageSize = batchSize,
-            orders = orders,
-            action = { results.addAll(it) },
-        )
-        return results
-    }
-
     fun countDistinct(
         uniqueColumn: DEF.() -> YawnTableDef<T, *>.ColumnDef<*>,
     ): Long {

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnPaginationQueriesTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnPaginationQueriesTest.kt
@@ -165,7 +165,7 @@ internal class YawnPaginationQueriesTest : BaseYawnDatabaseTest() {
     }
 
     @Test
-    fun `listing with batched`() {
+    fun `list batched`() {
         transactor.open { session ->
             val results = session.query(BookTable).listBatched(
                 batchSize = 2,
@@ -173,6 +173,27 @@ internal class YawnPaginationQueriesTest : BaseYawnDatabaseTest() {
             )
 
             assertThat(results.map { it.name }).containsExactly(
+                "Harry Potter",
+                "Lord of the Rings",
+                "The Emperor's New Clothes",
+                "The Hobbit",
+                "The Little Mermaid",
+                "The Ugly Duckling",
+            )
+        }
+    }
+
+    @Test
+    fun `list batched - projection`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                project(books.name)
+            }.listBatched(
+                batchSize = 2,
+                orders = listOf { YawnQueryOrder.asc(name) },
+            )
+
+            assertThat(results).containsExactly(
                 "Harry Potter",
                 "Lord of the Rings",
                 "The Emperor's New Clothes",


### PR DESCRIPTION
Now that `doPaginated` (& crew) are available in `BaseTypeSafeCriteriaBuilder`, there is no reason we can't support `listBatched` for projections as well.

This is a first step into potentially providing https://github.com/Faire/yawn/issues/59 in the future.