### PR TITLE
feat: Add piece-meal queries doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ transactor.callPrimaryReadOnly {
 
 - [Getting Started](getting_started.md)
 - [Basic Queries](basic_queries.md)
+- [Building Queries Piecemeal](piecemeal_queries.md)
 - [Joins](joins.md)
 - [Projections](projections.md)
 - [Sub-queries](sub_queries.md)

--- a/docs/basic_queries.md
+++ b/docs/basic_queries.md
@@ -28,7 +28,7 @@ operation, you get other instances to access the new joined columns.
 
 ## Other Available Criteria
 
-The rest of the criteria can be found in `YawnScopeWithWhere` such as:
+The rest of the criteria can be found in `YawnQueryScopeWithWhere` such as:
 
 - `addEq`
 - `addGt`
@@ -147,6 +147,8 @@ These operations are defined in `YawnQueryBuilder`, such as:
 
 ## Pass/Modify Queries Around
 
+For a complete guide to choosing helper types and sharing joins between query pieces, see [Building Queries Piecemeal](piecemeal_queries.md).
+
 If you want to “pass” a query object around, you can just call `applyFilter` multiple times.
 
 For example:
@@ -159,20 +161,20 @@ fun mainQuery(): List<DbBook> {
 }
 
 private fun applyFilters(
-    criteria: EntityYawnQueryBuilder<Book, BookTable>,
+    criteria: EntityYawnQueryBuilder<Book, BookTableDefType>,
 ) {
     criteria.applyAuthorFilters()
     criteria.applyPublisherFilters()
 }
 
-private fun EntityYawnQueryBuilder<Book, BookTable>.applyAuthorFilters() { 
+private fun EntityYawnQueryBuilder<Book, BookTableDefType>.applyAuthorFilters() {
     applyFilter { books ->
         val authors = join(books.author)
         addEq(authors.name, "J.K. Rowling")
     }
 }
 
-private fun EntityYawnQueryBuilder<Book, BookTable>.applyPublisherFilters() {
+private fun EntityYawnQueryBuilder<Book, BookTableDefType>.applyPublisherFilters() {
     applyFilter { books ->
         val publishers = join(books.publisher)
         addEq(publishers.name, "HarperCollins")

--- a/docs/joins.md
+++ b/docs/joins.md
@@ -137,8 +137,10 @@ criteria.applyFilter { books ->
 val results = criteria.list() // The Hobbit, Lord of the Rings
 ```
 
-Note that join references are for rare cases in which you want to pass a query around to be build piecemeal.
-Ideally, you can put all your query within a single lambda.
+Join references are useful when you want to pass a query around and build it piecemeal.
+Ideally, keep all related query logic within a single lambda.
+
+For more guidance on sharing joins between query pieces, see [Building Queries Piecemeal](piecemeal_queries.md).
 
 ### Join Types
 

--- a/docs/piecemeal_queries.md
+++ b/docs/piecemeal_queries.md
@@ -1,0 +1,125 @@
+# Building Queries Piecemeal
+
+Yawn query builders are mutable. This makes it possible to start a query in one function, pass it to other functions to add filters, joins, ordering,
+or pagination, and execute it only after all of the pieces have been applied.
+
+Prefer a single query lambda when all of the query logic belongs together. Piecemeal construction is useful when several callers share filters or when
+optional filters are selected at runtime.
+
+## Passing a query builder around
+
+Create the builder without a lambda, pass it to functions that call `applyFilter`, and invoke a terminal operation only after the query is complete:
+
+```kotlin
+fun findBooks(filters: BookFilters): List<Book> {
+    val query = yawn.query(BookTable)
+
+    query.applyBookFilters(filters)
+    query.orderAsc { name }
+
+    return query.list()
+}
+
+private fun EntityYawnQueryBuilder<Book, BookTableDefType>.applyBookFilters(
+    filters: BookFilters,
+) {
+    filters.title?.let { title ->
+        applyFilter { books ->
+            addLike(books.name, "%$title%")
+        }
+    }
+
+    filters.minimumPages?.let { minimumPages ->
+        applyFilter { books ->
+            addGe(books.numberOfPages, minimumPages)
+        }
+    }
+}
+```
+
+Each call mutates and returns the same builder, so calls can also be chained. Do not call `list`, `uniqueResult`, or another terminal operation in a helper
+that is only meant to contribute part of a query.
+
+If a base query will be used to execute more than one variation, create a new base builder for each variation. Mutations accumulate on a builder;
+executing it does not reset it.
+
+## Choosing a type for a helper
+
+The type to use depends on whether the helper receives a builder or runs inside a query lambda.
+
+| Helper receives | Type to use | What it can do |
+| --- | --- | --- |
+| A query being assembled | `EntityYawnQueryBuilder<Entity, TableDef>` | Add filters, projections, ordering, pagination, and terminal operations |
+| The receiver inside a root entity-query lambda | The generated `EntityEntityQueryScope` alias | Add filters and joins |
+| The receiver inside a join lambda | The generated `EntityJoinQueryScope` alias | Add filters relative to that join |
+| The receiver inside a projection lambda | The generated `EntityProjectedQueryScope<Result>` alias | Add filters and define a projection |
+
+KSP generates the scope aliases and a `TableDefType` alias for every `@YawnEntity`. For example, an entity named `Book` produces
+`BookEntityQueryScope`, `BookJoinQueryScope`, `BookProjectedQueryScope<Result>`, and `BookTableDefType`. Prefer these aliases for lambda helpers because
+they hide the internal `SOURCE`, table-definition, and projection generics:
+
+```kotlin
+private fun BookEntityQueryScope.addPublishedFilter(
+    books: BookTableDefType,
+) {
+    addEq(books.published, true)
+}
+
+private fun BookJoinQueryScope.addLongBookFilter(
+    books: BookTableDefType,
+) {
+    addGt(books.numberOfPages, 500)
+}
+```
+
+Use the concrete `EntityYawnQueryBuilder` type when a helper needs to own a larger piece of construction or decide which lambdas to apply. Use a generated
+scope alias when the helper only needs DSL operations such as `addEq` or `join`.
+
+`BaseYawnBuilder` and `BaseYawnQueryScope` are common implementation types, not the types to expose in application helpers. Prefer the concrete builder or
+generated aliases such as `BookEntityQueryScope` and `BookJoinQueryScope`, which preserve useful table-definition context. If direct generic types are
+unavoidable, `SOURCE` is the root entity
+of the whole query, `T` is the entity at the current scope, `DEF` is its generated definition, and a projected builder's `RETURNS` type is the terminal
+result type.
+
+## Reusing a join across query pieces
+
+Every call to `join` creates another join. When independently applied filters need to refer to the same joined table, create a join reference once and apply
+filters through that reference:
+
+```kotlin
+val query = yawn.query(BookTable)
+val authorRef = query.joinRef { author }
+
+query.applyJoinRef(authorRef) { authors ->
+    addLike(authors.name, "J.%")
+}
+
+query.applyJoinRef(authorRef) { authors ->
+    addLike(authors.name, "%n")
+}
+
+val books = query.list()
+```
+
+`joinRef` registers the join immediately. Its `get` method maps the root table definition supplied to a later `applyFilter` block to the table definition for
+that exact join. `applyJoinRef` packages that mapping into a less error-prone form. `applyJoinRefs` is available when a single filter needs two or three
+saved joins.
+
+If a helper may be called after another part of the query has already registered the same root join, use `getOrCreateJoinRef` instead:
+
+```kotlin
+private fun EntityYawnQueryBuilder<Book, BookTableDefType>.applyAuthorFilter(
+    authorName: String,
+) {
+    val authorRef = getOrCreateJoinRef { author }
+    applyJoinRef(authorRef) { authors ->
+        addEq(authors.name, authorName)
+    }
+}
+```
+
+Use `joinRef` when separate joins are intentional—for example, when two conditions must target two independently joined rows. Use `getOrCreateJoinRef` when
+the filters should constrain the same joined row. Reusing a reference also avoids creating duplicate join paths in Hibernate Criteria queries.
+
+Join references belong to the builder that created them. Do not save one globally or use it with another query builder, even if both builders query the
+same entity.

--- a/docs/piecemeal_queries.md
+++ b/docs/piecemeal_queries.md
@@ -3,8 +3,8 @@
 Yawn query builders are mutable. This makes it possible to start a query in one function, pass it to other functions to add filters, joins, ordering,
 or pagination, and execute it only after all of the pieces have been applied.
 
-Usually having a single query lambda is preferred when all of the query logic belongs together, but piecemeal construction is possible when several callers share filters or when
-optional filters are selected at runtime.
+Usually having a single query lambda is preferred when all of the query logic belongs together.
+Piecemeal construction is useful when several callers share filters or when optional filters are selected at runtime.
 
 ## Passing a query builder around
 

--- a/docs/piecemeal_queries.md
+++ b/docs/piecemeal_queries.md
@@ -3,7 +3,7 @@
 Yawn query builders are mutable. This makes it possible to start a query in one function, pass it to other functions to add filters, joins, ordering,
 or pagination, and execute it only after all of the pieces have been applied.
 
-Prefer a single query lambda when all of the query logic belongs together. Piecemeal construction is useful when several callers share filters or when
+Usually having a single query lambda is preferred when all of the query logic belongs together, but piecemeal construction is possible when several callers share filters or when
 optional filters are selected at runtime.
 
 ## Passing a query builder around
@@ -23,13 +23,15 @@ fun findBooks(filters: BookFilters): List<Book> {
 private fun EntityYawnQueryBuilder<Book, BookTableDefType>.applyBookFilters(
     filters: BookFilters,
 ) {
-    filters.title?.let { title ->
+    if (filters.title != null) {
+        val title = filters.title
         applyFilter { books ->
             addLike(books.name, "%$title%")
         }
     }
 
-    filters.minimumPages?.let { minimumPages ->
+    if (filters.minimumPages != null) {
+        val minimumPages = filters.minimumPages
         applyFilter { books ->
             addGe(books.numberOfPages, minimumPages)
         }
@@ -40,8 +42,8 @@ private fun EntityYawnQueryBuilder<Book, BookTableDefType>.applyBookFilters(
 Each call mutates and returns the same builder, so calls can also be chained. Do not call `list`, `uniqueResult`, or another terminal operation in a helper
 that is only meant to contribute part of a query.
 
-If a base query will be used to execute more than one variation, create a new base builder for each variation. Mutations accumulate on a builder;
-executing it does not reset it.
+If a base query will be used to execute more than one variation, create a new base builder for each variation or call `clone()` before diverging.
+Mutations accumulate on a builder; executing it does not reset it.
 
 ## Choosing a type for a helper
 


### PR DESCRIPTION
## Description:

- Adds piecemeal query doc and cleans up related examples to use the current public Yawn query types consistently. 

- The new guide explains how to pass builders/scopes through helpers, when to use generated scope aliases, and how join refs should be reused or created.

fixes: #98  