### PR TITLE
fix: Fix ClassCastException loading @JvmInline classes

### DIFF
--- a/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithCrossModuleValueClass.kt
+++ b/yawn-integration-test/src/main/kotlin/com/faire/yawn/EntityWithCrossModuleValueClass.kt
@@ -1,0 +1,27 @@
+package com.faire.yawn
+
+import com.faire.yawn.pagination.PageNumber
+import javax.persistence.Column
+import javax.persistence.Id
+
+/**
+ * Test entity that uses a [PageNumber] field — a [@JvmInline value class][JvmInline] defined in
+ * the [yawn-api] module, which is a binary dependency of this module.
+ *
+ * This entity exists to verify that Yawn's KSP processor correctly generates value-class adapters
+ * for cross-module value-class types (i.e. types that are not in the current compilation unit).
+ */
+@YawnEntity
+internal class EntityWithCrossModuleValueClass {
+    @Id
+    var id: Long = 0
+        protected set
+
+    /**
+     * Cross-module @JvmInline value class from yawn-api.
+     * The KSP processor must generate an adapter that unwraps [PageNumber] to its underlying [Int]
+     * before Hibernate binds the parameter.
+     */
+    @Column
+    var pageNumber: PageNumber? = null
+}

--- a/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityProcessorTest.kt
+++ b/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityProcessorTest.kt
@@ -3,7 +3,9 @@ package com.faire.yawn
 import com.faire.yawn.YawnTestUtils.YawnTestAssertContext.SOURCE
 import com.faire.yawn.YawnTestUtils.assertGeneratedEntity
 import com.faire.yawn.inheritance.ChildInheritanceEntity
+import com.faire.yawn.pagination.PageNumber
 import com.faire.yawn.utils.FakeToken
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import javax.persistence.Transient
 import kotlin.reflect.KVisibility
@@ -118,5 +120,31 @@ internal class YawnEntityProcessorTest {
                     >,
                 >("enums")
         }
+    }
+
+    /**
+     * Regression test for cross-module @JvmInline value class columns.
+     *
+     * In KSP2, [com.google.devtools.ksp.symbol.Modifier.VALUE] is not always present in
+     * [com.google.devtools.ksp.symbol.KSClassDeclaration.modifiers] for value classes loaded
+     * from binary (compiled) dependencies. This caused Yawn's KSP processor to skip adapter
+     * generation for such columns, resulting in a ClassCastException at runtime when Hibernate
+     * tried to bind the boxed value-class object as its underlying type.
+     *
+     * The fix is to also check for the [@JvmInline] annotation, which is reliably retained in
+     * binary class files.
+     */
+    @Test
+    fun `generates value-class adapter for cross-module @JvmInline column`() {
+        assertGeneratedEntity<EntityWithCrossModuleValueClass> {
+            hasTableColumn<EntityWithCrossModuleValueClass, PageNumber?>("pageNumber")
+        }
+
+        // Verify the adapter actually unwraps the value class to its underlying Int.
+        // Without the fix the adapter is absent and adaptValue returns the boxed PageNumber
+        // object, which would cause a ClassCastException when Hibernate tries to bind it.
+        val tableDef = EntityWithCrossModuleValueClassTableDef<Any>(YawnTableDefParent.RootTableDefParent)
+        val adapted = tableDef.pageNumber.adaptValue(PageNumber.zeroIndexed(42))
+        assertThat(adapted).isEqualTo(42)
     }
 }

--- a/yawn-processor/src/main/kotlin/com/faire/yawn/util/KspSymbolExtensions.kt
+++ b/yawn-processor/src/main/kotlin/com/faire/yawn/util/KspSymbolExtensions.kt
@@ -27,6 +27,7 @@ import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.Transient
+import kotlin.jvm.JvmInline
 
 internal fun KSPropertyDeclaration.isTransient(): Boolean {
     return isAnnotationPresent<Transient>()
@@ -163,6 +164,16 @@ internal fun KSClassDeclaration.isConstructorProperty(property: KSPropertyDeclar
         ?: false
 }
 
+/**
+ * Returns true if this type is a Kotlin value class.
+ *
+ * This checks both [Modifier.VALUE] (reliable for source symbols in the current compilation unit)
+ * and the [JvmInline] annotation (reliable for binary symbols from external dependencies).
+ * The dual check is necessary because KSP2 does not always include [Modifier.VALUE] in
+ * [com.google.devtools.ksp.symbol.KSClassDeclaration.modifiers] for classes loaded from
+ * binary (compiled) dependencies.
+ */
 internal fun KSType.isValueClass(): Boolean {
-    return declaration is KSClassDeclaration && Modifier.VALUE in declaration.modifiers
+    val classDecl = declaration as? KSClassDeclaration ?: return false
+    return Modifier.VALUE in classDecl.modifiers || classDecl.isAnnotationPresent<JvmInline>()
 }


### PR DESCRIPTION
In my project using KSP 2.2.20, I'm seeing `ClassCastException` when hibernate tries to convert a string to an inline class. My investigation with Claude suggests this is related to the newer KSP version, specifically that the new version does not include `Modifier.VALUE` in declaration.modifiers.

The fix is to also check for the `@JvmInline` annotation on the type.

I was able to verify this fixed the issue in my project by doing a local publish, and updating my project to use that local version.