### PR TITLE
chore: Remove jdbc from custom dictionaries as it was added upstream

### DIFF
--- a/.github/.cspell/library.dictionary.txt
+++ b/.github/.cspell/library.dictionary.txt
@@ -6,7 +6,6 @@ foojay # github.com/gradle/foojay-toolchains
 gson # github.com/google/gson
 guice # github.com/google/guice
 javax # part of the Java SDK
-jdbc # Java Database Connectivity
 kotlinpoet # github.com/square/kotlinpoet
 stdlib # the standard library of a programming language
 testkit # part of github.com/Nava2/gradle-plugin-better-testing


### PR DESCRIPTION
`JDBC` was likely added upstream to cspell, making our custom dictionary entry redundant (and failing our strict build). Hurray!