### PR TITLE
refactor: Render SQL projections through custom Hibernate Projection

### DIFF
--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
@@ -72,11 +72,11 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
     }
 
     private fun compileSql(leaf: ProjectionLeaf.Sql<SOURCE>): Projection {
-        // A leaf is always a single column; Hibernate wants parallel arrays, so wrap it here at the ORM boundary.
-        return Projections.sqlProjection(
-            leaf.sqlExpression,
-            arrayOf(leaf.columnAlias),
-            arrayOf(leaf.resultType.toHibernateType()),
+        // A leaf is always a single column, so this renders as a single aliased value.
+        return YawnSqlProjection(
+            sqlExpression = leaf.sqlExpression,
+            columnAlias = leaf.columnAlias,
+            type = leaf.resultType.toHibernateType(),
         )
     }
 

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlProjection.kt
@@ -1,0 +1,65 @@
+package com.faire.yawn.project
+
+import org.hibernate.Criteria
+import org.hibernate.criterion.CriteriaQuery
+import org.hibernate.criterion.Projection
+import org.hibernate.type.Type
+
+/**
+ * Hibernate [Projection] for a single raw SQL value.
+ *
+ * Yawn implements this rather than calling `Projections.sqlProjection`, because rendering the SQL ourselves is
+ * what gives us access to [CriteriaQuery] at render time. That is the only place the ORM will resolve an entity
+ * property to the physical column(s) backing it, which raw SQL has to name.
+ *
+ * This renders exactly what Hibernate's own SQL projection does: [sqlExpression] verbatim, with `{alias}`
+ * substituted, selected under [columnAlias]. The expression is therefore expected to name its own result.
+ */
+internal class YawnSqlProjection(
+    private val sqlExpression: String,
+    private val columnAlias: String,
+    private val type: Type,
+) : Projection {
+    override fun toSqlString(
+        criteria: Criteria,
+        position: Int,
+        criteriaQuery: CriteriaQuery,
+    ): String {
+        // `{alias}` is substituted with the SQL alias of the table this criteria selects from, matching how
+        // Hibernate's own SQL projections behave.
+        return sqlExpression.replace(TABLE_ALIAS_PLACEHOLDER, criteriaQuery.getSQLAlias(criteria))
+    }
+
+    override fun toGroupSqlString(
+        criteria: Criteria,
+        criteriaQuery: CriteriaQuery,
+    ): String = ""
+
+    override fun getTypes(
+        criteria: Criteria,
+        criteriaQuery: CriteriaQuery,
+    ): Array<Type> = arrayOf(type)
+
+    /** Only meaningful for projections addressable by a user-facing alias, which this is not. */
+    override fun getTypes(
+        alias: String?,
+        criteria: Criteria,
+        criteriaQuery: CriteriaQuery,
+    ): Array<Type>? = null
+
+    override fun getColumnAliases(position: Int): Array<String> = arrayOf(columnAlias)
+
+    /** Only meaningful for projections addressable by a user-facing alias, which this is not. */
+    override fun getColumnAliases(
+        alias: String?,
+        position: Int,
+    ): Array<String>? = null
+
+    override fun getAliases(): Array<String> = arrayOf(columnAlias)
+
+    override fun isGrouped(): Boolean = false
+
+    private companion object {
+        private const val TABLE_ALIAS_PLACEHOLDER = "{alias}"
+    }
+}


### PR DESCRIPTION
Groundwork, no behaviour change.

`ResolvedProjectionAdapter` compiled a `ProjectionLeaf.Sql` by calling `Projections.sqlProjection(...)`, which hands the rendering off to Hibernate. That is a dead end for two things we want next:

- **Column resolution.** Raw SQL has to name *physical columns*, but a `YawnColumnDef` knows an entity property path. Resolving one to the other requires `CriteriaQuery.getColumnsUsingProjection(...)`, and a `CriteriaQuery` only exists inside `Projection.toSqlString(criteria, position, criteriaQuery)`, i.e. only if we render.
- **Grouped SQL projections.** `Projections.sqlGroupProjection` carries a separate `GROUP BY` clause, expressed via `isGrouped()` / `toGroupSqlString()`. Yawn currently has no way to produce one, so those queries cannot be written through the v2 pipeline at all.

So this replaces the one call with our own `Projection` implementation, rendering byte-identical SQL:

```diff
-        return Projections.sqlProjection(
-            leaf.sqlExpression,
-            arrayOf(leaf.columnAlias),
-            arrayOf(leaf.resultType.toHibernateType()),
-        )
+        return YawnSqlProjection(
+            sqlExpression = leaf.sqlExpression,
+            columnAlias = leaf.columnAlias,
+            type = leaf.resultType.toHibernateType(),
+        )
```

`YawnSqlProjection` emits `sqlExpression` verbatim with `{alias}` substituted via `criteriaQuery.getSQLAlias(criteria)`, matching how Hibernate's own SQL projection behaves, selected under the caller-supplied `columnAlias`. The remaining seven SPI methods are the trivial single-column answers.
`isGrouped()` returns `false` and `toGroupSqlString()` returns `""` for now; those are the hooks the follow-up uses.

This should be a complete refactor with no behaviour change.