### PR TITLE
feat: Add mapResults to PaginationResult

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/pagination/PaginationResult.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/pagination/PaginationResult.kt
@@ -5,9 +5,11 @@ data class PaginationResult<T : Any>(
     val results: List<T>,
     val page: Page,
 ) {
-    fun <R : Any> map(mapper: (T) -> R): PaginationResult<R> = PaginationResult(
+    fun <R : Any> map(mapper: (T) -> R): PaginationResult<R> = mapResults { results.map(mapper) }
+
+    fun <R : Any> mapResults(mapper: (List<T>) -> List<R>): PaginationResult<R> = PaginationResult(
         totalResults = totalResults,
-        results = results.map(mapper),
+        results = mapper(results),
         page = page,
     )
 

--- a/yawn-api/src/test/kotlin/com/faire/yawn/pagination/PaginationResultTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/pagination/PaginationResultTest.kt
@@ -26,6 +26,13 @@ internal class PaginationResultTest {
             assertThat(page.pageNumber.zeroIndexedPageNumber).isEqualTo(0)
             assertThat(page.pageSize).isEqualTo(10)
         }
+
+        with(result.mapResults { results -> results.filter { it % 2 == 0 } }) {
+            assertThat(totalResults).isEqualTo(100)
+            assertThat(results).containsExactly(0, 2, 4, 6, 8)
+            assertThat(page.pageNumber.zeroIndexedPageNumber).isEqualTo(0)
+            assertThat(page.pageSize).isEqualTo(10)
+        }
     }
 
     @Test


### PR DESCRIPTION
This was extracted from the version on backend, keeps both of them in line for ease of replacement.

NOTE: as per our existing impl, this DOES NOT update the page size or any page computations. We mostly use it to batch process the list. To make a simple "couldn't do it with the other one" test, I opted to use a filter. I know that particular usage is potentially problematic depending on intent. Happy to change the test or consider alternatives.