### PR TITLE
feat: Move Modifier as nodes instead of leaves in the new projection pipeline

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ModifierKind.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ModifierKind.kt
@@ -1,7 +1,7 @@
 package com.faire.yawn.project
 
 /**
- * The kind of modifier to wrap around a [ProjectionLeaf].
+ * The kind of modifier to apply to a [ProjectionNode.Modifier].
  */
 enum class ModifierKind {
     DISTINCT,

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
@@ -49,12 +49,4 @@ sealed interface ProjectionLeaf<SOURCE : Any> {
         val aliases: List<String>,
         val resultTypes: List<KClass<*>>,
     ) : ProjectionLeaf<SOURCE>
-
-    /**
-     * Wraps another leaf with a SQL modifier (e.g. DISTINCT).
-     */
-    data class Modifier<SOURCE : Any>(
-        val kind: ModifierKind,
-        val inner: ProjectionLeaf<SOURCE>,
-    ) : ProjectionLeaf<SOURCE>
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionNode.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionNode.kt
@@ -11,6 +11,7 @@ import com.faire.yawn.YawnDef
  * * [Composite]: a grouping of multiple children with a mapper. Flattened during resolution.
  * * [Constant]: a fixed value, with no corresponding SQL. Eliminated during resolution.
  * * [Mapped]: wraps another projection with an in-memory transformation. Eliminated during resolution.
+ * * [Modifier]: passes through any child projection and flags a query-level modifier (e.g. DISTINCT).
  */
 sealed interface ProjectionNode<SOURCE : Any, TO> {
     /**
@@ -52,6 +53,17 @@ sealed interface ProjectionNode<SOURCE : Any, TO> {
     data class Mapped<SOURCE : Any, FROM, TO>(
         val from: YawnProjector<SOURCE, FROM>,
         val transform: (FROM) -> TO,
+    ) : ProjectionNode<SOURCE, TO>
+
+    /**
+     * Passes through any child projection and flags a query-level modifier (e.g. DISTINCT).
+     *
+     * During resolution, the inner projection is resolved normally and the modifier
+     * is hoisted as a flag onto the [ResolvedProjection].
+     */
+    data class Modifier<SOURCE : Any, TO>(
+        val kind: ModifierKind,
+        val inner: YawnProjector<SOURCE, TO>,
     ) : ProjectionNode<SOURCE, TO>
 
     companion object {
@@ -108,5 +120,9 @@ sealed interface ProjectionNode<SOURCE : Any, TO> {
             children: List<YawnProjector<SOURCE, *>>,
             mapper: (List<Any?>) -> R,
         ): Composite<SOURCE, R> = Composite(children, mapper)
+
+        fun <SOURCE : Any, TO> modifier(kind: ModifierKind, inner: YawnProjector<SOURCE, TO>): Modifier<SOURCE, TO> {
+            return Modifier(kind, inner)
+        }
     }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectorResolver.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectorResolver.kt
@@ -15,13 +15,14 @@ package com.faire.yawn.project
 class ProjectorResolver<SOURCE : Any> {
     private val nodes = mutableListOf<ProjectionNode.Value<SOURCE, *>>()
     private val dedupedLeafsToIndices = mutableMapOf<ProjectionLeaf<SOURCE>, Int>()
+    private val modifiers = mutableSetOf<ModifierKind>()
 
     /**
      * Resolves a [YawnProjector] into a [ResolvedProjection].
      */
     fun <TO> resolve(projector: YawnProjector<SOURCE, TO>): ResolvedProjection<SOURCE, TO> {
         val mapper = resolveNode(projector.projection())
-        return DefaultResolvedProjection(nodes.toList(), mapper)
+        return DefaultResolvedProjection(nodes.toList(), mapper, modifiers.toSet())
     }
 
     private fun <TO> resolveNode(node: ProjectionNode<SOURCE, TO>): ProjectionMapper<TO> {
@@ -30,6 +31,7 @@ class ProjectorResolver<SOURCE : Any> {
             is ProjectionNode.Composite -> resolveComposite(node)
             is ProjectionNode.Constant -> ProjectionMapper { node.value }
             is ProjectionNode.Mapped<SOURCE, *, TO> -> resolveMapped(node)
+            is ProjectionNode.Modifier -> resolveModifier(node)
         }
     }
 
@@ -49,5 +51,10 @@ class ProjectorResolver<SOURCE : Any> {
     private fun <FROM, TO> resolveMapped(node: ProjectionNode.Mapped<SOURCE, FROM, TO>): ProjectionMapper<TO> {
         val innerMapper = resolveNode(node.from.projection())
         return ProjectionMapper { results -> node.transform(innerMapper.map(results)) }
+    }
+
+    private fun <TO> resolveModifier(node: ProjectionNode.Modifier<SOURCE, TO>): ProjectionMapper<TO> {
+        modifiers.add(node.kind)
+        return resolveNode(node.inner.projection())
     }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjection.kt
@@ -20,6 +20,11 @@ interface ResolvedProjection<SOURCE : Any, TO> {
     val nodes: List<ProjectionNode.Value<SOURCE, *>>
 
     /**
+     * The set of query-level modifiers (e.g. DISTINCT) that should be applied to the compiled projection.
+     */
+    val modifiers: Set<ModifierKind> get() = setOf()
+
+    /**
      * Maps a raw result row to the projected type.
      *
      * @param values raw results in the same order as [nodes].
@@ -30,6 +35,7 @@ interface ResolvedProjection<SOURCE : Any, TO> {
 internal class DefaultResolvedProjection<SOURCE : Any, TO>(
     override val nodes: List<ProjectionNode.Value<SOURCE, *>>,
     private val mapper: ProjectionMapper<TO>,
+    override val modifiers: Set<ModifierKind> = setOf(),
 ) : ResolvedProjection<SOURCE, TO> {
     override fun mapRow(values: List<Any?>): TO = mapper.map(values)
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
@@ -22,13 +22,19 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
         val nodes = resolved.nodes
         check(nodes.isNotEmpty()) { "Cannot compile an empty projection." }
 
-        if (nodes.size == 1) {
-            return compileLeaf(nodes[0].leaf, context)
+        val projection = if (nodes.size == 1) {
+            compileLeaf(nodes[0].leaf, context)
+        } else {
+            Projections.projectionList().apply {
+                for (node in nodes) {
+                    add(compileLeaf(node.leaf, context))
+                }
+            }
         }
 
-        return Projections.projectionList().apply {
-            for (node in nodes) {
-                add(compileLeaf(node.leaf, context))
+        return resolved.modifiers.fold(projection) { acc, modifier ->
+            when (modifier) {
+                ModifierKind.DISTINCT -> Projections.distinct(acc)
             }
         }
     }
@@ -51,7 +57,6 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
         is ProjectionLeaf.Aggregate -> compileAggregate(leaf, context)
         is ProjectionLeaf.RowCount -> Projections.rowCount()
         is ProjectionLeaf.Sql -> compileSql(leaf)
-        is ProjectionLeaf.Modifier -> compileModifier(leaf, context)
     }
 
     private fun compileAggregate(
@@ -76,13 +81,6 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
             leaf.aliases.toTypedArray(),
             leaf.resultTypes.map { it.toHibernateType() }.toTypedArray(),
         )
-    }
-
-    private fun compileModifier(
-        leaf: ProjectionLeaf.Modifier<SOURCE>,
-        context: YawnCompilationContext,
-    ): Projection = when (leaf.kind) {
-        ModifierKind.DISTINCT -> Projections.distinct(compileLeaf(leaf.inner, context))
     }
 
     companion object {

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjector.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjector.kt
@@ -19,9 +19,7 @@ fun interface YawnProjector<SOURCE : Any, TO> {
 /**
  * A [YawnProjector] that is guaranteed to produce a [ProjectionNode.Value].
  *
- * This subtype exists mostly so that modifiers like distinct can enforce at compile time
- * that they only wrap single-value projections, not composites. But it can be used for other
- * contexts as needed.
+ * Useful as an internal implementation detail for factory methods that produce single-value nodes.
  */
 fun interface YawnValueProjector<SOURCE : Any, TO> : YawnProjector<SOURCE, TO> {
     override fun projection(): ProjectionNode.Value<SOURCE, TO>

--- a/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
@@ -153,17 +153,19 @@ internal class ProjectorResolverTest {
     }
 
     @Test
-    fun `modifier wraps leaf`() {
-        val projector = YawnValueProjector {
-            val from = ProjectionNode.property(authorCol)
-            ProjectionNode.Value(ProjectionLeaf.Modifier(DISTINCT, from.leaf), from.mapper)
+    fun `modifier wraps projection`() {
+        val projector = YawnProjector<Any, String> {
+            ProjectionNode.Modifier(
+                DISTINCT,
+                YawnValueProjector { ProjectionNode.property(authorCol) },
+            )
         }
 
         val resolved = resolve(projector)
 
-        val leaf = resolved.nodes.single().leaf as ProjectionLeaf.Modifier
-        assertThat(leaf.kind).isEqualTo(DISTINCT)
-        assertThat(leaf.inner).isEqualTo(ProjectionLeaf.Property(authorCol))
+        assertThat(resolved.modifiers).containsExactly(DISTINCT)
+        val leaf = resolved.nodes.single().leaf as ProjectionLeaf.Property
+        assertThat(leaf.column).isEqualTo(authorCol)
 
         assertThat(resolved.mapRow(listOf("Tolkien"))).isEqualTo("Tolkien")
     }
@@ -194,18 +196,21 @@ internal class ProjectorResolverTest {
                     // topAuthorStats: nested composite
                     YawnProjector {
                         ProjectionNode.composite(
-                            // authorInfo: pair(distinct(author), count(pages))
+                            // authorInfo: distinct(pair(author, count(pages)))
                             {
-                                ProjectionNode.composite(
-                                    YawnValueProjector<Any, String> {
-                                        ProjectionNode.Value(
-                                            ProjectionLeaf.Modifier(DISTINCT, ProjectionLeaf.Property(authorCol)),
-                                        )
+                                ProjectionNode.modifier(
+                                    DISTINCT,
+                                    YawnProjector {
+                                        ProjectionNode.composite(
+                                            YawnValueProjector<Any, String> {
+                                                ProjectionNode.property(authorCol)
+                                            },
+                                            YawnValueProjector<Any, Long> {
+                                                ProjectionNode.aggregateAs(COUNT, pagesCol)
+                                            },
+                                        ) { a, b -> Pair(a, b) }
                                     },
-                                    YawnValueProjector<Any, Long> {
-                                        ProjectionNode.aggregateAs(COUNT, pagesCol)
-                                    },
-                                ) { a, b -> Pair(a, b) }
+                                )
                             },
                             // pageStats: pair(avg(pages), max(pages))
                             {
@@ -247,13 +252,16 @@ internal class ProjectorResolverTest {
 
         val resolved = resolve(projector)
 
+        // Verify distinct modifier hoisted from nested composite
+        assertThat(resolved.modifiers).containsExactly(DISTINCT)
+
         // Verify flat node list: 6 unique leaves (SUM(revenue) deduped)
         assertThat(resolved.nodes).hasSize(6)
 
         // Verify node types in order
         assertThat(resolved.nodes[0].leaf).isEqualTo(ProjectionLeaf.Aggregate(GROUP_BY, nameCol))
         assertThat(resolved.nodes[1].leaf)
-            .isEqualTo(ProjectionLeaf.Modifier(DISTINCT, ProjectionLeaf.Property(authorCol)))
+            .isEqualTo(ProjectionLeaf.Property(authorCol))
         assertThat(resolved.nodes[2].leaf).isEqualTo(ProjectionLeaf.Aggregate(COUNT, pagesCol))
         assertThat(resolved.nodes[3].leaf).isEqualTo(ProjectionLeaf.Aggregate(AVG, pagesCol))
         assertThat(resolved.nodes[4].leaf).isEqualTo(ProjectionLeaf.Aggregate(MAX, pagesCol))
@@ -345,6 +353,41 @@ internal class ProjectorResolverTest {
         assertThat(leaf.sqlExpression).isEqualTo("LENGTH({alias}.name) AS name_length")
 
         assertThat(resolved.mapRow(listOf(10L))).isEqualTo(10L)
+    }
+
+    @Test
+    fun `distinct wrapping a composite projection`() {
+        val projector = YawnProjector<Any, Pair<String, Long>> {
+            ProjectionNode.modifier(
+                DISTINCT,
+                YawnProjector {
+                    ProjectionNode.composite(
+                        YawnValueProjector { ProjectionNode.property(authorCol) },
+                        YawnValueProjector { ProjectionNode.property(pagesCol) },
+                    ) { a, b -> a to b }
+                },
+            )
+        }
+
+        val resolved = resolve(projector)
+
+        assertThat(resolved.modifiers).containsExactly(DISTINCT)
+        assertThat(resolved.nodes).hasSize(2)
+        assertThat(resolved.nodes[0].leaf).isEqualTo(ProjectionLeaf.Property(authorCol))
+        assertThat(resolved.nodes[1].leaf).isEqualTo(ProjectionLeaf.Property(pagesCol))
+
+        val result = resolved.mapRow(listOf("Tolkien", 300L))
+        assertThat(result).isEqualTo("Tolkien" to 300L)
+    }
+
+    @Test
+    fun `distinct flag is false by default`() {
+        val projector = YawnValueProjector {
+            ProjectionNode.property(nameCol)
+        }
+
+        val resolved = resolve(projector)
+        assertThat(resolved.modifiers).isEqualTo(setOf<ModifierKind>())
     }
 
     data class AuthorSummary(

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
@@ -8,7 +8,6 @@ import com.faire.yawn.project.AggregateKind.MAX
 import com.faire.yawn.project.AggregateKind.MIN
 import com.faire.yawn.project.AggregateKind.SUM
 import com.faire.yawn.project.ModifierKind.DISTINCT
-import com.faire.yawn.project.ProjectionLeaf
 import com.faire.yawn.project.ProjectionNode
 import com.faire.yawn.project.ProjectorResolver
 import com.faire.yawn.project.ResolvedProjectionAdapter
@@ -128,9 +127,10 @@ internal class ResolvedProjectionAdapterTest : BaseYawnDatabaseTest() {
                 val authors = join(books.author)
                 project(
                     adapt(
-                        YawnValueProjector<Book, String> {
-                            ProjectionNode.Value(
-                                ProjectionLeaf.Modifier(DISTINCT, ProjectionLeaf.Property(authors.name)),
+                        YawnProjector<Book, String> {
+                            ProjectionNode.modifier(
+                                DISTINCT,
+                                YawnValueProjector { ProjectionNode.property(authors.name) },
                             )
                         },
                     ),


### PR DESCRIPTION
While trying to apply the new pipeline on BE, I realized we currently only allow distinct to contain leafs (value nodes).

This instinctively make sense, `distinct(column1)` is pretty clear while `distinct(Projection(column1, sum(column2))` is not.

However that is neither how distinct works in SQL nor in Hibernate.

In SQL, distinct is a query-level flag. This is quite unintuitive as people often do:

```
SELECT DISTINCT column1, column2 ...
```

Thinking it means

```
SELECT (DISTINCT column1), column2 ...
```

When in reality it means

```
(SELECT DISTINCT) column1, column2 ...
```

In that sense, distinct would make more sense as a query-level flag, not a projection at all (similar to `maxResults`, `setQueryHint`, etc)

In Hibernate however, distinct is just a wrapper over any projection (value or group or anything) that sets that flag to the query level. So in Hibernate it is perfectly valid to do `distinct(column1)` or `distinct(Projection(column1, sum(column2))`, and both just set the distinct at query level.

Our currently Yawn implementation allowing only leaf-level distinct is misleading. Between the two options, I think keeping the Hibernate-style is more inline with how the old Yawn projection works, which is in line with a lot of yawn migrated code, and also of course in line with any remaining old Hibernate code we have.

This choice also makes optimal use of the new projection pipeline, which can now support fully decoupling the projection nodes (entirely yawn-handled concepts) from the generated projection value tree that eventually just becomes a flat list of fields (plus, now, modifiers). See details on https://github.com/Faire/yawn/pull/117