### PR TITLE
chore: Update dokka to mitigate memory issues

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.10"
 ksp = "2.0.10-1.0.24"
-dokka = "1.9.20"
+dokka = "2.1.0"
 hibernate = "5.6.15.Final"
 javax-persistence = "2.2"
 google-auto-service = "1.1.1"


### PR DESCRIPTION
Dokka [is taking unreasonable amounts of time and often failing with OOMs](https://github.com/Faire/yawn/issues/90) to generate the docs for such a simple project.

Looking on their GitHub repo, I found evidence that issues have been mitigated on 2.x+ versions; this PR is trying this theory out.