### PR TITLE
refactor: Evolve distinct semantics

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/DetachedProjectedYawnBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/DetachedProjectedYawnBuilder.kt
@@ -17,10 +17,20 @@ import org.hibernate.criterion.DetachedCriteria
  * @param DEF the table definition of the entity being queried
  * @param RETURNS the type being projected to
  */
-class DetachedProjectedYawnBuilder<SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>, RETURNS : Any?>(
+class DetachedProjectedYawnBuilder<SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>, RETURNS>(
     val query: YawnQuery<SOURCE, T>,
     private val tableDef: DEF,
-) {
+) : BaseYawnBuilder<DetachedProjectedYawnBuilder<SOURCE, T, DEF, RETURNS>>(),
+    YawnBuilderWithDistinct<DetachedProjectedYawnBuilder<SOURCE, T, DEF, RETURNS>> {
+
+    override fun builderReturn(): DetachedProjectedYawnBuilder<SOURCE, T, DEF, RETURNS> {
+        return this
+    }
+
+    override fun distinct(distinct: Boolean): DetachedProjectedYawnBuilder<SOURCE, T, DEF, RETURNS> {
+        query.distinct = distinct
+        return builderReturn()
+    }
 
     fun compile(context: YawnCompilationContext): DetachedCriteria {
         return buildDetachedCriteria(context)
@@ -69,7 +79,7 @@ class DetachedProjectedYawnBuilder<SOURCE : Any, T : Any, DEF : YawnTableDef<SOU
             detachedCriteria.addOrder(order.compile(context))
         }
 
-        val hibernateProjection = query.projection?.compile(context)
+        val hibernateProjection = query.compileProjection(context)
         if (hibernateProjection != null) {
             detachedCriteria.setProjection(hibernateProjection)
         }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/ProjectedYawnQueryBuilder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/ProjectedYawnQueryBuilder.kt
@@ -24,8 +24,14 @@ class ProjectedYawnQueryBuilder<T : Any, DEF : YawnTableDef<T, T>, RETURNS : Any
     tableDef,
     queryFactory,
     query,
-) {
+),
+    YawnBuilderWithDistinct<ProjectedYawnQueryBuilder<T, DEF, RETURNS>> {
     override fun builderReturn(): ProjectedYawnQueryBuilder<T, DEF, RETURNS> = this
+
+    override fun distinct(distinct: Boolean): ProjectedYawnQueryBuilder<T, DEF, RETURNS> {
+        query.distinct = distinct
+        return builderReturn()
+    }
 
     override fun clone(): ProjectedYawnQueryBuilder<T, DEF, RETURNS> {
         return ProjectedYawnQueryBuilder(tableDef, queryFactory, query.copy())

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/YawnBuilderWithDistinct.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/builder/YawnBuilderWithDistinct.kt
@@ -1,0 +1,29 @@
+package com.faire.yawn.criteria.builder
+
+/**
+ * An interface for query builders that support query-level DISTINCT.
+ *
+ * This is implemented by both [ProjectedYawnQueryBuilder] (top-level queries)
+ * and [DetachedProjectedYawnBuilder] (subqueries / detached criteria).
+ * Hibernate only supports DISTINCT through projections, so non-projected builders cannot use this.
+ *
+ * Query-level DISTINCT applies `SELECT DISTINCT ...` to the entire projection.
+ * This is separate from aggregate-level distinct (e.g. `COUNT(DISTINCT col)`),
+ * which is handled via [com.faire.yawn.project.AggregateKind.COUNT_DISTINCT].
+ *
+ * @param CRITERIA the concrete builder type, for fluent chaining.
+ */
+interface YawnBuilderWithDistinct<CRITERIA : BaseYawnBuilder<*>> {
+    /**
+     * Applies query-level `SELECT DISTINCT` to this projected query.
+     *
+     * Unlike [com.faire.yawn.project.YawnProjections.distinct], which wraps a projection
+     * and relies on Hibernate's string-concatenation hack, this method sets a query-level flag
+     * that wraps the entire compiled projection with `Projections.distinct(...)` at compilation time.
+     *
+     * @param distinct whether to apply DISTINCT. Defaults to `true`. Pass `false` to turn off
+     *   distinct for queries built piecemeal or to set from a variable.
+     * @return this builder for chaining.
+     */
+    fun distinct(distinct: Boolean = true): CRITERIA
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
@@ -21,6 +21,11 @@ object YawnProjections {
         override fun project(value: Any?): TO = projection.project(value)
     }
 
+    @Deprecated(
+        message = "For query-level SELECT DISTINCT, use the .distinct() method on the projected builder. " +
+            "For aggregate-level COUNT(DISTINCT col), use countDistinct() instead.",
+        replaceWith = ReplaceWith("distinct()"),
+    )
     fun <SOURCE : Any, TO> distinct(
         projection: YawnQueryProjection<SOURCE, TO>,
     ): YawnQueryProjection<SOURCE, TO> {

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQuery.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQuery.kt
@@ -5,6 +5,8 @@ import com.faire.yawn.YawnTableDefParent.AssociationTableDefParent
 import com.faire.yawn.criteria.query.JoinYawnQueryScope
 import com.faire.yawn.project.YawnQueryProjection
 import com.faire.yawn.query.YawnQueryRestriction.YawnQueryRestrictionWithNestedRestriction
+import org.hibernate.criterion.Projection
+import org.hibernate.criterion.Projections
 import org.hibernate.sql.JoinType
 
 /**
@@ -22,6 +24,7 @@ data class YawnQuery<SOURCE : Any, T : Any>(
     var offset: Int? = null,
     var maxResults: Int? = null,
     var lockMode: YawnLockMode? = null,
+    var distinct: Boolean = false,
 ) : YawnQueryWithCriterion<SOURCE, T> {
 
     override fun addCriterion(criterion: YawnQueryCriterion<SOURCE>) {
@@ -73,6 +76,15 @@ data class YawnQuery<SOURCE : Any, T : Any>(
             orders = MutableList(orders.size) { orders[it].copy() },
             queryHints = MutableList(queryHints.size) { queryHints[it] },
         )
+    }
+
+    fun compileProjection(context: YawnCompilationContext): Projection? {
+        val compiled = projection?.compile(context)
+        if (compiled == null) {
+            check(!distinct) { "distinct() requires a projection to be set." }
+            return null
+        }
+        return if (distinct) Projections.distinct(compiled) else compiled
     }
 
     fun hasSubQuery(): Boolean {

--- a/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestQueryFactory.kt
+++ b/yawn-database-test/src/main/kotlin/com/faire/yawn/setup/hibernate/YawnTestQueryFactory.kt
@@ -57,7 +57,7 @@ internal class YawnTestQueryFactory(
             rawQuery.setFirstResult(offset)
         }
 
-        val hibernateProjection = query.projection?.compile(context)
+        val hibernateProjection = query.compileProjection(context)
         if (hibernateProjection != null) {
             rawQuery.setProjection(hibernateProjection)
         }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -180,17 +180,29 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
     }
 
     @Test
-    fun `yawn query with projection function - distinct`() {
+    fun `yawn query with query-level distinct`() {
         transactor.open { session ->
             val authors = session.project(BookTable) { books ->
                 val authors = join(books.author)
-                project(YawnProjections.distinct(authors.name))
-            }.list()
+                project(authors.name)
+            }.distinct().list()
             assertThat(authors).containsExactlyInAnyOrder(
                 "J.R.R. Tolkien",
                 "J.K. Rowling",
                 "Hans Christian Andersen",
             )
+        }
+    }
+
+    @Test
+    fun `yawn query with query-level distinct false is a no-op`() {
+        transactor.open { session ->
+            val authors = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                project(authors.name)
+            }.distinct(distinct = false).list()
+            // Without distinct, we get duplicates (one per book, not per author)
+            assertThat(authors).hasSizeGreaterThan(3)
         }
     }
 

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSubQueryTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSubQueryTest.kt
@@ -1,7 +1,6 @@
 package com.faire.yawn.database
 
 import com.faire.yawn.Yawn
-import com.faire.yawn.project.YawnProjections
 import com.faire.yawn.query.YawnSubQueryRestrictions
 import com.faire.yawn.setup.entities.BookTable
 import com.faire.yawn.setup.entities.PersonTable
@@ -54,11 +53,11 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
     }
 
     @Test
-    fun `yawn query with a sub query using detached criteria projected to a collection`() {
+    fun `yawn query with a sub query using detached criteria with query-level distinct`() {
         val detachedCriteria = Yawn.createProjectedDetachedCriteria(PersonTable) { person ->
             addLike(person.name, "J.%")
-            project(YawnProjections.distinct(person.name))
-        }
+            project(person.name)
+        }.distinct()
 
         transactor.open { session ->
             val books = session.query(BookTable) { books ->


### PR DESCRIPTION
SQL has two fundamentally different uses of `DISTINCT`: query-level (`SELECT DISTINCT ...`) which deduplicates entire rows, and aggregate-level (`COUNT(DISTINCT col)`) which deduplicates input to an aggregate function. Hibernate conflates these by modelling query-level distinct as `Projections.distinct(projection)` - a dumb string concatenation that prepends `"distinct "` to a projection's SQL. This only produces valid SQL when wrapping the outermost projection; any other placement (e.g. mid-list) compiles but fails at runtime. This PR divorces Yawn from Hibernate's broken model by treating query-level `DISTINCT` as what it really is: a query-level flag, not a projection decorator. The new `.distinct()` builder method sits alongside `.maxResults()` and `.addQueryHint()` as a query parameter, matching raw SQL semantics.

The implementation adds a `distinct: Boolean` flag to `YawnQuery` and a `compileProjection()` method that wraps the compiled projection with `Projections.distinct(...)` when the flag is set. A new `YawnBuilderWithDistinct` interface exposes `.distinct()` on both `ProjectedYawnQueryBuilder` and `DetachedProjectedYawnBuilder`. It is intentionally absent from `EntityYawnQueryBuilder` because Hibernate only supports `DISTINCT` through projections; there is no API to add it to a non-projected `Criteria`. Aggregate-level distinct (`COUNT(DISTINCT col)`) is unchanged and continues to use `countDistinct()` / `AggregateKind.COUNT_DISTINCT`.

The old `YawnProjections.distinct()` is now deprecated, pointing users to `.distinct()` for query-level distinct and `countDistinct()` for aggregate-level.