### PR TITLE
feat: Add YawnComparison enum to yawn-api

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnComparison.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnComparison.kt
@@ -1,0 +1,17 @@
+package com.faire.yawn.query
+
+import com.faire.yawn.YawnDef
+
+enum class YawnComparison {
+    LT, LE, GT, GE;
+
+    fun <SOURCE : Any, F> compare(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        value: F,
+    ): YawnQueryCriterion<SOURCE> = when (this) {
+        LT -> YawnRestrictions.lt(column, value)
+        LE -> YawnRestrictions.le(column, value)
+        GT -> YawnRestrictions.gt(column, value)
+        GE -> YawnRestrictions.ge(column, value)
+    }
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnComparison.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnComparison.kt
@@ -7,7 +7,7 @@ enum class YawnComparison {
 
     fun <SOURCE : Any, F> compare(
         column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-        value: F,
+        value: F & Any,
     ): YawnQueryCriterion<SOURCE> = when (this) {
         LT -> YawnRestrictions.lt(column, value)
         LE -> YawnRestrictions.le(column, value)

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnComparison.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnComparison.kt
@@ -3,12 +3,13 @@ package com.faire.yawn.query
 import com.faire.yawn.YawnDef
 
 enum class YawnComparison {
-    LT, LE, GT, GE;
+    EQ, LT, LE, GT, GE;
 
     fun <SOURCE : Any, F> compare(
         column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
         value: F & Any,
     ): YawnQueryCriterion<SOURCE> = when (this) {
+        EQ -> YawnRestrictions.eq(column, value)
         LT -> YawnRestrictions.lt(column, value)
         LE -> YawnRestrictions.le(column, value)
         GT -> YawnRestrictions.gt(column, value)

--- a/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
@@ -1,0 +1,63 @@
+package com.faire.yawn.query
+
+import com.faire.yawn.YawnTableDef
+import com.faire.yawn.YawnTableDefParent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class YawnComparisonTest {
+
+    private object TestDef : YawnTableDef<TestEntity, TestEntity>(YawnTableDefParent.RootTableDefParent) {
+        val amount: ColumnDef<Int> = ColumnDef("amount")
+    }
+
+    private class TestEntity
+
+    @Test
+    fun `LT delegates to YawnRestrictions lt`() {
+        val criterion = YawnComparison.LT.compare(TestDef.amount, 10)
+        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.LessThan::class.java)
+    }
+
+    @Test
+    fun `LE delegates to YawnRestrictions le`() {
+        val criterion = YawnComparison.LE.compare(TestDef.amount, 10)
+        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
+    }
+
+    @Test
+    fun `GT delegates to YawnRestrictions gt`() {
+        val criterion = YawnComparison.GT.compare(TestDef.amount, 10)
+        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.GreaterThan::class.java)
+    }
+
+    @Test
+    fun `GE delegates to YawnRestrictions ge`() {
+        val criterion = YawnComparison.GE.compare(TestDef.amount, 10)
+        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.GreaterThanOrEqualTo::class.java)
+    }
+
+    @Test
+    fun `compare produces same restriction type as calling YawnRestrictions directly`() {
+        for (comparison in YawnComparison.entries) {
+            val fromEnum = comparison.compare(TestDef.amount, 42)
+            val fromRestrictions = when (comparison) {
+                YawnComparison.LT -> YawnRestrictions.lt(TestDef.amount, 42)
+                YawnComparison.LE -> YawnRestrictions.le(TestDef.amount, 42)
+                YawnComparison.GT -> YawnRestrictions.gt(TestDef.amount, 42)
+                YawnComparison.GE -> YawnRestrictions.ge(TestDef.amount, 42)
+            }
+            assertThat(fromEnum.yawnRestriction::class).isEqualTo(fromRestrictions.yawnRestriction::class)
+        }
+    }
+
+    @Test
+    fun `all four comparison variants are present`() {
+        assertThat(YawnComparison.entries).containsExactly(
+            YawnComparison.LT,
+            YawnComparison.LE,
+            YawnComparison.GT,
+            YawnComparison.GE,
+        )
+    }
+}

--- a/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
@@ -14,6 +14,12 @@ internal class YawnComparisonTest {
     private class TestEntity
 
     @Test
+    fun `EQ delegates to YawnRestrictions eq`() {
+        val criterion = YawnComparison.EQ.compare(TestDef.amount, 10)
+        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.Equals::class.java)
+    }
+
+    @Test
     fun `LT delegates to YawnRestrictions lt`() {
         val criterion = YawnComparison.LT.compare(TestDef.amount, 10)
         assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.LessThan::class.java)
@@ -42,6 +48,7 @@ internal class YawnComparisonTest {
         for (comparison in YawnComparison.entries) {
             val fromEnum = comparison.compare(TestDef.amount, 42)
             val fromRestrictions = when (comparison) {
+                YawnComparison.EQ -> YawnRestrictions.eq(TestDef.amount, 42)
                 YawnComparison.LT -> YawnRestrictions.lt(TestDef.amount, 42)
                 YawnComparison.LE -> YawnRestrictions.le(TestDef.amount, 42)
                 YawnComparison.GT -> YawnRestrictions.gt(TestDef.amount, 42)
@@ -52,8 +59,9 @@ internal class YawnComparisonTest {
     }
 
     @Test
-    fun `all four comparison variants are present`() {
+    fun `all five comparison variants are present`() {
         assertThat(YawnComparison.entries).containsExactly(
+            YawnComparison.EQ,
             YawnComparison.LT,
             YawnComparison.LE,
             YawnComparison.GT,

--- a/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
@@ -20,58 +20,45 @@ internal class YawnComparisonTest {
         val itemCount: ColumnDef<Long> = ColumnDef("item_count")
     }
 
-    /**
-     * A helper that applies the same comparison to columns of different types.
-     * This is the pattern YawnComparison enables: F is resolved independently
-     * at each compare() call site, so a single comparison value works across
-     * ColumnDef<Int>, ColumnDef<String>, and ColumnDef<Long>.
-     *
-     * This cannot be expressed with a Kotlin function type parameter like
-     * `(YawnDef<SOURCE, *>.YawnColumnDef<F>, F & Any) -> YawnQueryCriterion<SOURCE>`
-     * because F would have to be fixed for the entire function signature.
-     */
-    private fun buildOrderCriteria(
-        comparison: YawnComparison,
-        amount: Int,
-        createdAt: String,
-        itemCount: Long,
-    ): List<YawnQueryCriterion<OrderEntity>> {
-        return listOf(
-            comparison.compare(OrderDef.amount, amount),
-            comparison.compare(OrderDef.createdAt, createdAt),
-            comparison.compare(OrderDef.itemCount, itemCount),
-        )
-    }
-
     @Test
     fun `same comparison applies to columns of different types`() {
-        val criteria = buildOrderCriteria(
+        val (amountCriterion, createdAtCriterion, itemCountCriterion) = buildOrderCriteria(
             comparison = YawnComparison.LE,
             amount = 100,
             createdAt = "2026-01-01",
             itemCount = 50L,
         )
 
-        assertThat(criteria).hasSize(3)
-        assertThat(criteria).allSatisfy { criterion ->
-            assertThat(criterion.yawnRestriction)
-                .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
-        }
+        assertThat(amountCriterion.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
+        assertThat(createdAtCriterion.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
+        assertThat(itemCountCriterion.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
     }
 
     @Test
     fun `switching comparison changes all generated restrictions`() {
-        val leCriteria = buildOrderCriteria(YawnComparison.LE, 100, "2026-01-01", 50L)
-        val gtCriteria = buildOrderCriteria(YawnComparison.GT, 100, "2026-01-01", 50L)
+        val (leAmount, leCreatedAt, leItemCount) = buildOrderCriteria(
+            YawnComparison.LE, 100, "2026-01-01", 50L,
+        )
+        val (gtAmount, gtCreatedAt, gtItemCount) = buildOrderCriteria(
+            YawnComparison.GT, 100, "2026-01-01", 50L,
+        )
 
-        assertThat(leCriteria).allSatisfy { criterion ->
-            assertThat(criterion.yawnRestriction)
-                .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
-        }
-        assertThat(gtCriteria).allSatisfy { criterion ->
-            assertThat(criterion.yawnRestriction)
-                .isInstanceOf(YawnQueryRestriction.GreaterThan::class.java)
-        }
+        assertThat(leAmount.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
+        assertThat(leCreatedAt.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
+        assertThat(leItemCount.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
+
+        assertThat(gtAmount.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.GreaterThan::class.java)
+        assertThat(gtCreatedAt.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.GreaterThan::class.java)
+        assertThat(gtItemCount.yawnRestriction)
+            .isInstanceOf(YawnQueryRestriction.GreaterThan::class.java)
     }
 
     @Test
@@ -100,6 +87,29 @@ internal class YawnComparisonTest {
             YawnComparison.LE,
             YawnComparison.GT,
             YawnComparison.GE,
+        )
+    }
+
+    /**
+     * A helper that applies the same comparison to columns of different types.
+     * This is the pattern YawnComparison enables: F is resolved independently
+     * at each compare() call site, so a single comparison value works across
+     * ColumnDef<Int>, ColumnDef<String>, and ColumnDef<Long>.
+     *
+     * This cannot be expressed with a Kotlin function type parameter like
+     * `(YawnDef<SOURCE, *>.YawnColumnDef<F>, F & Any) -> YawnQueryCriterion<SOURCE>`
+     * because F would have to be fixed for the entire function signature.
+     */
+    private fun buildOrderCriteria(
+        comparison: YawnComparison,
+        amount: Int,
+        createdAt: String,
+        itemCount: Long,
+    ): Triple<YawnQueryCriterion<OrderEntity>, YawnQueryCriterion<OrderEntity>, YawnQueryCriterion<OrderEntity>> {
+        return Triple(
+            comparison.compare(OrderDef.amount, amount),
+            comparison.compare(OrderDef.createdAt, createdAt),
+            comparison.compare(OrderDef.itemCount, itemCount),
         )
     }
 }

--- a/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
@@ -7,59 +7,93 @@ import org.junit.jupiter.api.Test
 
 internal class YawnComparisonTest {
 
-    private object TestDef : YawnTableDef<TestEntity, TestEntity>(YawnTableDefParent.RootTableDefParent) {
+    private class OrderEntity
+
+    /**
+     * Simulates a table with columns of different types — the scenario where
+     * you can't pass YawnRestrictions::le as a function parameter because F
+     * is invariant and would need to unify across Int, String, and Long.
+     */
+    private object OrderDef : YawnTableDef<OrderEntity, OrderEntity>(YawnTableDefParent.RootTableDefParent) {
         val amount: ColumnDef<Int> = ColumnDef("amount")
+        val createdAt: ColumnDef<String> = ColumnDef("created_at")
+        val itemCount: ColumnDef<Long> = ColumnDef("item_count")
     }
 
-    private class TestEntity
-
-    @Test
-    fun `EQ delegates to YawnRestrictions eq`() {
-        val criterion = YawnComparison.EQ.compare(TestDef.amount, 10)
-        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.Equals::class.java)
-    }
-
-    @Test
-    fun `LT delegates to YawnRestrictions lt`() {
-        val criterion = YawnComparison.LT.compare(TestDef.amount, 10)
-        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.LessThan::class.java)
-    }
-
-    @Test
-    fun `LE delegates to YawnRestrictions le`() {
-        val criterion = YawnComparison.LE.compare(TestDef.amount, 10)
-        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
-    }
-
-    @Test
-    fun `GT delegates to YawnRestrictions gt`() {
-        val criterion = YawnComparison.GT.compare(TestDef.amount, 10)
-        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.GreaterThan::class.java)
-    }
-
-    @Test
-    fun `GE delegates to YawnRestrictions ge`() {
-        val criterion = YawnComparison.GE.compare(TestDef.amount, 10)
-        assertThat(criterion.yawnRestriction).isInstanceOf(YawnQueryRestriction.GreaterThanOrEqualTo::class.java)
+    /**
+     * A helper that applies the same comparison to columns of different types.
+     * This is the pattern YawnComparison enables: F is resolved independently
+     * at each compare() call site, so a single comparison value works across
+     * ColumnDef<Int>, ColumnDef<String>, and ColumnDef<Long>.
+     *
+     * This cannot be expressed with a Kotlin function type parameter like
+     * `(YawnDef<SOURCE, *>.YawnColumnDef<F>, F & Any) -> YawnQueryCriterion<SOURCE>`
+     * because F would have to be fixed for the entire function signature.
+     */
+    private fun buildOrderCriteria(
+        comparison: YawnComparison,
+        amount: Int,
+        createdAt: String,
+        itemCount: Long,
+    ): List<YawnQueryCriterion<OrderEntity>> {
+        return listOf(
+            comparison.compare(OrderDef.amount, amount),
+            comparison.compare(OrderDef.createdAt, createdAt),
+            comparison.compare(OrderDef.itemCount, itemCount),
+        )
     }
 
     @Test
-    fun `compare produces same restriction type as calling YawnRestrictions directly`() {
-        for (comparison in YawnComparison.entries) {
-            val fromEnum = comparison.compare(TestDef.amount, 42)
-            val fromRestrictions = when (comparison) {
-                YawnComparison.EQ -> YawnRestrictions.eq(TestDef.amount, 42)
-                YawnComparison.LT -> YawnRestrictions.lt(TestDef.amount, 42)
-                YawnComparison.LE -> YawnRestrictions.le(TestDef.amount, 42)
-                YawnComparison.GT -> YawnRestrictions.gt(TestDef.amount, 42)
-                YawnComparison.GE -> YawnRestrictions.ge(TestDef.amount, 42)
-            }
-            assertThat(fromEnum.yawnRestriction::class).isEqualTo(fromRestrictions.yawnRestriction::class)
+    fun `same comparison applies to columns of different types`() {
+        val criteria = buildOrderCriteria(
+            comparison = YawnComparison.LE,
+            amount = 100,
+            createdAt = "2026-01-01",
+            itemCount = 50L,
+        )
+
+        assertThat(criteria).hasSize(3)
+        assertThat(criteria).allSatisfy { criterion ->
+            assertThat(criterion.yawnRestriction)
+                .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
         }
     }
 
     @Test
-    fun `all five comparison variants are present`() {
+    fun `switching comparison changes all generated restrictions`() {
+        val leCriteria = buildOrderCriteria(YawnComparison.LE, 100, "2026-01-01", 50L)
+        val gtCriteria = buildOrderCriteria(YawnComparison.GT, 100, "2026-01-01", 50L)
+
+        assertThat(leCriteria).allSatisfy { criterion ->
+            assertThat(criterion.yawnRestriction)
+                .isInstanceOf(YawnQueryRestriction.LessThanOrEqualTo::class.java)
+        }
+        assertThat(gtCriteria).allSatisfy { criterion ->
+            assertThat(criterion.yawnRestriction)
+                .isInstanceOf(YawnQueryRestriction.GreaterThan::class.java)
+        }
+    }
+
+    @Test
+    fun `each variant produces the expected restriction type`() {
+        val expected = mapOf(
+            YawnComparison.EQ to YawnQueryRestriction.Equals::class.java,
+            YawnComparison.LT to YawnQueryRestriction.LessThan::class.java,
+            YawnComparison.LE to YawnQueryRestriction.LessThanOrEqualTo::class.java,
+            YawnComparison.GT to YawnQueryRestriction.GreaterThan::class.java,
+            YawnComparison.GE to YawnQueryRestriction.GreaterThanOrEqualTo::class.java,
+        )
+
+        for ((comparison, restrictionClass) in expected) {
+            val criterion = comparison.compare(OrderDef.amount, 42)
+            assertThat(criterion.yawnRestriction)
+                .`as`("YawnComparison.%s", comparison.name)
+                .isInstanceOf(restrictionClass)
+        }
+    }
+
+    @Test
+    fun `all comparison variants are present`() {
         assertThat(YawnComparison.entries).containsExactly(
             YawnComparison.EQ,
             YawnComparison.LT,

--- a/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt
@@ -40,10 +40,16 @@ internal class YawnComparisonTest {
     @Test
     fun `switching comparison changes all generated restrictions`() {
         val (leAmount, leCreatedAt, leItemCount) = buildOrderCriteria(
-            YawnComparison.LE, 100, "2026-01-01", 50L,
+            comparison = YawnComparison.LE,
+            amount = 100,
+            createdAt = "2026-01-01",
+            itemCount = 50L,
         )
         val (gtAmount, gtCreatedAt, gtItemCount) = buildOrderCriteria(
-            YawnComparison.GT, 100, "2026-01-01", 50L,
+            comparison = YawnComparison.GT,
+            amount = 100,
+            createdAt = "2026-01-01",
+            itemCount = 50L,
         )
 
         assertThat(leAmount.yawnRestriction)

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnComparisonDatabaseTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnComparisonDatabaseTest.kt
@@ -1,0 +1,124 @@
+package com.faire.yawn.database
+
+import com.faire.yawn.query.YawnComparison
+import com.faire.yawn.setup.entities.BookTable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class YawnComparisonDatabaseTest : BaseYawnDatabaseTest() {
+
+    @Test
+    fun `compare filters books by numberOfPages with LT`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(YawnComparison.LT.compare(books.numberOfPages, 110L))
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("The Little Mermaid")
+        }
+    }
+
+    @Test
+    fun `compare filters books by numberOfPages with LE`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(YawnComparison.LE.compare(books.numberOfPages, 110L))
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "The Little Mermaid",
+                    "The Ugly Duckling",
+                )
+        }
+    }
+
+    @Test
+    fun `compare filters books by numberOfPages with GT`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(YawnComparison.GT.compare(books.numberOfPages, 300L))
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Harry Potter",
+                    "Lord of the Rings",
+                )
+        }
+    }
+
+    @Test
+    fun `compare filters books by name with EQ`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(YawnComparison.EQ.compare(books.name, "The Hobbit"))
+            }.list()
+
+            assertThat(results.single().name).isEqualTo("The Hobbit")
+        }
+    }
+
+    /**
+     * Demonstrates the core use case: a single YawnComparison parameter applied to
+     * columns of different types (Long and String) in the same query. This is impossible
+     * with a Kotlin function reference because F would need to unify across both column types.
+     */
+    @Test
+    fun `same comparison applies to columns of different types in a single query`() {
+        transactor.open { session ->
+            val results = queryBooksFiltered(
+                session,
+                comparison = YawnComparison.GE,
+                pageThreshold = 300L,
+                nameThreshold = "The",
+            )
+
+            assertThat(results).containsExactlyInAnyOrder("The Hobbit")
+        }
+    }
+
+    @Test
+    fun `switching comparison changes query results`() {
+        transactor.open { session ->
+            val leResults = queryBooksFiltered(
+                session,
+                comparison = YawnComparison.LE,
+                pageThreshold = 1000L,
+                nameThreshold = "M",
+            )
+            val gtResults = queryBooksFiltered(
+                session,
+                comparison = YawnComparison.GT,
+                pageThreshold = 1000L,
+                nameThreshold = "M",
+            )
+
+            assertThat(leResults).containsExactlyInAnyOrder(
+                "Harry Potter",
+                "Lord of the Rings",
+            )
+            assertThat(gtResults).isEmpty()
+        }
+    }
+
+    /**
+     * Helper that applies the same comparison to columns of different types (Long and String).
+     * This pattern is what YawnComparison enables — F is resolved independently at each call site.
+     */
+    private fun queryBooksFiltered(
+        session: com.faire.yawn.setup.hibernate.YawnTestSession,
+        comparison: YawnComparison,
+        pageThreshold: Long,
+        nameThreshold: String,
+    ): List<String> {
+        return session.query(BookTable) { books ->
+            add(comparison.compare(books.numberOfPages, pageThreshold))
+            add(comparison.compare(books.name, nameThreshold))
+        }.list().map { it.name }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow up from this backend [PR](https://github.com/Faire/backend/pull/238317), we want to create a way to pass a typesafe comparison operators (EQ, LT, LE, GT, GE) as a parameter in Kotlin.

## Summary

Adds a `YawnComparison` enum to the `com.faire.yawn.query` package in `yawn-api`. This provides a type-safe way to pass comparison operators (EQ, LT, LE, GT, GE) as a parameter, working around Kotlin's lack of higher-rank polymorphism on function types.

## Motivation

When writing helper functions that apply the same comparison operator to multiple columns with different generic types (e.g. `ColumnDef<DateTime>` and `ColumnDef<DateTime?>`), you can't pass `YawnRestrictions::le` directly as a function parameter because `ColumnDef<F>` is invariant in `F` and Kotlin function types require `F` to be fixed. An enum with a generic `compare` method solves this — `F` is resolved independently at each call site.

## Changes

- New file: `yawn-api/src/main/kotlin/com/faire/yawn/query/YawnComparison.kt`
  - `enum class YawnComparison` with variants `EQ`, `LT`, `LE`, `GT`, `GE`
  - Generic `compare` method that delegates to the corresponding `YawnRestrictions` method
  - Placed in the same package as `YawnRestrictions` and `YawnQueryCriterion`
  - Public API for consumers of `yawn-api`
- New file: `yawn-api/src/test/kotlin/com/faire/yawn/query/YawnComparisonTest.kt`
  - Unit tests demonstrating the realistic use case: a helper function that applies the same comparison to columns of different generic types (`Int`, `String`, `Long`)
  - Each column's restriction type is asserted separately for readability
  - Verifies switching the comparison variant changes all generated restrictions
  - Verifies each variant maps to the correct restriction type
  - Verifies all five variants are present
- New file: `yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnComparisonDatabaseTest.kt`
  - Database integration tests using H2 with the BookFixtures dataset
  - Tests each comparison variant (LT, LE, GT, EQ) against real queries
  - Tests applying a single `YawnComparison` to columns of different types (`Long` and `String`) in the same query via a shared helper function
  - Tests that switching the comparison variant changes query results
<!-- CURSOR_AGENT_PR_BODY_END -->

