### PR TITLE
feat: Enhanced projection handling - new types

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/AggregateKind.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/AggregateKind.kt
@@ -1,0 +1,15 @@
+package com.faire.yawn.project
+
+/**
+ * The kind of aggregate or grouping projection to apply.
+ * Each kind maps to a specific SQL aggregation or clause.
+ */
+enum class AggregateKind {
+    COUNT,
+    COUNT_DISTINCT,
+    SUM,
+    AVG,
+    MIN,
+    MAX,
+    GROUP_BY,
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ModifierKind.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ModifierKind.kt
@@ -1,0 +1,8 @@
+package com.faire.yawn.project
+
+/**
+ * The kind of modifier to wrap around a [ProjectionLeaf].
+ */
+enum class ModifierKind {
+    DISTINCT,
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
@@ -1,0 +1,60 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.YawnDef
+import kotlin.reflect.KClass
+
+/**
+ * An ORM-agnostic descriptor of a single atomic projection.
+ *
+ * Leaves are the terminal elements that produce actual SQL in the compiled query projection tree.
+ * The Query Factory is responsible for converting each leaf to the underlying ORM's implementation projection.
+ *
+ * Leaf deduplication uses data class equality: two [Property] leaves with the same [YawnDef.YawnColumnDef]
+ * reference, or two [Aggregate] leaves with the same [AggregateKind] and column, are considered identical
+ * and will share an index in the re-packed result list.
+ */
+sealed interface ProjectionLeaf<SOURCE : Any> {
+    /**
+     * A simple column property access (SQL: `alias.column`).
+     */
+    data class Property<SOURCE : Any>(
+        val column: YawnDef<SOURCE, *>.YawnColumnDef<*>,
+    ) : ProjectionLeaf<SOURCE>
+
+    /**
+     * An aggregate or grouping projection on a column (SQL: `SUM(alias.column)`, `GROUP BY alias.column`, etc.).
+     */
+    data class Aggregate<SOURCE : Any>(
+        val kind: AggregateKind,
+        val column: YawnDef<SOURCE, *>.YawnColumnDef<*>,
+    ) : ProjectionLeaf<SOURCE>
+
+    /**
+     * A row count projection (SQL: `COUNT(*)`).
+     */
+    class RowCount<SOURCE : Any> : ProjectionLeaf<SOURCE> {
+        override fun equals(other: Any?): Boolean = other is RowCount<*>
+        override fun hashCode(): Int = RowCount::class.hashCode()
+    }
+
+    /**
+     * A raw SQL projection for custom expressions.
+     *
+     * The [sqlExpression] may use `{alias}` placeholders for table alias substitution.
+     * [resultTypes] are used by the query factory to map SQL results to Kotlin types.
+     * It is up to the user to guarantee type-safety when using raw SQL projections!
+     */
+    data class Sql<SOURCE : Any>(
+        val sqlExpression: String,
+        val aliases: List<String>,
+        val resultTypes: List<KClass<*>>,
+    ) : ProjectionLeaf<SOURCE>
+
+    /**
+     * Wraps another leaf with a SQL modifier (e.g. DISTINCT).
+     */
+    data class Modifier<SOURCE : Any>(
+        val kind: ModifierKind,
+        val inner: ProjectionLeaf<SOURCE>,
+    ) : ProjectionLeaf<SOURCE>
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionMapper.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionMapper.kt
@@ -8,6 +8,6 @@ package com.faire.yawn.project
  * You should never need to implement this directly; use the simple lambdas pointing to [ProjectionNode.Value],
  * [ProjectionNode.Composite], or [ProjectionNode.Mapped].
  */
-fun interface ProjectionMapper<TO> {
+internal fun interface ProjectionMapper<TO> {
     fun map(results: List<Any?>): TO
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionMapper.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionMapper.kt
@@ -1,0 +1,13 @@
+package com.faire.yawn.project
+
+/**
+ * Maps a raw result row (as a list of values corresponding to resolved projection leaves)
+ * into the desired projection type.
+ *
+ * This is an internal type produced by the [ProjectorResolver] resolution engine.
+ * You should never need to implement this directly; use the simple lambdas pointing to [ProjectionNode.Value],
+ * [ProjectionNode.Composite], or [ProjectionNode.Mapped].
+ */
+fun interface ProjectionMapper<TO> {
+    fun map(results: List<Any?>): TO
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionNode.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionNode.kt
@@ -1,0 +1,112 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.YawnDef
+
+/**
+ * A declarative description of a projection's structure.
+ *
+ * The [ProjectorResolver] resolution engine walks this tree to produce a flat [ResolvedProjection].
+ * There are four variants:
+ * * [Value]: a single leaf projection (column, aggregate, SQL, etc.). Only Values will survive resolution.
+ * * [Composite]: a grouping of multiple children with a mapper. Flattened during resolution.
+ * * [Constant]: a fixed value, with no corresponding SQL. Eliminated during resolution.
+ * * [Mapped]: wraps another projection with an in-memory transformation. Eliminated during resolution.
+ */
+sealed interface ProjectionNode<SOURCE : Any, TO> {
+    /**
+     * A single leaf projection that maps to one slot in the SQL result.
+     *
+     * @param leaf the ORM-agnostic projection descriptor.
+     * @param mapper transforms the raw SQL value to the desired type. Defaults to a simple unchecked cast.
+     */
+    data class Value<SOURCE : Any, TO>(
+        val leaf: ProjectionLeaf<SOURCE>,
+        val mapper: (Any?) -> TO = {
+            @Suppress("UNCHECKED_CAST")
+            it as TO
+        },
+    ) : ProjectionNode<SOURCE, TO>
+
+    /**
+     * Groups multiple child projections and combines their results with a mapper.
+     *
+     * During resolution, composites are recursively flattened: their children's leaves are added to
+     * the parent's flat list, and the mapper is composed to reconstruct the grouped result.
+     */
+    data class Composite<SOURCE : Any, TO>(
+        val children: List<YawnProjector<SOURCE, *>>,
+        val mapper: (List<Any?>) -> TO,
+    ) : ProjectionNode<SOURCE, TO>
+
+    /**
+     * A constant value that requires no SQL. Eliminated during resolution.
+     */
+    data class Constant<SOURCE : Any, TO>(
+        val value: TO,
+    ) : ProjectionNode<SOURCE, TO>
+
+    /**
+     * Wraps another projection with a post-query transform. Eliminated during resolution;
+     * the transform is folded into the composed mapper.
+     */
+    data class Mapped<SOURCE : Any, FROM, TO>(
+        val from: YawnProjector<SOURCE, FROM>,
+        val transform: (FROM) -> TO,
+    ) : ProjectionNode<SOURCE, TO>
+
+    companion object {
+        fun <SOURCE : Any, TO> property(
+            column: YawnDef<SOURCE, *>.YawnColumnDef<TO>,
+        ): Value<SOURCE, TO> = Value(ProjectionLeaf.Property(column))
+
+        fun <SOURCE : Any, TO> aggregate(
+            kind: AggregateKind,
+            column: YawnDef<SOURCE, *>.YawnColumnDef<TO>,
+        ): Value<SOURCE, TO> = Value(ProjectionLeaf.Aggregate(kind, column))
+
+        fun <SOURCE : Any, TO> aggregateAs(
+            kind: AggregateKind,
+            column: YawnDef<SOURCE, *>.YawnColumnDef<*>,
+        ): Value<SOURCE, TO> = Value(ProjectionLeaf.Aggregate(kind, column))
+
+        fun <SOURCE : Any> rowCount(): Value<SOURCE, Long> =
+            Value(ProjectionLeaf.RowCount())
+
+        fun <SOURCE : Any, TO> sql(
+            sqlExpression: String,
+            aliases: List<String>,
+            resultTypes: List<kotlin.reflect.KClass<*>>,
+        ): Value<SOURCE, TO> = Value(ProjectionLeaf.Sql(sqlExpression, aliases, resultTypes))
+
+        fun <SOURCE : Any, TO> constant(value: TO): Constant<SOURCE, TO> = Constant(value)
+
+        fun <SOURCE : Any, FROM, TO> mapped(
+            from: YawnProjector<SOURCE, FROM>,
+            transform: (FROM) -> TO,
+        ): Mapped<SOURCE, FROM, TO> = Mapped(from, transform)
+
+        fun <SOURCE : Any, A, B, R> composite(
+            a: YawnProjector<SOURCE, A>,
+            b: YawnProjector<SOURCE, B>,
+            mapper: (A, B) -> R,
+        ): Composite<SOURCE, R> = Composite(listOf(a, b)) { values ->
+            @Suppress("UNCHECKED_CAST")
+            mapper(values[0] as A, values[1] as B)
+        }
+
+        fun <SOURCE : Any, A, B, C, R> composite(
+            a: YawnProjector<SOURCE, A>,
+            b: YawnProjector<SOURCE, B>,
+            c: YawnProjector<SOURCE, C>,
+            mapper: (A, B, C) -> R,
+        ): Composite<SOURCE, R> = Composite(listOf(a, b, c)) { values ->
+            @Suppress("UNCHECKED_CAST")
+            mapper(values[0] as A, values[1] as B, values[2] as C)
+        }
+
+        fun <SOURCE : Any, R> composite(
+            children: List<YawnProjector<SOURCE, *>>,
+            mapper: (List<Any?>) -> R,
+        ): Composite<SOURCE, R> = Composite(children, mapper)
+    }
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectorResolver.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectorResolver.kt
@@ -1,0 +1,53 @@
+package com.faire.yawn.project
+
+/**
+ * Yawn's projection resolution engine, which allows for complex nested projection arrangements that are then
+ * flattened into an ORM-friendly node structure.
+ *
+ * Walks a [ProjectionNode] tree and produces a [ResolvedProjection] by:
+ * - Flattening [ProjectionNode.Composite] nodes (their children become top-level)
+ * - Eliminating [ProjectionNode.Constant] nodes (no SQL, value folded into mapper)
+ * - Eliminating [ProjectionNode.Mapped] nodes (transform folded into mapper)
+ * - Keeping [ProjectionNode.Value] nodes in a flat list
+ * - Deduplicating identical [ProjectionLeaf] instances (same leaf shares an index)
+ * - Composing a [ProjectionMapper] that reconstructs the full result from the flat list
+ */
+class ProjectorResolver<SOURCE : Any> {
+    private val nodes = mutableListOf<ProjectionNode.Value<SOURCE, *>>()
+    private val dedupedLeafsToIndices = mutableMapOf<ProjectionLeaf<SOURCE>, Int>()
+
+    /**
+     * Resolves a [YawnProjector] into a [ResolvedProjection].
+     */
+    fun <TO> resolve(projector: YawnProjector<SOURCE, TO>): ResolvedProjection<SOURCE, TO> {
+        val mapper = resolveNode(projector.projection())
+        return DefaultResolvedProjection(nodes.toList(), mapper)
+    }
+
+    private fun <TO> resolveNode(node: ProjectionNode<SOURCE, TO>): ProjectionMapper<TO> {
+        return when (node) {
+            is ProjectionNode.Value -> resolveValue(node)
+            is ProjectionNode.Composite -> resolveComposite(node)
+            is ProjectionNode.Constant -> ProjectionMapper { node.value }
+            is ProjectionNode.Mapped<SOURCE, *, TO> -> resolveMapped(node)
+        }
+    }
+
+    private fun <TO> resolveValue(node: ProjectionNode.Value<SOURCE, TO>): ProjectionMapper<TO> {
+        val idx = dedupedLeafsToIndices.getOrPut(node.leaf) {
+            nodes.add(node)
+            nodes.size - 1
+        }
+        return ProjectionMapper { results -> node.mapper(results[idx]) }
+    }
+
+    private fun <TO> resolveComposite(node: ProjectionNode.Composite<SOURCE, TO>): ProjectionMapper<TO> {
+        val childMappers = node.children.map { resolveNode(it.projection()) }
+        return ProjectionMapper { results -> node.mapper(childMappers.map { it.map(results) }) }
+    }
+
+    private fun <FROM, TO> resolveMapped(node: ProjectionNode.Mapped<SOURCE, FROM, TO>): ProjectionMapper<TO> {
+        val innerMapper = resolveNode(node.from.projection())
+        return ProjectionMapper { results -> node.transform(innerMapper.map(results)) }
+    }
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjection.kt
@@ -1,0 +1,35 @@
+package com.faire.yawn.project
+
+/**
+ * The result of resolving a [YawnProjector] through the [ProjectorResolver] engine.
+ *
+ * Contains a flat list of [ProjectionNode.Value] nodes (all composites, constants, and mapped
+ * transforms have been eliminated) and a function to map a result row back to the desired type.
+ *
+ * This interface is ORM-agnostic. The Query Factory is the one responsible for:
+ * - Compiling each node's [ProjectionLeaf] to the underlying implementation projection type;
+ * - Normalizing the ORM result row into a `List<Any?>` matching the order of [nodes];
+ * - Calling [mapRow] to reconstruct the projected type.
+ */
+interface ResolvedProjection<SOURCE : Any, TO> {
+    /**
+     * The flat, deduped, re-ordered list of value nodes to compile into the query.
+     * The query factory must compile them _in this order_, and result values
+     * must be provided at matching indices when calling [mapRow].
+     */
+    val nodes: List<ProjectionNode.Value<SOURCE, *>>
+
+    /**
+     * Maps a raw result row to the projected type.
+     *
+     * @param values raw results in the same order as [nodes].
+     */
+    fun mapRow(values: List<Any?>): TO
+}
+
+internal class DefaultResolvedProjection<SOURCE : Any, TO>(
+    override val nodes: List<ProjectionNode.Value<SOURCE, *>>,
+    private val mapper: ProjectionMapper<TO>,
+) : ResolvedProjection<SOURCE, TO> {
+    override fun mapRow(values: List<Any?>): TO = mapper.map(values)
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjector.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjector.kt
@@ -1,0 +1,28 @@
+package com.faire.yawn.project
+
+/**
+ * A type-safe projection descriptor that can be resolved into a flat list of
+ * [ProjectionNode.Value] nodes for query compilation.
+ *
+ * Implementations describe the shape of a projection by returning a [ProjectionNode]
+ * from [projection]. The [ProjectorResolver] resolution engine then walks this tree,
+ * flattening composites, eliminating constants and mapped transforms, deduplicating
+ * identical leaves, and producing a [ResolvedProjection] that the query factory can compile.
+ *
+ * @param SOURCE the type of the entity being queried.
+ * @param TO the result type of this projection.
+ */
+fun interface YawnProjector<SOURCE : Any, TO> {
+    fun projection(): ProjectionNode<SOURCE, TO>
+}
+
+/**
+ * A [YawnProjector] that is guaranteed to produce a [ProjectionNode.Value].
+ *
+ * This subtype exists mostly so that modifiers like distinct can enforce at compile time
+ * that they only wrap single-value projections, not composites. But it can be used for other
+ * contexts as needed.
+ */
+fun interface YawnValueProjector<SOURCE : Any, TO> : YawnProjector<SOURCE, TO> {
+    override fun projection(): ProjectionNode.Value<SOURCE, TO>
+}

--- a/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
@@ -1,0 +1,378 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.YawnDef
+import com.faire.yawn.project.AggregateKind.AVG
+import com.faire.yawn.project.AggregateKind.COUNT
+import com.faire.yawn.project.AggregateKind.COUNT_DISTINCT
+import com.faire.yawn.project.AggregateKind.GROUP_BY
+import com.faire.yawn.project.AggregateKind.MAX
+import com.faire.yawn.project.AggregateKind.MIN
+import com.faire.yawn.project.AggregateKind.SUM
+import com.faire.yawn.project.ModifierKind.DISTINCT
+import com.faire.yawn.query.YawnCompilationContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class ProjectorResolverTest {
+    private val def = TestDef()
+    private val nameCol = def.column<String>("name")
+    private val nullableNameCol = def.column<String?>("name")
+    private val pagesCol = def.column<Long>("pages")
+    private val authorCol = def.column<String>("author")
+    private val ratingCol = def.column<Double>("rating")
+    private val revenueCol = def.column<Long>("revenue")
+
+    @Test
+    fun `single value projection`() {
+        val projector = YawnValueProjector {
+            ProjectionNode.property(nameCol)
+        }
+
+        val resolved = resolve(projector)
+
+        val leaf = resolved.nodes.single().leaf as ProjectionLeaf.Property
+        assertThat(leaf.column).isEqualTo(nameCol)
+
+        assertThat(resolveAndMap(projector, "The Hobbit")).isEqualTo("The Hobbit")
+    }
+
+    @Test
+    fun `aggregate value projection`() {
+        val projector = YawnValueProjector {
+            ProjectionNode.aggregate(MIN, ratingCol)
+        }
+
+        val resolved = resolve(projector)
+
+        val leaf = resolved.nodes.single().leaf as ProjectionLeaf.Aggregate
+        assertThat(leaf.kind).isEqualTo(MIN)
+
+        assertThat(resolveAndMap(projector, 3.5)).isEqualTo(3.5)
+    }
+
+    @Test
+    fun `constant projection produces no nodes`() {
+        val projector = YawnProjector<Any, String?> {
+            ProjectionNode.constant(null)
+        }
+
+        val resolved = resolve(projector)
+        assertThat(resolved.nodes).isEmpty()
+        assertThat(resolved.mapRow(listOf())).isNull()
+    }
+
+    @Test
+    fun `constant with non-null value`() {
+        val projector = YawnProjector {
+            ProjectionNode.constant("hello")
+        }
+
+        val resolved = resolve(projector)
+        assertThat(resolved.nodes).isEmpty()
+        assertThat(resolved.mapRow(listOf())).isEqualTo("hello")
+    }
+
+    @Test
+    fun `mapped projection folds transform into mapper`() {
+        val inner = YawnValueProjector {
+            ProjectionNode.property(nullableNameCol)
+        }
+        val projector = YawnProjector {
+            ProjectionNode.mapped(inner) { it ?: "default" }
+        }
+
+        val resolved = resolve(projector)
+        assertThat(resolved.nodes).hasSize(1) // mapped is eliminated, only the inner value remains
+
+        assertThat(resolved.mapRow(listOf("present"))).isEqualTo("present")
+        assertThat(resolved.mapRow(listOf(null))).isEqualTo("default")
+    }
+
+    @Test
+    fun `pair composite flattens into two nodes`() {
+        val projector = YawnProjector {
+            ProjectionNode.composite(
+                YawnValueProjector { ProjectionNode.property(nameCol) },
+                YawnValueProjector { ProjectionNode.aggregate(SUM, pagesCol) },
+            ) { a, b -> Pair(a, b) }
+        }
+
+        val resolved = resolve(projector)
+        assertThat(resolved.nodes).hasSize(2)
+
+        val result = resolved.mapRow(listOf("The Hobbit", 1_300L))
+        assertThat(result).isEqualTo("The Hobbit" to 1_300L)
+    }
+
+    @Test
+    fun `triple composite flattens into three nodes`() {
+        val projector = YawnProjector {
+            ProjectionNode.composite(
+                YawnValueProjector { ProjectionNode.property(nameCol) },
+                YawnValueProjector { ProjectionNode.property(authorCol) },
+                YawnValueProjector { ProjectionNode.aggregate(SUM, pagesCol) },
+            ) { a, b, c -> Triple(a, b, c) }
+        }
+
+        val resolved = resolve(projector)
+        assertThat(resolved.nodes).hasSize(3)
+
+        val result = resolved.mapRow(listOf("The Hobbit", "Tolkien", 300L))
+        assertThat(result).isEqualTo(Triple("The Hobbit", "Tolkien", 300L))
+    }
+
+    @Test
+    fun `deduplication of identical leaves`() {
+        val projector = YawnProjector {
+            ProjectionNode.composite(
+                YawnValueProjector { ProjectionNode.aggregate(SUM, revenueCol) },
+                YawnValueProjector { ProjectionNode.aggregate(SUM, revenueCol) },
+            ) { a, b -> Pair(a, b) }
+        }
+
+        val resolved = resolve(projector)
+        assertThat(resolved.nodes).hasSize(1) // deduplicated!
+
+        val result = resolved.mapRow(listOf(50_000L))
+        assertThat(result).isEqualTo(50_000L to 50_000L) // both fields get the same value
+    }
+
+    @Test
+    fun `different kinds on same column are NOT deduplicated`() {
+        val projector = YawnProjector {
+            ProjectionNode.composite(
+                YawnValueProjector { ProjectionNode.aggregate(COUNT_DISTINCT, pagesCol) },
+                YawnValueProjector { ProjectionNode.aggregate(COUNT, pagesCol) },
+            ) { a, b -> Pair(a, b) }
+        }
+
+        val resolved = resolve(projector)
+
+        // different kinds => different leaves
+        assertThat(resolved.nodes).hasSize(2)
+    }
+
+    @Test
+    fun `modifier wraps leaf`() {
+        val projector = YawnValueProjector {
+            val from = ProjectionNode.property(authorCol)
+            ProjectionNode.Value(ProjectionLeaf.Modifier(DISTINCT, from.leaf), from.mapper)
+        }
+
+        val resolved = resolve(projector)
+
+        val leaf = resolved.nodes.single().leaf as ProjectionLeaf.Modifier
+        assertThat(leaf.kind).isEqualTo(DISTINCT)
+        assertThat(leaf.inner).isEqualTo(ProjectionLeaf.Property(authorCol))
+
+        assertThat(resolved.mapRow(listOf("Tolkien"))).isEqualTo("Tolkien")
+    }
+
+    @Test
+    fun `row count projection`() {
+        val projector = YawnValueProjector {
+            ProjectionNode.rowCount()
+        }
+
+        val resolved = resolve(projector)
+
+        val leaf = resolved.nodes.single().leaf
+        assertThat(leaf).isInstanceOf(ProjectionLeaf.RowCount::class.java)
+
+        assertThat(resolved.mapRow(listOf(42L))).isEqualTo(42L)
+    }
+
+    @Test
+    fun `3-level nested composites with deduplication`() {
+        val projector = YawnProjector {
+            ProjectionNode.composite(
+                listOf(
+                    // publisherName: groupBy
+                    YawnValueProjector {
+                        ProjectionNode.aggregate(GROUP_BY, nameCol)
+                    },
+                    // topAuthorStats: nested composite
+                    YawnProjector {
+                        ProjectionNode.composite(
+                            // authorInfo: pair(distinct(author), count(pages))
+                            {
+                                ProjectionNode.composite(
+                                    YawnValueProjector<Any, String> {
+                                        ProjectionNode.Value(
+                                            ProjectionLeaf.Modifier(DISTINCT, ProjectionLeaf.Property(authorCol)),
+                                        )
+                                    },
+                                    YawnValueProjector<Any, Long> {
+                                        ProjectionNode.aggregateAs(COUNT, pagesCol)
+                                    },
+                                ) { a, b -> Pair(a, b) }
+                            },
+                            // pageStats: pair(avg(pages), max(pages))
+                            {
+                                ProjectionNode.composite(
+                                    YawnValueProjector<Any, Double> {
+                                        ProjectionNode.aggregateAs(AVG, pagesCol)
+                                    },
+                                    YawnValueProjector {
+                                        ProjectionNode.aggregate(MAX, pagesCol)
+                                    },
+                                ) { a, b -> Pair(a, b) }
+                            },
+                        ) { authorInfo, pageStats ->
+                            AuthorSummary(
+                                authorInfo = authorInfo,
+                                pageStats = pageStats,
+                            )
+                        }
+                    },
+                    // totalRevenue: sum(revenue)
+                    YawnValueProjector {
+                        ProjectionNode.aggregate(SUM, revenueCol)
+                    },
+                    // totalRevenueCheck: sum(revenue) (duplicate)
+                    YawnValueProjector {
+                        ProjectionNode.aggregate(SUM, revenueCol)
+                    },
+                ),
+            ) { values ->
+                @Suppress("UNCHECKED_CAST")
+                PublisherReport(
+                    publisherName = values[0] as String,
+                    topAuthorStats = values[1] as AuthorSummary,
+                    totalRevenue = values[2] as Long,
+                    totalRevenueCheck = values[3] as Long,
+                )
+            }
+        }
+
+        val resolved = resolve(projector)
+
+        // Verify flat node list: 6 unique leaves (SUM(revenue) deduped)
+        assertThat(resolved.nodes).hasSize(6)
+
+        // Verify node types in order
+        assertThat(resolved.nodes[0].leaf).isEqualTo(ProjectionLeaf.Aggregate(GROUP_BY, nameCol))
+        assertThat(resolved.nodes[1].leaf)
+            .isEqualTo(ProjectionLeaf.Modifier(DISTINCT, ProjectionLeaf.Property(authorCol)))
+        assertThat(resolved.nodes[2].leaf).isEqualTo(ProjectionLeaf.Aggregate(COUNT, pagesCol))
+        assertThat(resolved.nodes[3].leaf).isEqualTo(ProjectionLeaf.Aggregate(AVG, pagesCol))
+        assertThat(resolved.nodes[4].leaf).isEqualTo(ProjectionLeaf.Aggregate(MAX, pagesCol))
+        assertThat(resolved.nodes[5].leaf).isEqualTo(ProjectionLeaf.Aggregate(SUM, revenueCol))
+
+        // Verify result mapping with mock data
+        val result = resolved.mapRow(
+            listOf("Penguin", "Tolkien", 5L, 320.0, 1_000L, 50_000L),
+        )
+        assertThat(result).isEqualTo(
+            PublisherReport(
+                publisherName = "Penguin",
+                topAuthorStats = AuthorSummary(
+                    authorInfo = "Tolkien" to 5L,
+                    pageStats = 320.0 to 1_000L,
+                ),
+                totalRevenue = 50_000L,
+                totalRevenueCheck = 50_000L, // same value from deduplicated index
+            ),
+        )
+    }
+
+    @Test
+    fun `composite with constants and mapped produces minimal nodes`() {
+        val nullablePagesCol = def.column<Long?>("pages")
+        val projector = YawnProjector {
+            ProjectionNode.composite(
+                // real column
+                YawnValueProjector { ProjectionNode.property(nameCol) },
+                // null constant; no SQL
+                { ProjectionNode.constant(null) },
+                // coalesce (mapped) wrapping a column; one SQL column
+                {
+                    ProjectionNode.mapped(
+                        YawnValueProjector {
+                            ProjectionNode.property(nullablePagesCol)
+                        },
+                    ) { it ?: 0L }
+                },
+            ) { a, b, c -> Triple(a, b, c) }
+        }
+
+        val resolved = resolve(projector)
+
+        assertThat(resolved.nodes).hasSize(2) // only the two real columns
+
+        val result = resolved.mapRow(listOf("The Hobbit", null))
+        assertThat(result).isEqualTo(Triple("The Hobbit", null, 0L)) // coalesce applied, constant is null
+    }
+
+    @Test
+    fun `deeply nested mapped chains are all eliminated`() {
+        val projector = YawnProjector {
+            ProjectionNode.mapped(
+                {
+                    ProjectionNode.mapped(
+                        {
+                            ProjectionNode.mapped(
+                                YawnValueProjector { ProjectionNode.property(nameCol) },
+                            ) { it.lowercase() }
+                        },
+                    ) { it.trim() }
+                },
+            ) { it.uppercase() }
+        }
+
+        val resolved = resolve(projector)
+
+        assertThat(resolved.nodes).hasSize(1) // all mapped layers eliminated
+
+        val result = resolved.mapRow(listOf("  Hello World  "))
+        // Transforms applied inside-out: lowercase -> trim -> uppercase
+        assertThat(result).isEqualTo("HELLO WORLD")
+    }
+
+    @Test
+    fun `sql leaf projection`() {
+        val projector = YawnValueProjector<Any, Long> {
+            ProjectionNode.sql(
+                sqlExpression = "LENGTH({alias}.name) AS name_length",
+                aliases = listOf("name_length"),
+                resultTypes = listOf(Long::class),
+            )
+        }
+
+        val resolved = resolve(projector)
+
+        val leaf = resolved.nodes.single().leaf as ProjectionLeaf.Sql
+        assertThat(leaf.sqlExpression).isEqualTo("LENGTH({alias}.name) AS name_length")
+
+        assertThat(resolved.mapRow(listOf(10L))).isEqualTo(10L)
+    }
+
+    data class AuthorSummary(
+        val authorInfo: Pair<String, Long>,
+        val pageStats: Pair<Double, Long>,
+    )
+
+    data class PublisherReport(
+        val publisherName: String,
+        val topAuthorStats: AuthorSummary,
+        val totalRevenue: Long,
+        val totalRevenueCheck: Long,
+    )
+
+    private class TestDef : YawnDef<Any, Any>() {
+        fun <T> column(name: String): YawnColumnDef<T> = TestColumnDef(name)
+
+        private inner class TestColumnDef<T>(private val name: String) : YawnColumnDef<T>() {
+            override fun generatePath(context: YawnCompilationContext): String = name
+            override fun toString(): String = "col($name)"
+        }
+    }
+
+    private fun <TO> resolve(projector: YawnProjector<Any, TO>): ResolvedProjection<Any, TO> =
+        ProjectorResolver<Any>().resolve(projector)
+
+    private fun <TO> resolveAndMap(projector: YawnProjector<Any, TO>, vararg values: Any?): TO {
+        val resolved = resolve(projector)
+        return resolved.mapRow(listOf(*values))
+    }
+}


### PR DESCRIPTION
I am redesigning our projection infra! This will be a relatively big change, so I am attempting to split this the best as possible to facilitate review (and migration). I will go over the translation plan below.

# Design Goals

My design goals:

* fully decouple projections from Hibernate
* move handling of projection collection, parsing, deduping and indexing to Yawn core and out of projection definitions and query factories
* support nested groupings!

# Current Problem

Let me go into some detail for the later - what actually current breaks and the limitations of how we do things (other than the coupling).

Let's see how hibernate works first for context when using nested projections. As a simple example, consider this nested double projection list:

```
      val result = session.session.createCriteria(Book::class.java)
          .setProjection(
              Projections.projectionList()
                  .add(Projections.property("name"))
                  .add(
                      Projections.projectionList()
                          .add(Projections.property("numberOfPages"))
                          .add(Projections.property("originalLanguage")),
                  ),
          )
          .list()
          .first() as Array<*>
```

You might think that this will result in a `[name, [pages, language]]` array, but it doesn't. Since this translates to a list of sql clauses, hibernate returns `[name, pages, language]`.

That breaks yawn's current implementation which would expect the former. The current projections are unaware of this flattening. the following test will break when trying to cast the string pages into an array of [pages, language].

```
    @Test
    fun `pairs will not work inside projection classes`() {
        val result = transactor.open { session ->
            session.project(BookTable) { books ->
                val authors = join(books.author)
                addEq(authors.name, "J.K. Rowling")
                val notes = addIsNotNull(books.notes)
                project(
                    YawnProjectionTest_ProjectionWithPairProjection.create(
                        name = books.name,
                        authorAndNotes = YawnProjections.pair(authors.name, notes),
                    ),
                )
            }.uniqueResult()!!
        }

        assertThat(result.name).isEqualTo("Harry Potter")
        assertThat(result.authorAndNotes.first).isEqualTo("J.K. Rowling")
        assertThat(result.authorAndNotes.second).isEqualTo("Note for The Hobbit and Harry")
    }

    @YawnProjection
    internal data class ProjectionWithPair(
        val name: String,
        val authorAndNotes: Pair<String, String>,
    )
```

This is not only impactful for contrived examples, but blocks us from having transformations as well. A very simple example is `YawnProjections.mapping` that I wanted to add; you can see [how the test is incorrect due to me copy and pasting the output](https://github.com/Faire/yawn/pull/115/changes#diff-9e6fbfe0bd2ade48ba878f55dc960a49c836c7368820189a3b2fbaf3d641bb84R28).

The whole reason is that yawn doesn't know the indices of where projection columns will go. We also ran into this when I added the "constant" projection. as you can [see in the impl](https://github.com/Faire/yawn/blob/main/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt#L189), it has to add a sentinel to the hibernate projection list that is actually added to the sql query for no reason other than appeasing the indexing management. that constant could be entirely populated in memory by yawn on the resulting object instead.

In a way, we will be taking over and re-implementing part of hibernate. we will never do nested projectionLists(), and always send the simplest possible set of flattened projections to hibernate. all nesting, mapping, and transforming is resolved by yawn.

# A Bright New Future

With all that in mind, I am proposing a bold new structure; the `YawnQueryProjection` is broken into two parts:

* `YawnProjector` is what column defs, data class projections and custom projections on `YawnProjections` implement. they are not project-ions, they are project-ors, that _can_ be projected to a `ProjectionNode`. they do _not_ do the actual projecting, they define how to do it. this is what you compose to make your projection node tree
* when you call `project()` now it actually _does_ something -> it will convert the projection node tree into a resolved projection. this actually does a lot of heavy lifting: it will flatten groups, collect value nodes, de-dupe, re-index and store a final list of projections to send to hibernate (or the ORM), and is able to then re-collect the result in order to generate the final object after the code is run.

That is the basic structure plus some niceties. Hopefully this first PR will make it more clear. The following will add a compatibility adapter so that we can try out the new structure within the framework of the old one on our internal repos.

# Migration Path

My proposed migration path is as follows: merge PRs (1) and (2) which are entirely net-new and release a version. Test it out at small scale on our internal repos by using the "adapt" method. That goes through the whole tree parsing and the most complicated parts but still uses the v1 query factory. that will be the first test. note that the ergonomics for the adapt method are clunky (you can see on PR (2)), but that is because you have to explicitly create the projectors. the actual end user facing api will be _identical_ in the end. and the actual definitions of specific typed projections, column def and data-class-projections will be _simpler_. once we have sufficiently tested v2, we can update `YawnProjectionts` to hook up v2 by default, and then remove the adapt method.