### PR TITLE
feat: Add missing overloads for `and` and `or` operators plus tests

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithWhere.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/TypeSafeCriteriaWithWhere.kt
@@ -175,8 +175,20 @@ sealed interface TypeSafeCriteriaWithWhere<SOURCE : Any, T : Any> {
         add(YawnRestrictions.or(*predicates))
     }
 
+    fun addOr(predicates: List<YawnQueryCriterion<SOURCE>>) {
+        add(YawnRestrictions.or(predicates))
+    }
+
+    fun addAnd(lhs: YawnQueryCriterion<SOURCE>, rhs: YawnQueryCriterion<SOURCE>) {
+        add(YawnRestrictions.and(lhs, rhs))
+    }
+
     fun addAnd(vararg predicates: YawnQueryCriterion<SOURCE>) {
         add(YawnRestrictions.and(*predicates))
+    }
+
+    fun addAnd(predicates: List<YawnQueryCriterion<SOURCE>>) {
+        add(YawnRestrictions.and(predicates))
     }
 
     fun <F> addNotEq(

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnRestrictions.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnRestrictions.kt
@@ -141,8 +141,16 @@ object YawnRestrictions {
         return YawnQueryCriterion(Or(*criterion))
     }
 
+    fun <SOURCE : Any> or(criteria: List<YawnQueryCriterion<SOURCE>>): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(Or(criteria))
+    }
+
     fun <SOURCE : Any> and(vararg criterion: YawnQueryCriterion<SOURCE>): YawnQueryCriterion<SOURCE> {
         return YawnQueryCriterion(And(*criterion))
+    }
+
+    fun <SOURCE : Any> and(criteria: List<YawnQueryCriterion<SOURCE>>): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(And(criteria))
     }
 
     fun <SOURCE : Any, F : String?> like(


### PR DESCRIPTION
Fixes https://github.com/Faire/yawn/issues/54

Also adding missing tests for every single code path (tests are a bit convoluted, I am open to suggestions to making them more systematic).