### PR TITLE
fix!: Mandate SQL projected-leaves to single column

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
@@ -41,16 +41,27 @@ sealed interface ProjectionLeaf<SOURCE : Any> {
     }
 
     /**
-     * A raw SQL projection for custom expressions.
+     * A raw SQL projection of a single computed value.
      *
      * The [sqlExpression] may use `{alias}` placeholders for table alias substitution.
-     * [resultTypes] are used by the query factory to map SQL results to Kotlin types.
+     * [columnAlias] is the name the projected column is selected as, which the query factory uses to read
+     * the value back out of the result set. [resultType] is used to map that SQL result to a Kotlin type.
      * It is up to the user to guarantee type-safety when using raw SQL projections!
+     *
+     * A leaf projects **exactly one** column, because it occupies exactly one slot in the resolved result
+     * row (see [ProjectionNode.Value], whose mapper receives a single value). To project several values,
+     * combine several leaves under a [ProjectionNode.Composite] instead.
+     *
+     * Note that this describes the projection in ORM-agnostic terms; adapting a single column to whatever
+     * arity the underlying ORM expects is the query factory's job. Note also that the single-column shape
+     * can only be enforced for what is *declared*: a [sqlExpression] that in fact selects two columns
+     * would still shift every subsequent result slot, and validating the implementation of custom
+     * projections remains the caller's responsibility.
      */
     data class Sql<SOURCE : Any>(
         val sqlExpression: String,
-        val aliases: List<String>,
-        val resultTypes: List<KClass<*>>,
+        val columnAlias: String,
+        val resultType: KClass<*>,
     ) : ProjectionLeaf<SOURCE>
 
     /**

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionNode.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionNode.kt
@@ -72,11 +72,14 @@ sealed interface ProjectionNode<SOURCE : Any, TO> {
         fun <SOURCE : Any> rowCount(): Value<SOURCE, Long> =
             Value(ProjectionLeaf.RowCount())
 
+        /**
+         * A raw SQL projection of a single computed value; see [ProjectionLeaf.Sql].
+         */
         fun <SOURCE : Any, TO> sql(
             sqlExpression: String,
-            aliases: List<String>,
-            resultTypes: List<kotlin.reflect.KClass<*>>,
-        ): Value<SOURCE, TO> = Value(ProjectionLeaf.Sql(sqlExpression, aliases, resultTypes))
+            columnAlias: String,
+            resultType: kotlin.reflect.KClass<*>,
+        ): Value<SOURCE, TO> = Value(ProjectionLeaf.Sql(sqlExpression, columnAlias, resultType))
 
         fun <SOURCE : Any, TO> constant(value: TO): Constant<SOURCE, TO> = Constant(value)
 

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
@@ -72,10 +72,11 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
     }
 
     private fun compileSql(leaf: ProjectionLeaf.Sql<SOURCE>): Projection {
+        // A leaf is always a single column; Hibernate wants parallel arrays, so wrap it here at the ORM boundary.
         return Projections.sqlProjection(
             leaf.sqlExpression,
-            leaf.aliases.toTypedArray(),
-            leaf.resultTypes.map { it.toHibernateType() }.toTypedArray(),
+            arrayOf(leaf.columnAlias),
+            arrayOf(leaf.resultType.toHibernateType()),
         )
     }
 

--- a/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
+++ b/yawn-api/src/test/kotlin/com/faire/yawn/project/ProjectorResolverTest.kt
@@ -354,8 +354,8 @@ internal class ProjectorResolverTest {
         val projector = YawnValueProjector<Any, Long> {
             ProjectionNode.sql(
                 sqlExpression = "LENGTH({alias}.name) AS name_length",
-                aliases = listOf("name_length"),
-                resultTypes = listOf(Long::class),
+                columnAlias = "name_length",
+                resultType = Long::class,
             )
         }
 
@@ -365,6 +365,29 @@ internal class ProjectorResolverTest {
         assertThat(leaf.sqlExpression).isEqualTo("LENGTH({alias}.name) AS name_length")
 
         assertThat(resolved.mapRow(listOf(10L))).isEqualTo(10L)
+    }
+
+    @Test
+    fun `sql leaf occupies exactly one result slot, between other values`() {
+        val projector = YawnProjector<Any, Triple<String, Long, Long>> {
+            ProjectionNode.composite(
+                YawnValueProjector<Any, String> { ProjectionNode.property(nameCol) },
+                YawnValueProjector<Any, Long> {
+                    ProjectionNode.sql(
+                        sqlExpression = "111 AS sentinel",
+                        columnAlias = "sentinel",
+                        resultType = Long::class,
+                    )
+                },
+                YawnValueProjector<Any, Long> { ProjectionNode.property(pagesCol) },
+            ) { name, sentinel, pages -> Triple(name, sentinel, pages) }
+        }
+
+        val resolved = resolve(projector)
+
+        assertThat(resolved.nodes).hasSize(3)
+        assertThat(resolved.mapRow(listOf("The Hobbit", 111L, 300L)))
+            .isEqualTo(Triple("The Hobbit", 111L, 300L))
     }
 
     data class AuthorSummary(

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
@@ -245,8 +245,8 @@ internal class ResolvedProjectionAdapterTest : BaseYawnDatabaseTest() {
                         YawnValueProjector<Book, Long> {
                             ProjectionNode.sql(
                                 sqlExpression = "COUNT(*) AS total",
-                                aliases = listOf("total"),
-                                resultTypes = listOf(Long::class),
+                                columnAlias = "total",
+                                resultType = Long::class,
                             )
                         },
                     ),
@@ -787,8 +787,8 @@ internal class ResolvedProjectionAdapterTest : BaseYawnDatabaseTest() {
     ): YawnValueProjector<SOURCE, TO> = YawnValueProjector {
         ProjectionNode.sql(
             sqlExpression = "$expression AS $alias",
-            aliases = listOf(alias),
-            resultTypes = listOf(Date::class),
+            columnAlias = alias,
+            resultType = Date::class,
         )
     }
 


### PR DESCRIPTION
`ProjectionLeaf.Sql` took `aliases: List<String>` and `resultTypes: List<KClass<*>>`, implying it could project several columns. It cannot: a leaf becomes exactly one `ProjectionNode.Value`, which occupies exactly one slot in the resolved result row and whose mapper receives a single value.

Declaring more than one column silently corrupted the whole projection. The extra columns shifted every subsequent slot, so the last value was dropped and everything after the leaf read the wrong column:

```kotlin
ProjectionNode.composite(
    YawnValueProjector { ProjectionNode.property(books.name) },
    YawnValueProjector {
        ProjectionNode.sql("111 AS c1, 222 AS c2", aliases = listOf("c1", "c2"), resultTypes = listOf(Long::class, Long::class))
    },
    YawnValueProjector { ProjectionNode.property(books.numberOfPages) },
) { a, b, c -> Triple(a, b, c) }

// got:      ("The Hobbit", 111, 222)   <- numberOfPages (300) silently dropped
// expected: ("The Hobbit", <value>, 300)
```

The new API makes this impossible:

```diff
 data class Sql<SOURCE : Any>(
     val sqlExpression: String,
-    val aliases: List<String>,
-    val resultTypes: List<KClass<*>>,
+    val columnAlias: String,
+    val resultType: KClass<*>,
 ) : ProjectionLeaf<SOURCE>
```

`ResolvedProjectionAdapter.compileSql` now wraps the single column into the parallel arrays Hibernate wants. That is the right home for it: `ProjectionLeaf` is documented as "an ORM-agnostic descriptor of a single atomic projection", so mirroring the ORM's array arity was a leak the adapter should absorb.

`columnAlias` (singular, and renamed) disambiguates from the `{alias}` *table* placeholder inside `sqlExpression`. Those are two unrelated things that were both called "alias".

This _is_ a breaking change, but we are not using v2 yet, so I am not adding a deprecated multi-state migration path.