### PR TITLE
feat: Project to a JoinColumnDef on new projection pipeline

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnDef.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnDef.kt
@@ -21,8 +21,6 @@ abstract class YawnDef<SOURCE : Any, D : Any> {
      * @param F the type of the column.
      */
     abstract inner class YawnColumnDef<F> : YawnQueryProjection<SOURCE, F>, YawnPathProvider<SOURCE> {
-        abstract override fun generatePath(context: YawnCompilationContext): String
-
         open fun adaptValue(value: F): Any? {
             return value
         }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnDef.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnDef.kt
@@ -1,5 +1,6 @@
 package com.faire.yawn
 
+import com.faire.yawn.project.YawnPathProvider
 import com.faire.yawn.project.YawnQueryProjection
 import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
@@ -19,8 +20,8 @@ abstract class YawnDef<SOURCE : Any, D : Any> {
      *
      * @param F the type of the column.
      */
-    abstract inner class YawnColumnDef<F> : YawnQueryProjection<SOURCE, F> {
-        abstract fun generatePath(context: YawnCompilationContext): String
+    abstract inner class YawnColumnDef<F> : YawnQueryProjection<SOURCE, F>, YawnPathProvider<SOURCE> {
+        abstract override fun generatePath(context: YawnCompilationContext): String
 
         open fun adaptValue(value: F): Any? {
             return value

--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDef.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDef.kt
@@ -1,7 +1,11 @@
 package com.faire.yawn
 
 import com.faire.yawn.adapter.YawnValueAdapter
+import com.faire.yawn.project.ProjectionLeaf
+import com.faire.yawn.project.ProjectionNode
+import com.faire.yawn.project.YawnPathProvider
 import com.faire.yawn.project.YawnQueryProjection
+import com.faire.yawn.project.YawnValueProjector
 import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
 import org.hibernate.criterion.Projections
@@ -76,8 +80,8 @@ abstract class YawnTableDef<SOURCE : Any, D : Any>(
         private val parent: YawnTableDefParent,
         protected val name: String,
         private val tableDefProvider: (YawnTableDefParent) -> DEF,
-    ) {
-        fun path(context: YawnCompilationContext): String {
+    ) : YawnPathProvider<SOURCE> {
+        override fun generatePath(context: YawnCompilationContext): String {
             return listOfNotNull(context.generateAlias(parent), name).joinToString(".")
         }
 
@@ -107,17 +111,22 @@ abstract class YawnTableDef<SOURCE : Any, D : Any>(
         name,
         tableDefProvider,
     ),
-        YawnQueryProjection<SOURCE, T> {
+        YawnQueryProjection<SOURCE, T>,
+        YawnValueProjector<SOURCE, T> {
         val foreignKey: REF
             get() = foreignKeyProvider(name)
 
         override fun compile(context: YawnCompilationContext): Projection {
-            return Projections.property(path(context))
+            return Projections.property(generatePath(context))
         }
 
         override fun project(value: Any?): T {
             @Suppress("UNCHECKED_CAST")
             return value as T
+        }
+
+        override fun projection(): ProjectionNode.Value<SOURCE, T> {
+            return ProjectionNode.Value(ProjectionLeaf.Property(this))
         }
     }
 

--- a/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDefParent.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/YawnTableDefParent.kt
@@ -43,7 +43,7 @@ interface YawnTableDefParent {
         val parentColumnDef: YawnTableDef<*, *>.JoinColumnDef<*, *>,
     ) : YawnTableDefParent {
         override fun getAliasBaseString(context: YawnCompilationContext): String {
-            return parentColumnDef.path(context)
+            return parentColumnDef.generatePath(context)
         }
     }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/DetachedProjectedTypeSafeCriteriaBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/DetachedProjectedTypeSafeCriteriaBuilder.kt
@@ -51,13 +51,13 @@ class DetachedProjectedTypeSafeCriteriaBuilder<SOURCE : Any, T : Any, DEF : Yawn
             if (join.joinCriteria.isNotEmpty()) {
                 val criterion = And(join.joinCriteria)
                 detachedCriteria.createAlias(
-                    join.path(context),
+                    join.generatePath(context),
                     alias,
                     join.joinType,
                     criterion.compile(context),
                 )
             } else {
-                detachedCriteria.createAlias(join.path(context), alias, join.joinType)
+                detachedCriteria.createAlias(join.generatePath(context), alias, join.joinType)
             }
         }
 

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
@@ -9,16 +9,19 @@ import kotlin.reflect.KClass
  * Leaves are the terminal elements that produce actual SQL in the compiled query projection tree.
  * The Query Factory is responsible for converting each leaf to the underlying ORM's implementation projection.
  *
- * Leaf deduplication uses data class equality: two [Property] leaves with the same [YawnDef.YawnColumnDef]
+ * Leaf deduplication uses data class equality: two [Property] leaves with the same [YawnPathProvider]
  * reference, or two [Aggregate] leaves with the same [AggregateKind] and column, are considered identical
  * and will share an index in the re-packed result list.
  */
 sealed interface ProjectionLeaf<SOURCE : Any> {
     /**
-     * A simple column property access (SQL: `alias.column`).
+     * A property access (SQL: `alias.column`).
+     *
+     * Works with any [YawnPathProvider], including both [YawnDef.YawnColumnDef]
+     * and [com.faire.yawn.YawnTableDef.JoinColumnDef].
      */
     data class Property<SOURCE : Any>(
-        val column: YawnDef<SOURCE, *>.YawnColumnDef<*>,
+        val column: YawnPathProvider<SOURCE>,
     ) : ProjectionLeaf<SOURCE>
 
     /**

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnPathProvider.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnPathProvider.kt
@@ -1,0 +1,13 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.query.YawnCompilationContext
+
+/**
+ * A column reference that can be converted to a dotted path.
+ *
+ * * [com.faire.yawn.YawnDef.YawnColumnDef] — the path of a simple column, e.g. `"name"` or `"a.name"`.
+ * * [com.faire.yawn.YawnTableDef.JoinColumnDef] — the path of a join association, e.g. `"publisher"` or `"a.publisher"`.
+ */
+fun interface YawnPathProvider<SOURCE : Any> {
+    fun generatePath(context: YawnCompilationContext): String
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryJoin.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryJoin.kt
@@ -13,5 +13,5 @@ data class YawnQueryJoin<SOURCE : Any>(
     val joinType: JoinType,
     val joinCriteria: MutableList<YawnQueryCriterion<SOURCE>> = mutableListOf(),
 ) {
-    fun path(context: YawnCompilationContext): String = columnDef.path(context)
+    fun generatePath(context: YawnCompilationContext): String = columnDef.generatePath(context)
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
@@ -243,7 +243,7 @@ interface YawnQueryRestriction<SOURCE : Any> {
     ) : YawnQueryRestriction<SOURCE> {
         override fun compile(
             context: YawnCompilationContext,
-        ): Criterion = Restrictions.isEmpty(joinColumn.path(context))
+        ): Criterion = Restrictions.isEmpty(joinColumn.generatePath(context))
     }
 
     class IsNotEmpty<SOURCE : Any>(
@@ -251,7 +251,7 @@ interface YawnQueryRestriction<SOURCE : Any> {
     ) : YawnQueryRestriction<SOURCE> {
         override fun compile(
             context: YawnCompilationContext,
-        ): Criterion = Restrictions.isNotEmpty(joinColumn.path(context))
+        ): Criterion = Restrictions.isNotEmpty(joinColumn.generatePath(context))
     }
 }
 

--- a/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
@@ -1,6 +1,8 @@
 package com.faire.yawn.project
 
 import com.faire.yawn.YawnDef
+import com.faire.yawn.YawnTableDef
+import com.faire.yawn.YawnTableDefParent
 import com.faire.yawn.project.AggregateKind.AVG
 import com.faire.yawn.project.AggregateKind.COUNT
 import com.faire.yawn.project.AggregateKind.COUNT_DISTINCT
@@ -135,6 +137,24 @@ internal class ProjectorResolverTest {
 
         val result = resolved.mapRow(listOf(50_000L))
         assertThat(result).isEqualTo(50_000L to 50_000L) // both fields get the same value
+    }
+
+    @Test
+    fun `deduplication of identical join column leaves`() {
+        val tableDef = TestTableDef()
+        val projector = YawnProjector<TestEntity, Pair<TestEntity, TestEntity>> {
+            ProjectionNode.composite(
+                tableDef.joined,
+                tableDef.joined,
+            ) { a, b -> Pair(a, b) }
+        }
+
+        val resolved = ProjectorResolver<TestEntity>().resolve(projector)
+        assertThat(resolved.nodes).hasSize(1)
+
+        val entity = TestEntity()
+        val result = resolved.mapRow(listOf(entity))
+        assertThat(result).isEqualTo(entity to entity)
     }
 
     @Test
@@ -358,6 +378,17 @@ internal class ProjectorResolverTest {
         val totalRevenue: Long,
         val totalRevenueCheck: Long,
     )
+
+    private class TestEntity
+
+    private class TestTableDef : YawnTableDef<TestEntity, TestEntity>(YawnTableDefParent.RootTableDefParent) {
+        val joined = JoinColumnDefWithForeignKey<TestEntity, TestTableDef, Long>(
+            parent,
+            "joined",
+            "id",
+            { TestTableDef() },
+        )
+    }
 
     private class TestDef : YawnDef<Any, Any>() {
         fun <T> column(name: String): YawnColumnDef<T> = TestColumnDef(name)

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestQueryFactory.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestQueryFactory.kt
@@ -34,9 +34,9 @@ internal class YawnTestQueryFactory(
 
             if (join.joinCriteria.isNotEmpty()) {
                 val criterion = And(join.joinCriteria)
-                rawQuery.createAlias(join.path(context), alias, join.joinType, criterion.compile(context))
+                rawQuery.createAlias(join.generatePath(context), alias, join.joinType, criterion.compile(context))
             } else {
-                rawQuery.createAlias(join.path(context), alias, join.joinType)
+                rawQuery.createAlias(join.generatePath(context), alias, join.joinType)
             }
         }
 

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
@@ -376,6 +376,20 @@ internal class ResolvedProjectionAdapterTest : BaseYawnDatabaseTest() {
     }
 
     @Test
+    fun `join column def projection returns entity`() {
+        transactor.open { session ->
+            val publishers = session.project(BookTable) { books ->
+                addLike(books.name, "The %")
+                addIsNotNull(books.publisher.foreignKey)
+                project(adapt(books.publisher))
+            }.set()
+
+            assertThat(publishers.map { it.name })
+                .containsExactlyInAnyOrder("Random House", "Penguin")
+        }
+    }
+
+    @Test
     fun `sum with nullable columns`() {
         transactor.open { session ->
             fun getSumRatingsByLanguage(vararg authorNames: String): Map<Book.Language, Any?> {

--- a/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityPathTest.kt
+++ b/yawn-integration-test/src/test/kotlin/com/faire/yawn/YawnEntityPathTest.kt
@@ -27,7 +27,7 @@ internal class YawnEntityPathTest {
     fun `join column def path contains whole chain`() {
         val withParent = EntityWithSimpleRelationsTableDef<EntityWithoutRelations>(parent = RootTableDefParent)
         val asField = withParent.nonNullOneToOneYawn
-        assertThat(asField.path(context)).isEqualTo("nonNullOneToOneYawn")
+        assertThat(asField.generatePath(context)).isEqualTo("nonNullOneToOneYawn")
 
         val asJoinWithAlias = withParent.nonNullOneToOneYawn.joinTableDef(AssociationTableDefParent(asField))
         assertThat(asJoinWithAlias.randomField.generatePath(context)).isEqualTo("nnotoy.randomField")
@@ -38,7 +38,7 @@ internal class YawnEntityPathTest {
         val subQueryCompilationContext = YawnCompilationContext(withSubQuery = true)
         val withParent = EntityWithSimpleRelationsTableDef<EntityWithoutRelations>(parent = RootTableDefParent)
         val asField = withParent.nonNullOneToOneYawn
-        assertThat(asField.path(subQueryCompilationContext)).isEqualTo("r.nonNullOneToOneYawn")
+        assertThat(asField.generatePath(subQueryCompilationContext)).isEqualTo("r.nonNullOneToOneYawn")
 
         val asJoinWithAlias = withParent.nonNullOneToOneYawn.joinTableDef(AssociationTableDefParent(asField))
         // cSpell:ignore nnotoy - this is the alias given with the initials of "nonUllOneToOneYawn"


### PR DESCRIPTION
By design, `JoinColumnDef`s are _not_ `ColumnDef`s - they have different semantics in some cases.
But projections is not one of those cases; the old projections absolutely support projecting to join column defs.

This standardizes the "path creation methods" under `generatePath(context) -> string` via an interface and rename.