### PR TITLE
chore!: Remove deprecated pagination methods from BaseTypeSafeCriteriaBuilder

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/BaseTypeSafeCriteriaBuilder.kt
@@ -135,16 +135,6 @@ abstract class BaseTypeSafeCriteriaBuilder<
         return maxResults(1).uniqueResult()
     }
 
-    @Deprecated("Use paginate with Page instead.")
-    fun paginateZeroIndexed(
-        pageNumber: Int,
-        pageSize: Int,
-        orders: List<DEF.() -> YawnQueryOrder<T>>,
-    ): CRITERIA {
-        val page = PageNumber.zeroIndexed(pageNumber) / pageSize
-        return paginate(page, orders)
-    }
-
     fun paginate(
         page: Page,
         orders: List<DEF.() -> YawnQueryOrder<T>>,
@@ -152,16 +142,6 @@ abstract class BaseTypeSafeCriteriaBuilder<
         applyOrders(orders)
         return offset(page.computeOffset())
             .maxResults(page.pageSize)
-    }
-
-    @Deprecated("Use listPaginated with Page instead.")
-    fun listPaginatedZeroIndexed(
-        pageNumber: Int,
-        pageSize: Int,
-        orders: List<DEF.() -> YawnQueryOrder<T>>,
-    ): List<RETURNS> {
-        val page = PageNumber.zeroIndexed(pageNumber) / pageSize
-        return listPaginated(page, orders)
     }
 
     fun listPaginated(


### PR DESCRIPTION
These have been deprecated for a while and have been fully cleaned up from our own internal codebases.
Will remove for next release. The replacements are quite easy to migrate to.