### PR TITLE
fix: Multiple constant selectors on same query no longer collide

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
@@ -174,9 +174,10 @@ object YawnProjections {
         private val constant: String,
     ) : YawnQueryProjection<SOURCE, String> {
         override fun compile(context: YawnCompilationContext): Projection {
+            val alias = context.generateResultAlias()
             return Projections.sqlProjection(
-                "'$constant' as $CONSTANT_ALIAS",
-                arrayOf(CONSTANT_ALIAS),
+                "'$constant' as $alias",
+                arrayOf(alias),
                 arrayOf(StandardBasicTypes.STRING),
             )
         }
@@ -209,9 +210,10 @@ object YawnProjections {
 
     internal class Null<SOURCE : Any, FROM : Any> : YawnQueryProjection<SOURCE, FROM?> {
         override fun compile(context: YawnCompilationContext): Projection {
+            val alias = context.generateResultAlias()
             return Projections.sqlProjection(
-                "null as $CONSTANT_ALIAS",
-                arrayOf(CONSTANT_ALIAS),
+                "null as $alias",
+                arrayOf(alias),
                 arrayOf(StandardBasicTypes.STRING),
             )
         }
@@ -276,5 +278,3 @@ object YawnProjections {
         return TripleProjection(firstProjection, secondProjection, thirdProjection)
     }
 }
-
-private const val CONSTANT_ALIAS = "_yawn_ct"

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnCompilationContext.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnCompilationContext.kt
@@ -12,6 +12,8 @@ data class YawnCompilationContext(
 ) {
     private val aliasManager: YawnAliasManager = YawnAliasManager()
 
+    private var resultAliasCounter: Int = 0
+
     fun generateAlias(tableDef: YawnTableDef<*, *>): String? {
         return generateAlias(tableDef.parent)
     }
@@ -20,9 +22,23 @@ data class YawnCompilationContext(
         return aliasManager.generate(parent, this)
     }
 
+    /**
+     * Generates an alias for a projected SQL value, unique within this compilation.
+     *
+     * A projection that selects a raw SQL value must name it, so that the ORM can read that value back out of the
+     * result set. Two projections in the same projection list sharing one name are indistinguishable at read time,
+     * and both end up reading whichever column the name resolves to first.
+     *
+     * Note that this is unrelated to [generateAlias]: those name the *tables* a query selects from, whereas this
+     * names a single *column* the query selects.
+     */
+    internal fun generateResultAlias(): String = "$RESULT_ALIAS_PREFIX${resultAliasCounter++}"
+
     companion object {
         fun fromQuery(query: YawnQuery<*, *>): YawnCompilationContext {
             return YawnCompilationContext(withSubQuery = query.hasSubQuery())
         }
     }
 }
+
+private const val RESULT_ALIAS_PREFIX = "_yawn_ct"

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -647,7 +647,7 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
                 project(
                     YawnProjectionTest_NullabilityAllowanceProjection.create(
                         name = books.name,
-                        // TODO(yawn): support selectConstant for non-String types and multiple different values
+                        // TODO(yawn): support selectConstant for non-String types
                         aLong = books.numberOfPages,
                         aNullableLong = YawnProjections.`null`(),
                         aString = authors.name,
@@ -669,6 +669,77 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
                     aLong = 100,
                     aNullableLong = null,
                     aString = "Hans Christian Andersen",
+                    aNullableString = null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `multiple distinct constants in one projection do not collide`() {
+        transactor.open { session ->
+            val pair = session.project(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+                project(
+                    YawnProjections.pair(
+                        YawnProjections.selectConstant("one"),
+                        YawnProjections.selectConstant("two"),
+                    ),
+                )
+            }.uniqueResult()!!
+
+            assertThat(pair).isEqualTo("one" to "two")
+        }
+    }
+
+    @Test
+    fun `constants and nulls in one projection each get their own slot`() {
+        transactor.open { session ->
+            val triple = session.project(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+                project(
+                    YawnProjections.triple(
+                        YawnProjections.selectConstant("first"),
+                        YawnProjections.`null`<Book, Long>(),
+                        YawnProjections.selectConstant("third"),
+                    ),
+                )
+            }.uniqueResult()!!
+
+            assertThat(triple).isEqualTo(Triple("first", null, "third"))
+        }
+    }
+
+    @Test
+    fun `constants compose with real columns without shifting slots`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                addIn(books.name, setOf("The Hobbit", "The Little Mermaid"))
+                orderAsc(books.name)
+                project(
+                    YawnProjectionTest_NullabilityAllowanceProjection.create(
+                        name = books.name,
+                        aLong = books.numberOfPages,
+                        aNullableLong = YawnProjections.`null`(),
+                        aString = YawnProjections.selectConstant("constant"),
+                        aNullableString = YawnProjections.`null`(),
+                    ),
+                )
+            }.list()
+
+            assertThat(results).containsExactly(
+                NullabilityAllowance(
+                    name = "The Hobbit",
+                    aLong = 300,
+                    aNullableLong = null,
+                    aString = "constant",
+                    aNullableString = null,
+                ),
+                NullabilityAllowance(
+                    name = "The Little Mermaid",
+                    aLong = 100,
+                    aNullableLong = null,
+                    aString = "constant",
                     aNullableString = null,
                 ),
             )

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSimpleQueriesTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSimpleQueriesTest.kt
@@ -29,7 +29,7 @@ internal class YawnSimpleQueriesTest : BaseYawnDatabaseTest() {
          *
          * Example:
          *     SELECT
-         *         '1' as _yawn_ct
+         *         '1' as _yawn_ct0
          *     FROM
          *         books this_
          *     WHERE


### PR DESCRIPTION
Fixes partially the TODO on the old (v1) constant selector helper that would use the same alias causing possible conflicts on queries with more than one. Just tidying up but might be superseded later by the new projection mapping feature.

Want to make sure we have the tests in place to ensure the new pipeline can support these cases.