### PR TITLE
feat: Support comparing columns of different nullability on lt/gt/le/ge

### DIFF
--- a/docs/nullability.md
+++ b/docs/nullability.md
@@ -68,6 +68,26 @@ addEq(nullable(image.url), images.originalUrl)
 That could also be useful for custom projections, though we have special code baked in the projection generated code to automatically support both nullable and
 non-nullable columns.
 
+## Comparing two columns of different nullability
+
+For the ordering comparisons (`lt`, `le`, `gt` and `ge`), `YawnRestrictions` also accepts a nullable column against a non-nullable column of the same underlying
+type, in either position, so no `nullable` call is needed:
+
+```kotlin
+// in a Yawn lambda; `books.notes` is a `ColumnDef<String?>` while `books.name` is a `ColumnDef<String>`
+add(lt(books.notes, books.name)) // ok!
+add(lt(books.name, books.notes)) // ok as well!
+```
+
+This is not the loose typing rejected above: both columns must still share the same underlying type, so comparing a `ColumnDef<String?>` against a
+`ColumnDef<Long>` remains a compile error.
+
+These comparisons follow plain SQL semantics: a row where the nullable column is `NULL` never matches, since the comparison evaluates to `NULL` and not to
+`TRUE`. If you want such rows to match, combine the criterion with an explicit `isNull` check using `or`.
+
+Note that the `addLt`/`addLe`/`addGt`/`addGe` shorthands of the query DSL only take columns of the exact same type; inside a Yawn lambda you can either wrap the
+non-nullable column with `nullable(...)` or use `add(lt(...))` with the `YawnRestrictions` function directly.
+
 ## Custom Projections
 
 There are also some considerations regarding custom projections (i.e., with a data class and `@YawnProjection`).

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
@@ -58,9 +58,15 @@ interface YawnQueryRestriction<SOURCE : Any> {
         ): Criterion = Restrictions.gt(property.generatePath(context), property.adaptValue(value))
     }
 
+    /**
+     * @param F the common type of both columns being compared; the columns are accepted covariantly so that two
+     * columns of the same underlying type but different nullability can be compared (e.g. a `YawnColumnDef<Instant?>`
+     * against a `YawnColumnDef<Instant>`, with `F = Instant?`). Comparing two unrelated types is prevented by the
+     * [YawnRestrictions] factory functions, which is where type-safety is enforced.
+     */
     class GreaterThanProperty<SOURCE : Any, F>(
-        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
     ) : YawnQueryRestriction<SOURCE> {
         override fun compile(
             context: YawnCompilationContext,
@@ -76,9 +82,12 @@ interface YawnQueryRestriction<SOURCE : Any> {
         ): Criterion = Restrictions.ge(property.generatePath(context), property.adaptValue(value))
     }
 
+    /**
+     * @param F see [GreaterThanProperty].
+     */
     class GreaterThanOrEqualToProperty<SOURCE : Any, F>(
-        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
     ) : YawnQueryRestriction<SOURCE> {
         override fun compile(
             context: YawnCompilationContext,
@@ -94,9 +103,12 @@ interface YawnQueryRestriction<SOURCE : Any> {
         ): Criterion = Restrictions.lt(property.generatePath(context), property.adaptValue(value))
     }
 
+    /**
+     * @param F see [GreaterThanProperty].
+     */
     class LessThanProperty<SOURCE : Any, F>(
-        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
     ) : YawnQueryRestriction<SOURCE> {
         override fun compile(
             context: YawnCompilationContext,
@@ -112,9 +124,12 @@ interface YawnQueryRestriction<SOURCE : Any> {
         ): Criterion = Restrictions.le(property.generatePath(context), property.adaptValue(value))
     }
 
+    /**
+     * @param F see [GreaterThanProperty].
+     */
     class LessThanOrEqualToProperty<SOURCE : Any, F>(
-        private val property: YawnDef<SOURCE, *>.YawnColumnDef<F>,
-        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        private val property: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
+        private val otherProperty: YawnDef<SOURCE, *>.YawnColumnDef<out F>,
     ) : YawnQueryRestriction<SOURCE> {
         override fun compile(
             context: YawnCompilationContext,

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryRestriction.kt
@@ -59,10 +59,10 @@ interface YawnQueryRestriction<SOURCE : Any> {
     }
 
     /**
-     * @param F the common type of both columns being compared; the columns are accepted covariantly so that two
-     * columns of the same underlying type but different nullability can be compared (e.g. a `YawnColumnDef<Instant?>`
-     * against a `YawnColumnDef<Instant>`, with `F = Instant?`). Comparing two unrelated types is prevented by the
-     * [YawnRestrictions] factory functions, which is where type-safety is enforced.
+     * @param F the common type of both columns being compared; each column is accepted as a `YawnColumnDef<out F>`,
+     * so that two columns of the same underlying type but different nullability can be compared (e.g. a
+     * `YawnColumnDef<Instant?>` against a `YawnColumnDef<Instant>`, with `F = Instant?`). Comparing two unrelated
+     * types is prevented by the [YawnRestrictions] factory functions, which is where type-safety is enforced.
      */
     class GreaterThanProperty<SOURCE : Any, F>(
         private val property: YawnDef<SOURCE, *>.YawnColumnDef<out F>,

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnRestrictions.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnRestrictions.kt
@@ -75,6 +75,30 @@ object YawnRestrictions {
         return YawnQueryCriterion(GreaterThanProperty(column, otherColumn))
     }
 
+    /**
+     * Compares a nullable column against a non-nullable column of the same underlying type.
+     * See the note on nullable comparisons on [lt].
+     */
+    @JvmName("gtNullableToNonNullProperty")
+    fun <SOURCE : Any, F : Any> gt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanProperty<SOURCE, F?>(column, otherColumn))
+    }
+
+    /**
+     * Compares a non-nullable column against a nullable column of the same underlying type.
+     * See the note on nullable comparisons on [lt].
+     */
+    @JvmName("gtNonNullToNullableProperty")
+    fun <SOURCE : Any, F : Any> gt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanProperty<SOURCE, F?>(column, otherColumn))
+    }
+
     fun <SOURCE : Any, F> ge(
         column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
         value: F & Any,
@@ -87,6 +111,30 @@ object YawnRestrictions {
         otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
     ): YawnQueryCriterion<SOURCE> {
         return YawnQueryCriterion(GreaterThanOrEqualToProperty(column, otherColumn))
+    }
+
+    /**
+     * Compares a nullable column against a non-nullable column of the same underlying type.
+     * See the note on nullable comparisons on [lt].
+     */
+    @JvmName("geNullableToNonNullProperty")
+    fun <SOURCE : Any, F : Any> ge(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanOrEqualToProperty<SOURCE, F?>(column, otherColumn))
+    }
+
+    /**
+     * Compares a non-nullable column against a nullable column of the same underlying type.
+     * See the note on nullable comparisons on [lt].
+     */
+    @JvmName("geNonNullToNullableProperty")
+    fun <SOURCE : Any, F : Any> ge(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(GreaterThanOrEqualToProperty<SOURCE, F?>(column, otherColumn))
     }
 
     fun <SOURCE : Any, F> lt(
@@ -103,6 +151,32 @@ object YawnRestrictions {
         return YawnQueryCriterion(LessThanProperty(column, otherColumn))
     }
 
+    /**
+     * Compares a nullable column against a non-nullable column of the same underlying type.
+     *
+     * Note that this follows plain SQL semantics: a row where the nullable column is `NULL` never matches
+     * (the comparison evaluates to `NULL`, not to `TRUE`), so such rows are filtered out of the results.
+     */
+    @JvmName("ltNullableToNonNullProperty")
+    fun <SOURCE : Any, F : Any> lt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanProperty<SOURCE, F?>(column, otherColumn))
+    }
+
+    /**
+     * Compares a non-nullable column against a nullable column of the same underlying type.
+     * See the note on nullable comparisons on [lt].
+     */
+    @JvmName("ltNonNullToNullableProperty")
+    fun <SOURCE : Any, F : Any> lt(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanProperty<SOURCE, F?>(column, otherColumn))
+    }
+
     fun <SOURCE : Any, F> le(
         column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
         value: F & Any,
@@ -115,6 +189,30 @@ object YawnRestrictions {
         otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
     ): YawnQueryCriterion<SOURCE> {
         return YawnQueryCriterion(LessThanOrEqualToProperty(column, otherColumn))
+    }
+
+    /**
+     * Compares a nullable column against a non-nullable column of the same underlying type.
+     * See the note on nullable comparisons on [lt].
+     */
+    @JvmName("leNullableToNonNullProperty")
+    fun <SOURCE : Any, F : Any> le(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanOrEqualToProperty<SOURCE, F?>(column, otherColumn))
+    }
+
+    /**
+     * Compares a non-nullable column against a nullable column of the same underlying type.
+     * See the note on nullable comparisons on [lt].
+     */
+    @JvmName("leNonNullToNullableProperty")
+    fun <SOURCE : Any, F : Any> le(
+        column: YawnDef<SOURCE, *>.YawnColumnDef<F>,
+        otherColumn: YawnDef<SOURCE, *>.YawnColumnDef<F?>,
+    ): YawnQueryCriterion<SOURCE> {
+        return YawnQueryCriterion(LessThanOrEqualToProperty<SOURCE, F?>(column, otherColumn))
     }
 
     fun <SOURCE : Any, F> between(

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnCriterionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnCriterionTest.kt
@@ -384,6 +384,183 @@ internal class YawnCriterionTest : BaseYawnDatabaseTest() {
         }
     }
 
+    /**
+     * `notes` is a nullable column and `name` is not, but they share the same underlying type, so they can be
+     * compared against each other. Only the three books that have notes can ever match, as a comparison against
+     * `NULL` is never true.
+     *
+     * The three books with notes compare as follows:
+     * * "Note for Lord of the Rings" > "Lord of the Rings"
+     * * "Note for The Hobbit and Harry Potter" < "The Hobbit"
+     * * "Note for The Hobbit and Harry Potter" > "Harry Potter"
+     */
+    @Test
+    fun `lt nullable column against non-nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    lt(books.notes, books.name),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("The Hobbit")
+        }
+    }
+
+    @Test
+    fun `lt non-nullable column against nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    lt(books.name, books.notes),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "Harry Potter",
+                )
+        }
+    }
+
+    @Test
+    fun `gt nullable column against non-nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    gt(books.notes, books.name),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "Harry Potter",
+                )
+        }
+    }
+
+    @Test
+    fun `gt non-nullable column against nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    gt(books.name, books.notes),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("The Hobbit")
+        }
+    }
+
+    @Test
+    fun `le nullable column against non-nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    le(books.notes, books.name),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("The Hobbit")
+        }
+    }
+
+    @Test
+    fun `le non-nullable column against nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    le(books.name, books.notes),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "Harry Potter",
+                )
+        }
+    }
+
+    @Test
+    fun `ge nullable column against non-nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    ge(books.notes, books.name),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder(
+                    "Lord of the Rings",
+                    "Harry Potter",
+                )
+        }
+    }
+
+    @Test
+    fun `ge non-nullable column against nullable column`() {
+        transactor.open { session ->
+            val results = session.query(BookTable) { books ->
+                add(
+                    ge(books.name, books.notes),
+                )
+            }.list()
+
+            assertThat(results)
+                .extracting("name")
+                .containsExactlyInAnyOrder("The Hobbit")
+        }
+    }
+
+    /**
+     * Comparing a nullable column against the very same column (made non-nullable by [addIsNotNull]) isolates the
+     * behavior on equal values: only `le` and `ge` match, while `lt` and `gt` never do.
+     */
+    @Test
+    fun `nullable column comparisons against non-nullable column with equal values`() {
+        transactor.open { session ->
+            val booksWithNotes = listOf(
+                "Lord of the Rings",
+                "The Hobbit",
+                "Harry Potter",
+            )
+
+            val leResults = session.query(BookTable) { books ->
+                add(le(books.notes, addIsNotNull(books.notes)))
+            }.list()
+            assertThat(leResults).extracting("name").containsExactlyInAnyOrderElementsOf(booksWithNotes)
+
+            val geResults = session.query(BookTable) { books ->
+                add(ge(addIsNotNull(books.notes), books.notes))
+            }.list()
+            assertThat(geResults).extracting("name").containsExactlyInAnyOrderElementsOf(booksWithNotes)
+
+            val ltResults = session.query(BookTable) { books ->
+                add(lt(books.notes, addIsNotNull(books.notes)))
+            }.list()
+            assertThat(ltResults).isEmpty()
+
+            val gtResults = session.query(BookTable) { books ->
+                add(gt(addIsNotNull(books.notes), books.notes))
+            }.list()
+            assertThat(gtResults).isEmpty()
+        }
+    }
+
     @Test
     fun `between column with low and high values`() {
         transactor.open { session ->


### PR DESCRIPTION
## Summary

`YawnRestrictions.lt/gt/le/ge` (and the underlying `LessThanProperty`, `GreaterThanProperty`, `LessThanOrEqualToProperty` and `GreaterThanOrEqualToProperty` restrictions) required both columns of a property-to-property comparison to have the *exact* same type parameter `F`. That meant a `YawnColumnDef<DateTime?>` could not be compared against a `YawnColumnDef<DateTime>`, even though nullability plays no role in the generated SQL — both sides are just paths.

This PR adds overloads accepting a nullable column against a non-nullable column of the same underlying type, in **both** positions, for all four ordering comparisons:

```kotlin
// books.notes is a ColumnDef<String?>, books.name is a ColumnDef<String>
add(lt(books.notes, books.name)) // now compiles
add(lt(books.name, books.notes)) // ditto
```

Both directions are supported because either operand can plausibly be the nullable one (e.g. `lt(entity.createdAt, entity.deletedAt)` vs. `lt(entity.deletedAt, entity.createdAt)`).

## Why This Change Is Needed

Two call sites in `backend` have each hand-rolled the same private `NullableLtPropertyRestriction<SOURCE>` class, hardcoded to `DateTime?`/`DateTime`, purely to work around this gap (`MessengerConversationParticipantQueries.kt`, and `NewMessageEmailNotificationTask.kt` in Faire/backend#287647). Both implement `compile()` as a plain `Restrictions.ltProperty(...)` of the two paths — no value adaptation involved — which is exactly what Yawn itself does.

The existing escape hatch, `nullable(column)`, only helps inside a Yawn lambda (it is a member of `BaseYawnQueryScope`); it is not reachable when building a `YawnQueryCriterion` outside of one, which is what both call sites do.

## Implementation

* The four `*Property` restriction classes now take their columns covariantly (`YawnColumnDef<out F>`) so a single class can carry two operands of slightly different nullability. Their `compile()` only ever needs `generatePath`, so nothing else changes.
* Type-safety is enforced where it was before — in the `YawnRestrictions` factory functions. The new overloads are `<F : Any>(YawnColumnDef<F?>, YawnColumnDef<F>)` (and its mirror), so the two columns must still share the same underlying type: `lt(books.notes /* String? */, books.numberOfPages /* Long */)` remains a compile error (verified). This deliberately avoids the `where F1 : F, F2 : F` shape that `docs/nullability.md` rejects, which would resolve for *any* two types via a common supertype.
* `@JvmName` is used on the new overloads to avoid a JVM platform declaration clash with the existing same-type overloads (identical erasure).
* Purely additive: every existing same-type overload is untouched, and the erased JVM signatures of the restriction classes are unchanged.

The `addLt`/`addLe`/`addGt`/`addGe` shorthands of the query DSL were intentionally left alone: they live on a `sealed interface` with default implementations, and Kotlin does not allow `@JvmName` on open members, so the same overloads cannot be added there. Inside a Yawn lambda, `nullable(...)` or `add(lt(...))` covers the case; this is now documented.

## Tests

`YawnCriterionTest` gains nine tests, comparing `books.notes` (`String?`) against `books.name` (`String`) for `lt`, `gt`, `le` and `ge` in both nullability directions, asserting that rows with a `NULL` note never match. A final test compares a nullable column against the very same column made non-nullable via `addIsNotNull`, which isolates the behavior on *equal* values so `le`/`ge` are distinguishable from `lt`/`gt`.

`./gradlew build` passes (compile, tests, detekt, formatting).

## Follow-up (not in this PR)

Once this is released in a new Yawn version, both `backend` call sites can drop their private `NullableLtPropertyRestriction` classes and call `YawnRestrictions.lt` directly. No changes were made to `backend` or to Faire/backend#287647 here.

## Related

* `docs/nullability.md` updated with a section on comparing columns of different nullability.

---
_Generated by [Claude Code](https://claude.ai/code)_
