### PR TITLE
feat: Introduce YawnProjections.mapping

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
@@ -291,6 +291,47 @@ object YawnProjections {
     ): YawnQueryProjection<SOURCE, Triple<A, B, C>> {
         return TripleProjection(firstProjection, secondProjection, thirdProjection)
     }
+
+    /**
+     * Provides an in-memory transformation over a column value to a different type.
+     * Use this when using more complex data classes as projections to apply minor
+     * type or value compliance transformations to database column values
+     * while keeping your projection classes type-safe, without needing to use
+     * intermediary representations.
+     * NOTE: this _does not_ change the query and is post-processed in memory.
+     */
+    fun <SOURCE : Any, FROM, TO> mapping(
+        column: YawnQueryProjection<SOURCE, FROM>,
+        transform: (FROM) -> TO,
+    ): YawnQueryProjection<SOURCE, TO> {
+        return object : YawnQueryProjection<SOURCE, TO> {
+            override fun compile(context: YawnCompilationContext): Projection = column.compile(context)
+
+            @Suppress("UNCHECKED_CAST")
+            override fun project(value: Any?): TO = transform(column.project(value))
+        }
+    }
+
+    /**
+     * A 2-arity version of the [mapping] method.
+     */
+    fun <SOURCE : Any, C1, C2, TO> mapping(
+        column1: YawnQueryProjection<SOURCE, C1>,
+        column2: YawnQueryProjection<SOURCE, C2>,
+        transform: (C1, C2) -> TO,
+    ): YawnQueryProjection<SOURCE, TO> {
+        return object : YawnQueryProjection<SOURCE, TO> {
+            override fun compile(context: YawnCompilationContext): Projection {
+                return Projections.projectionList()
+                    .add(column1.compile(context))
+                    .add(column2.compile(context))
+            }
+
+            override fun project(value: Any?): TO {
+                return transform(column1.project(value), column2.project(value))
+            }
+        }
+    }
 }
 
 private const val CONSTANT_ALIAS = "_yawn_ct"

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
@@ -1,6 +1,7 @@
 package com.faire.yawn.project
 
 import com.faire.yawn.YawnDef
+import com.faire.yawn.project.YawnProjections.mapping
 import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
 import org.hibernate.criterion.Projections
@@ -240,20 +241,9 @@ object YawnProjections {
     }
 
     internal class PairProjection<SOURCE : Any, A : Any?, B : Any?>(
-        private val firstProjection: YawnQueryProjection<SOURCE, A>,
-        private val secondProjection: YawnQueryProjection<SOURCE, B>,
-    ) : YawnQueryProjection<SOURCE, Pair<A, B>> {
-        override fun compile(context: YawnCompilationContext): Projection {
-            return Projections.projectionList()
-                .add(firstProjection.compile(context))
-                .add(secondProjection.compile(context))
-        }
-
-        override fun project(value: Any?): Pair<A, B> {
-            val queryResult = value as Array<*>
-            return Pair(firstProjection.project(queryResult[0]), secondProjection.project(queryResult[1]))
-        }
-    }
+        firstProjection: YawnQueryProjection<SOURCE, A>,
+        secondProjection: YawnQueryProjection<SOURCE, B>,
+    ) : Mapping2Projection<SOURCE, A, B, Pair<A, B>>(firstProjection, secondProjection, { a, b -> Pair(a, b) })
 
     fun <SOURCE : Any, A : Any?, B : Any?> pair(
         firstProjection: YawnQueryProjection<SOURCE, A>,
@@ -263,26 +253,15 @@ object YawnProjections {
     }
 
     internal class TripleProjection<SOURCE : Any, A : Any?, B : Any?, C : Any?>(
-        private val firstProjection: YawnQueryProjection<SOURCE, A>,
-        private val secondProjection: YawnQueryProjection<SOURCE, B>,
-        private val thirdProjection: YawnQueryProjection<SOURCE, C>,
-    ) : YawnQueryProjection<SOURCE, Triple<A, B, C>> {
-        override fun compile(context: YawnCompilationContext): Projection {
-            return Projections.projectionList()
-                .add(firstProjection.compile(context))
-                .add(secondProjection.compile(context))
-                .add(thirdProjection.compile(context))
-        }
-
-        override fun project(value: Any?): Triple<A, B, C> {
-            val queryResult = value as Array<*>
-            return Triple(
-                firstProjection.project(queryResult[0]),
-                secondProjection.project(queryResult[1]),
-                thirdProjection.project(queryResult[2]),
-            )
-        }
-    }
+        firstProjection: YawnQueryProjection<SOURCE, A>,
+        secondProjection: YawnQueryProjection<SOURCE, B>,
+        thirdProjection: YawnQueryProjection<SOURCE, C>,
+    ) : Mapping3Projection<SOURCE, A, B, C, Triple<A, B, C>>(
+        firstProjection,
+        secondProjection,
+        thirdProjection,
+        { a, b, c -> Triple(a, b, c) },
+    )
 
     fun <SOURCE : Any, A : Any?, B : Any?, C : Any?> triple(
         firstProjection: YawnQueryProjection<SOURCE, A>,
@@ -304,12 +283,7 @@ object YawnProjections {
         column: YawnQueryProjection<SOURCE, FROM>,
         transform: (FROM) -> TO,
     ): YawnQueryProjection<SOURCE, TO> {
-        return object : YawnQueryProjection<SOURCE, TO> {
-            override fun compile(context: YawnCompilationContext): Projection = column.compile(context)
-
-            @Suppress("UNCHECKED_CAST")
-            override fun project(value: Any?): TO = transform(column.project(value))
-        }
+        return Mapping1Projection(column, transform)
     }
 
     /**
@@ -320,16 +294,55 @@ object YawnProjections {
         column2: YawnQueryProjection<SOURCE, C2>,
         transform: (C1, C2) -> TO,
     ): YawnQueryProjection<SOURCE, TO> {
-        return object : YawnQueryProjection<SOURCE, TO> {
-            override fun compile(context: YawnCompilationContext): Projection {
-                return Projections.projectionList()
-                    .add(column1.compile(context))
-                    .add(column2.compile(context))
-            }
+        return Mapping2Projection(column1, column2, transform)
+    }
 
-            override fun project(value: Any?): TO {
-                return transform(column1.project(value), column2.project(value))
-            }
+    internal open class Mapping1Projection<SOURCE : Any, FROM, TO>(
+        private val column: YawnQueryProjection<SOURCE, FROM>,
+        private val transform: (FROM) -> TO,
+    ) : YawnQueryProjection<SOURCE, TO> {
+        override fun compile(context: YawnCompilationContext): Projection = column.compile(context)
+
+        override fun project(value: Any?): TO = transform(column.project(value))
+    }
+
+    internal open class Mapping2Projection<SOURCE : Any, C1, C2, TO>(
+        private val column1: YawnQueryProjection<SOURCE, C1>,
+        private val column2: YawnQueryProjection<SOURCE, C2>,
+        private val transform: (C1, C2) -> TO,
+    ) : YawnQueryProjection<SOURCE, TO> {
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.projectionList()
+                .add(column1.compile(context))
+                .add(column2.compile(context))
+        }
+
+        override fun project(value: Any?): TO {
+            val queryResult = value as Array<*>
+            return transform(column1.project(queryResult[0]), column2.project(queryResult[1]))
+        }
+    }
+
+    internal open class Mapping3Projection<SOURCE : Any, C1, C2, C3, TO>(
+        private val column1: YawnQueryProjection<SOURCE, C1>,
+        private val column2: YawnQueryProjection<SOURCE, C2>,
+        private val column3: YawnQueryProjection<SOURCE, C3>,
+        private val transform: (C1, C2, C3) -> TO,
+    ) : YawnQueryProjection<SOURCE, TO> {
+        override fun compile(context: YawnCompilationContext): Projection {
+            return Projections.projectionList()
+                .add(column1.compile(context))
+                .add(column2.compile(context))
+                .add(column3.compile(context))
+        }
+
+        override fun project(value: Any?): TO {
+            val queryResult = value as Array<*>
+            return transform(
+                column1.project(queryResult[0]),
+                column2.project(queryResult[1]),
+                column3.project(queryResult[2]),
+            )
         }
     }
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionMappingTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionMappingTest.kt
@@ -1,0 +1,38 @@
+package com.faire.yawn.database
+
+import com.faire.yawn.project.YawnProjection
+import com.faire.yawn.project.YawnProjections
+import com.faire.yawn.setup.entities.BookTable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class YawnProjectionMappingTest : BaseYawnDatabaseTest() {
+    @Test
+    fun `yawn query with projection`() {
+        transactor.open { session ->
+            val hobbit = session.project(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+                val authors = join(books.author)
+                project(
+                    YawnProjectionMappingTest_BookNameAndNotesProjection.create(
+                        uppercaseTitle = YawnProjections.mapping(books.name) { it.uppercase() },
+                        authorNotes = YawnProjections.mapping(authors.name, books.notes) { author, notes ->
+                            "$author says: $notes"
+                        },
+                    ),
+                )
+            }.uniqueResult()
+
+            with(hobbit!!) {
+                assertThat(uppercaseTitle).isEqualTo("THE HOBBIT")
+                assertThat(authorNotes).isEqualTo("J.R.R. Tolkien says: J.R.R. Tolkien")
+            }
+        }
+    }
+
+    @YawnProjection
+    internal data class BookNameAndNotes(
+        val uppercaseTitle: String,
+        val authorNotes: String,
+    )
+}


### PR DESCRIPTION
Sometimes we might want to have slightly more type-safe projection classes that are based on some minor transformation from the actual column types. Examples might include:

* combining one or two columns into a standardized data class used elsewhere in the codebase
* applying minimal in-memory processing to the values of certain columns
* compatibilizing a projection data-class that might be used on more than one query from different sources

While this could be accomplished by a two-step approach (i.e. have the projection match the exact database column types and then have a second data class and the appropriate wrappers), for some use cases that is cumbersome and unnecessarily boilerplate-y.

This adds a `YawnProjection.mapping` function (3 arities available) that performs an in-memory post-processing to a projection value. This does not change the SQL query, but just uses Yawn's strong type system to apply the transformation in-memory before building the resulting object.

This also makes other projections cleaner; `pair`, `triple`, and `coalesce` are now defined in terms of it.