### PR TITLE
feat: Add sqlValue helper for single-value custom SQL projections

### DIFF
--- a/docs/projections.md
+++ b/docs/projections.md
@@ -120,7 +120,7 @@ When the value you want isn’t expressible with the built-in functions, project
 `YawnQueryProjection` by hand:
 
 ```kotlin
-project(YawnProjections.sqlValue<Long> { "SUM(${books.quantity.sql} * ${books.priceMinor.sql})" })
+project(sqlValue<Long> { "SUM(${books.quantity.sql} * ${books.priceMinor.sql})" })
 ```
 
 Reference columns through `.sql`, which **Yawn** substitutes with the physical column backing that property, already qualified by its table’s alias. This works
@@ -130,7 +130,7 @@ one explicitly, and `.sql` keeps working when they don’t.
 The type argument decides how the result is mapped, and should be nullable when the expression can evaluate to `NULL`:
 
 ```kotlin
-project(YawnProjections.sqlValue<Int?> { "NULLIF(${books.rating.sql}, 0)" })
+project(sqlValue<Int?> { "NULLIF(${books.rating.sql}, 0)" })
 ```
 
 The result composes anywhere an ordinary column does — inside `pair`, `triple`, or a data class projection:
@@ -139,12 +139,23 @@ The result composes anywhere an ordinary column does — inside `pair`, `triple`
 project(
   BookSummaryProjection.create(
     author = YawnProjections.groupBy(authors.name),
-    totalPages = YawnProjections.sqlValue<Long> { "SUM(${books.numberOfPages.sql})" },
+    totalPages = sqlValue<Long> { "SUM(${books.numberOfPages.sql})" },
   ),
 )
 ```
 
 Do not name the result yourself (no `AS total`): **Yawn** selects it under an alias it generates, so two SQL values in one query can never collide.
+
+`sqlValue` lives on the projected query scope, so it already knows what you are selecting from and only the result type has to be named. To share one across
+queries, write a helper on that scope, taking the table definition as a parameter:
+
+```kotlin
+private fun BookProjectedQueryScope<Long>.totalPages(
+  books: BookTableDefType,
+): YawnSingleValueProjection<Book, Long> {
+  return sqlValue<Long> { "SUM(${books.numberOfPages.sql})" }
+}
+```
 
 > [!WARNING]
 > 🥱 Raw SQL projections cannot bind parameters, so anything you interpolate into the expression is inlined into the statement verbatim. Never build one out of
@@ -203,8 +214,8 @@ internal data class AuthorAndBooks(
 yawn.project(BookTable) {
   project(
     AuthorAndBooksProjectionDef.create(
-      author = TypedProjections.groupBy(books.author),
-      numberOfBooks = TypedProjections.count(books.name),
+      author = YawnProjections.groupBy(books.author),
+      numberOfBooks = YawnProjections.count(books.name),
     ),
   )
 }
@@ -222,8 +233,8 @@ In order to further refine a projection, i.e. add conditions on top of projected
 ```kotlin
 project(
   AuthorAndBooksProjectionDef.create(
-    author = TypedProjections.groupBy(books.author),
-    numberOfBooks = TypedProjections.count(books.name),
+    author = YawnProjections.groupBy(books.author),
+    numberOfBooks = YawnProjections.count(books.name),
   ),
 ) { authorAndBooks ->
   addGe(authorAndBooks.numberOfBooks, 1)

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -114,57 +114,6 @@ sorting in Kotlin. The value returned by `orderDescBy`/`orderAscBy` must be pass
 inside a `pair`/`triple`/`@YawnProjection` data class is fine): the expression can only be ordered by once it's also
 selected, so if the returned value isn't projected, resolving the order will fail at query time.
 
-### Project to Custom SQL
-
-When the value you want isn’t expressible with the built-in functions, project a single raw SQL expression with `sqlValue`, instead of implementing
-`YawnQueryProjection` by hand:
-
-```kotlin
-project(sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" })
-```
-
-Reference columns through `.sql`, which **Yawn** substitutes with the physical column backing that property, already qualified by its table’s alias. This works
-for joined tables and embedded types too. Prefer it over writing column names by hand: a property’s name and its column’s name coincide only until someone maps
-one explicitly, and `.sql` keeps working when they don’t.
-
-The type argument decides how the result is mapped, and should be nullable when the expression can evaluate to `NULL`:
-
-```kotlin
-project(sqlValue<Int?> { "NULLIF(${books.rating.sql}, 0)" })
-```
-
-The result composes anywhere an ordinary column does — inside `pair`, `triple`, or a data class projection:
-
-```kotlin
-val pagesPrintedPerAuthor = yawn.project(BookTable) { books ->
-  val authors = join(books.author)
-
-  project(
-    YawnProjections.pair(
-      YawnProjections.groupBy(authors.name),
-      sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" },
-    ),
-  )
-}.list()
-```
-
-Do not name the result yourself (no `AS total`): **Yawn** selects it under an alias it generates, so two SQL values in one query can never collide.
-
-`sqlValue` lives on the projected query scope, so it already knows what you are selecting from and only the result type has to be named. To share one across
-queries, write a helper on that scope, taking the table definition as a parameter:
-
-```kotlin
-private fun BookProjectedQueryScope<Long>.pagesPrinted(
-  books: BookTableDefType,
-): YawnSingleValueProjection<Book, Long> {
-  return sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" }
-}
-```
-
-> [!WARNING]
-> 🥱 Raw SQL projections cannot bind parameters, so anything you interpolate into the expression is inlined into the statement verbatim. Never build one out of
-> untrusted input. And as with any raw SQL, the result type is a claim **Yawn** takes at face value — it cannot verify that your expression really produces it.
-
 ### Project to Data Class
 
 Sometimes you want to return more than a single field. For that, you can project to a data class with any assortment of columns you desire, built off of other
@@ -224,6 +173,57 @@ yawn.project(BookTable) {
   )
 }
 ```
+
+### Project to Custom SQL
+
+When the value you want isn’t expressible with the built-in functions, project a single raw SQL expression with `sqlValue`, instead of implementing
+`YawnQueryProjection` by hand:
+
+```kotlin
+project(sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" })
+```
+
+Reference columns through `.sql`, which **Yawn** substitutes with the physical column backing that property, already qualified by its table’s alias. This works
+for joined tables and embedded types too. Prefer it over writing column names by hand: a property’s name and its column’s name coincide only until someone maps
+one explicitly, and `.sql` keeps working when they don’t.
+
+The type argument decides how the result is mapped, and should be nullable when the expression can evaluate to `NULL`:
+
+```kotlin
+project(sqlValue<Int?> { "NULLIF(${books.rating.sql}, 0)" })
+```
+
+The result composes anywhere an ordinary column does — inside `pair`, `triple`, or a data class projection:
+
+```kotlin
+val pagesPrintedPerAuthor = yawn.project(BookTable) { books ->
+  val authors = join(books.author)
+
+  project(
+    YawnProjections.pair(
+      YawnProjections.groupBy(authors.name),
+      sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" },
+    ),
+  )
+}.list()
+```
+
+Do not name the result yourself (no `AS total`): **Yawn** selects it under an alias it generates, so two SQL values in one query can never collide.
+
+`sqlValue` lives on the projected query scope, so it already knows what you are selecting from and only the result type has to be named. To share one across
+queries, write a helper on that scope, taking the table definition as a parameter:
+
+```kotlin
+private fun BookProjectedQueryScope<Long>.pagesPrinted(
+  books: BookTableDefType,
+): YawnSingleValueProjection<Book, Long> {
+  return sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" }
+}
+```
+
+> [!WARNING]
+> 🥱 Raw SQL projections cannot bind parameters, so anything you interpolate into the expression is inlined into the statement verbatim. Never build one out of
+> untrusted input. And as with any raw SQL, the result type is a claim **Yawn** takes at face value — it cannot verify that your expression really produces it.
 
 ## Refine
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -120,7 +120,7 @@ When the value you want isn’t expressible with the built-in functions, project
 `YawnQueryProjection` by hand:
 
 ```kotlin
-project(sqlValue<Long> { "SUM(${books.quantity.sql} * ${books.priceMinor.sql})" })
+project(sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" })
 ```
 
 Reference columns through `.sql`, which **Yawn** substitutes with the physical column backing that property, already qualified by its table’s alias. This works
@@ -136,12 +136,16 @@ project(sqlValue<Int?> { "NULLIF(${books.rating.sql}, 0)" })
 The result composes anywhere an ordinary column does — inside `pair`, `triple`, or a data class projection:
 
 ```kotlin
-project(
-  BookSummaryProjection.create(
-    author = YawnProjections.groupBy(authors.name),
-    totalPages = sqlValue<Long> { "SUM(${books.numberOfPages.sql})" },
-  ),
-)
+val pagesPrintedPerAuthor = yawn.project(BookTable) { books ->
+  val authors = join(books.author)
+
+  project(
+    YawnProjections.pair(
+      YawnProjections.groupBy(authors.name),
+      sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" },
+    ),
+  )
+}.list()
 ```
 
 Do not name the result yourself (no `AS total`): **Yawn** selects it under an alias it generates, so two SQL values in one query can never collide.
@@ -150,10 +154,10 @@ Do not name the result yourself (no `AS total`): **Yawn** selects it under an al
 queries, write a helper on that scope, taking the table definition as a parameter:
 
 ```kotlin
-private fun BookProjectedQueryScope<Long>.totalPages(
+private fun BookProjectedQueryScope<Long>.pagesPrinted(
   books: BookTableDefType,
 ): YawnSingleValueProjection<Book, Long> {
-  return sqlValue<Long> { "SUM(${books.numberOfPages.sql})" }
+  return sqlValue<Long> { "SUM(${books.numberOfPages.sql} * ${books.sales.paperBacksSold.sql})" }
 }
 ```
 
@@ -213,7 +217,7 @@ internal data class AuthorAndBooks(
 // later:
 yawn.project(BookTable) {
   project(
-    AuthorAndBooksProjectionDef.create(
+    AuthorAndBooksProjection.create(
       author = YawnProjections.groupBy(books.author),
       numberOfBooks = YawnProjections.count(books.name),
     ),
@@ -232,7 +236,7 @@ In order to further refine a projection, i.e. add conditions on top of projected
 
 ```kotlin
 project(
-  AuthorAndBooksProjectionDef.create(
+  AuthorAndBooksProjection.create(
     author = YawnProjections.groupBy(books.author),
     numberOfBooks = YawnProjections.count(books.name),
   ),

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -114,6 +114,42 @@ sorting in Kotlin. The value returned by `orderDescBy`/`orderAscBy` must be pass
 inside a `pair`/`triple`/`@YawnProjection` data class is fine): the expression can only be ordered by once it's also
 selected, so if the returned value isn't projected, resolving the order will fail at query time.
 
+### Project to Custom SQL
+
+When the value you want isn’t expressible with the built-in functions, project a single raw SQL expression with `sqlValue`, instead of implementing
+`YawnQueryProjection` by hand:
+
+```kotlin
+project(YawnProjections.sqlValue<Long> { "SUM(${books.quantity.sql} * ${books.priceMinor.sql})" })
+```
+
+Reference columns through `.sql`, which **Yawn** substitutes with the physical column backing that property, already qualified by its table’s alias. This works
+for joined tables and embedded types too. Prefer it over writing column names by hand: a property’s name and its column’s name coincide only until someone maps
+one explicitly, and `.sql` keeps working when they don’t.
+
+The type argument decides how the result is mapped, and should be nullable when the expression can evaluate to `NULL`:
+
+```kotlin
+project(YawnProjections.sqlValue<Int?> { "NULLIF(${books.rating.sql}, 0)" })
+```
+
+The result composes anywhere an ordinary column does — inside `pair`, `triple`, or a data class projection:
+
+```kotlin
+project(
+  BookSummaryProjection.create(
+    author = YawnProjections.groupBy(authors.name),
+    totalPages = YawnProjections.sqlValue<Long> { "SUM(${books.numberOfPages.sql})" },
+  ),
+)
+```
+
+Do not name the result yourself (no `AS total`): **Yawn** selects it under an alias it generates, so two SQL values in one query can never collide.
+
+> [!WARNING]
+> 🥱 Raw SQL projections cannot bind parameters, so anything you interpolate into the expression is inlined into the statement verbatim. Never build one out of
+> untrusted input. And as with any raw SQL, the result type is a claim **Yawn** takes at face value — it cannot verify that your expression really produces it.
+
 ### Project to Data Class
 
 Sometimes you want to return more than a single field. For that, you can project to a data class with any assortment of columns you desire, built off of other

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/ProjectedYawnQueryScope.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/ProjectedYawnQueryScope.kt
@@ -2,7 +2,10 @@ package com.faire.yawn.criteria.query
 
 import com.faire.yawn.YawnTableDef
 import com.faire.yawn.project.YawnQueryProjection
+import com.faire.yawn.project.YawnRawSqlProjection
+import com.faire.yawn.project.YawnSqlScope
 import com.faire.yawn.query.YawnQuery
+import kotlin.reflect.typeOf
 
 /**
  * A context providing the DSL for Yawn projected queries.
@@ -39,6 +42,39 @@ private constructor(
         ensureUniqueProjection()
         return projection
     }
+
+    /**
+     * Projects a single value computed by a raw SQL [expression], e.g. `SUM(quantity * price)`.
+     *
+     * Use this instead of implementing [YawnQueryProjection] by hand when all you need is one custom SQL value.
+     * The result composes anywhere an ordinary column does; see [YawnSingleValueProjection].
+     *
+     * Reference columns through [YawnSqlScope.sql], which substitutes the physical column backing a property,
+     * already qualified by its table's alias:
+     *
+     * ```
+     * project(sqlValue<Long> { "SUM(${books.numberOfPages.sql} * 2)" })
+     * ```
+     *
+     * The type argument decides how the result is mapped, and should be nullable if the expression can evaluate
+     * to `NULL`. As with any raw SQL projection, this is a claim Yawn takes at face value rather than something
+     * it can verify: it is up to you to ensure the expression really does produce that type.
+     *
+     * Do not name the result yourself (no `AS total`): Yawn selects it under an alias it generates, unique within
+     * the query. Note also that raw SQL cannot bind parameters, so any value in [expression] is inlined verbatim;
+     * never interpolate untrusted input into it.
+     *
+     * To share one across queries, write a helper on this scope taking the table definition as a parameter, so that
+     * nothing is captured from the query it was written in:
+     *
+     * ```
+     * private fun BookProjectedQueryScope<Long>.doubledPages(books: BookTableDefType) =
+     *     sqlValue<Long> { "SUM(${books.numberOfPages.sql} * 2)" }
+     * ```
+     */
+    inline fun <reified TO> sqlValue(
+        noinline expression: YawnSqlScope<SOURCE>.() -> String,
+    ): YawnRawSqlProjection<SOURCE, TO> = YawnRawSqlProjection(expression, typeOf<TO>())
 
     companion object {
         internal fun <SOURCE : Any, T : Any, DEF : YawnTableDef<SOURCE, T>, PROJECTION : Any?> applyLambda(

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/CriteriaSqlScope.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/CriteriaSqlScope.kt
@@ -32,7 +32,7 @@ internal class CriteriaSqlScope<SOURCE : Any>(
 
             check(columns.size == 1) {
                 """
-                    Path "$path" is a multi-column mapping backend by columns (${columns.joinToString()}),
+                    Path "$path" is a multi-column mapping backed by columns (${columns.joinToString()}),
                     and thus has no single-value substitute into a SQL projection.
                     Reference one of its columns individually instead.
                 """.trimIndent()

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/CriteriaSqlScope.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/CriteriaSqlScope.kt
@@ -1,0 +1,43 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.query.YawnCompilationContext
+import org.hibernate.Criteria
+import org.hibernate.HibernateException
+import org.hibernate.criterion.CriteriaQuery
+
+/**
+ * The [YawnSqlScope] handed to an expression for a Hibernate Criteria query renderer.
+ * Responsible for providing a [YawnPathProvider] with a `.sql` compiler to render a SQL fragment in a projection.
+ */
+internal class CriteriaSqlScope<SOURCE : Any>(
+    private val context: YawnCompilationContext,
+    private val criteria: Criteria,
+    private val criteriaQuery: CriteriaQuery,
+) : YawnSqlScope<SOURCE> {
+    override val YawnPathProvider<SOURCE>.sql: String
+        get() {
+            val path = generatePath(context)
+
+            val columns = try {
+                criteriaQuery.getColumnsUsingProjection(criteria, path)
+            } catch (e: HibernateException) {
+                throw IllegalStateException(
+                    """
+                    Could not resolve path "$path" to a column in a SQL projection.
+                    If it is on a joined table, make sure the join is part of this query.
+                    """.trimIndent(),
+                    e,
+                )
+            }
+
+            check(columns.size == 1) {
+                """
+                    Path "$path" is a multi-column mapping backend by columns (${columns.joinToString()}),
+                    and thus has no single-value substitute into a SQL projection.
+                    Reference one of its columns individually instead.
+                """.trimIndent()
+            }
+
+            return columns.single()
+        }
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/HibernateYawnSqlProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/HibernateYawnSqlProjection.kt
@@ -1,0 +1,43 @@
+package com.faire.yawn.project
+
+import org.hibernate.Criteria
+import org.hibernate.criterion.CriteriaQuery
+
+/**
+ * A [YawnSqlProjection] that follows Hibernate's own `{alias}` convention for raw SQL projections.
+ *
+ * **Prefer [ProjectionLeaf.SqlValue] and [YawnProjections.sqlValue] over this.** It exists to compile the older
+ * string-based [ProjectionLeaf.Sql], whose expressions were written against `Projections.sqlProjection` and so
+ * expect its substitution behavior. Everything peculiar about that behavior is deliberately confined here.
+ *
+ * The expression names its own result, so it is emitted verbatim apart from the alias substitution.
+ */
+internal class HibernateYawnSqlProjection<SOURCE : Any>(
+    private val leaf: ProjectionLeaf.Sql<SOURCE>,
+) : YawnSqlProjection(leaf.columnAlias, leaf.resultType) {
+    override fun renderSql(
+        criteria: Criteria,
+        criteriaQuery: CriteriaQuery,
+    ): String {
+        // This substitution is not ours to choose: it reproduces, exactly, what Hibernate does for the raw SQL
+        // projections this leaf used to compile to, so that expressions already written against
+        // `Projections.sqlProjection` keep behaving identically. Compare `SQLProjection#toSqlString`:
+        // https://github.com/hibernate/hibernate-orm/blob/5.6/hibernate-core/src/main/java/org/hibernate/criterion/SQLProjection.java#L41
+        //
+        //     return StringHelper.replace( sql, "{alias}", criteriaQuery.getSQLAlias( criteria ) );
+        //
+        // Note it is purely textual and unaware of quoting, so an expression containing a literal `{alias}` —
+        // inside a string literal or a JSON path, say — is silently rewritten too. That is Hibernate's
+        // behavior, reproduced faithfully rather than fixed, since fixing it here would mean this leaf and
+        // `Projections.sqlProjection` disagreeing about the same input.
+        return leaf.sqlExpression.replace(TABLE_ALIAS_PLACEHOLDER, criteriaQuery.getSQLAlias(criteria))
+    }
+
+    private companion object {
+        /**
+         * Hibernate's convention, not Yawn's: the token users write in a raw SQL projection where the alias of
+         * the table being selected from should go. Its value is fixed by Hibernate, so it cannot be renamed.
+         */
+        private const val TABLE_ALIAS_PLACEHOLDER = "{alias}"
+    }
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/HibernateYawnSqlProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/HibernateYawnSqlProjection.kt
@@ -6,9 +6,9 @@ import org.hibernate.criterion.CriteriaQuery
 /**
  * A [YawnSqlProjection] that follows Hibernate's own `{alias}` convention for raw SQL projections.
  *
- * **Prefer [ProjectionLeaf.SqlValue] and [YawnProjections.sqlValue] over this.** It exists to compile the older
- * string-based [ProjectionLeaf.Sql], whose expressions were written against `Projections.sqlProjection` and so
- * expect its substitution behavior. Everything peculiar about that behavior is deliberately confined here.
+ * **Prefer [ProjectionLeaf.SqlValue], which [ProjectedYawnQueryScope.sqlValue] produces.** This exists to compile
+ * the older string-based [ProjectionLeaf.Sql], whose expressions were written against `Projections.sqlProjection`
+ * and so expect its substitution behavior. Everything peculiar about that behavior is deliberately confined here.
  *
  * The expression names its own result, so it is emitted verbatim apart from the alias substitution.
  */

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ProjectionLeaf.kt
@@ -65,6 +65,22 @@ sealed interface ProjectionLeaf<SOURCE : Any> {
     ) : ProjectionLeaf<SOURCE>
 
     /**
+     * A raw SQL projection of a single computed value, assembled at render time.
+     *
+     * Unlike [Sql], the expression is built by [render] rather than supplied up front, because the ORM will only
+     * resolve an entity property to its physical column while it is rendering the query. That is what makes
+     * [YawnSqlScope.sql] possible. The expression is bare: the query factory selects it under an alias it
+     * generates, so two SQL values in the same query can never be read from the same column.
+     *
+     * Note that this cannot use structural equality the way the other leaves do, since [render] is a function.
+     * Two of these therefore never deduplicate onto one result slot, even when they would render identically.
+     */
+    class SqlValue<SOURCE : Any>(
+        val render: YawnSqlScope<SOURCE>.() -> String,
+        val resultType: KClass<*>,
+    ) : ProjectionLeaf<SOURCE>
+
+    /**
      * Wraps another leaf with a SQL modifier (e.g. DISTINCT).
      */
     data class Modifier<SOURCE : Any>(

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ResolvedProjectionAdapter.kt
@@ -3,12 +3,6 @@ package com.faire.yawn.project
 import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
 import org.hibernate.criterion.Projections
-import org.hibernate.type.StandardBasicTypes
-import org.hibernate.type.Type
-import java.math.BigDecimal
-import java.math.BigInteger
-import java.sql.Date
-import kotlin.reflect.KClass
 
 /**
  * Bridges a [ResolvedProjection] into the existing [YawnQueryProjection] pipeline.
@@ -24,12 +18,12 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
         check(nodes.isNotEmpty()) { "Cannot compile an empty projection." }
 
         if (nodes.size == 1) {
-            return compileLeaf(nodes[0].leaf, context)
+            return compileLeaf(context, nodes[0].leaf)
         }
 
         return Projections.projectionList().apply {
             for (node in nodes) {
-                add(compileLeaf(node.leaf, context))
+                add(compileLeaf(context, node.leaf))
             }
         }
     }
@@ -45,19 +39,20 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
     }
 
     private fun compileLeaf(
-        leaf: ProjectionLeaf<SOURCE>,
         context: YawnCompilationContext,
+        leaf: ProjectionLeaf<SOURCE>,
     ): Projection = when (leaf) {
         is ProjectionLeaf.Property -> Projections.property(leaf.column.generatePath(context))
-        is ProjectionLeaf.Aggregate -> compileAggregate(leaf, context)
+        is ProjectionLeaf.Aggregate -> compileAggregate(context, leaf)
         is ProjectionLeaf.RowCount -> Projections.rowCount()
-        is ProjectionLeaf.Sql -> compileSql(leaf)
-        is ProjectionLeaf.Modifier -> compileModifier(leaf, context)
+        is ProjectionLeaf.Sql -> HibernateYawnSqlProjection(leaf)
+        is ProjectionLeaf.SqlValue -> ScopedYawnSqlProjection(context, leaf)
+        is ProjectionLeaf.Modifier -> compileModifier(context, leaf)
     }
 
     private fun compileAggregate(
-        leaf: ProjectionLeaf.Aggregate<SOURCE>,
         context: YawnCompilationContext,
+        leaf: ProjectionLeaf.Aggregate<SOURCE>,
     ): Projection {
         val path = leaf.column.generatePath(context)
         return when (leaf.kind) {
@@ -71,37 +66,10 @@ class ResolvedProjectionAdapter<SOURCE : Any, TO>(
         }
     }
 
-    private fun compileSql(leaf: ProjectionLeaf.Sql<SOURCE>): Projection {
-        // A leaf is always a single column, so this renders as a single aliased value.
-        return YawnSqlProjection(
-            sqlExpression = leaf.sqlExpression,
-            columnAlias = leaf.columnAlias,
-            type = leaf.resultType.toHibernateType(),
-        )
-    }
-
     private fun compileModifier(
-        leaf: ProjectionLeaf.Modifier<SOURCE>,
         context: YawnCompilationContext,
+        leaf: ProjectionLeaf.Modifier<SOURCE>,
     ): Projection = when (leaf.kind) {
-        ModifierKind.DISTINCT -> Projections.distinct(compileLeaf(leaf.inner, context))
-    }
-
-    companion object {
-        private fun KClass<*>.toHibernateType(): Type = when (this) {
-            String::class -> StandardBasicTypes.STRING
-            Long::class -> StandardBasicTypes.LONG
-            Int::class -> StandardBasicTypes.INTEGER
-            Double::class -> StandardBasicTypes.DOUBLE
-            Float::class -> StandardBasicTypes.FLOAT
-            Boolean::class -> StandardBasicTypes.BOOLEAN
-            Short::class -> StandardBasicTypes.SHORT
-            Byte::class -> StandardBasicTypes.BYTE
-            BigDecimal::class -> StandardBasicTypes.BIG_DECIMAL
-            BigInteger::class -> StandardBasicTypes.BIG_INTEGER
-            // SQL `date(...)` expressions (and friends) come back from the database as [java.sql.Date].
-            Date::class -> StandardBasicTypes.DATE
-            else -> error("Unsupported SQL projection result type: $this")
-        }
+        ModifierKind.DISTINCT -> Projections.distinct(compileLeaf(context, leaf.inner))
     }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ScopedYawnSqlProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ScopedYawnSqlProjection.kt
@@ -1,0 +1,31 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.query.YawnCompilationContext
+import org.hibernate.Criteria
+import org.hibernate.criterion.CriteriaQuery
+
+/**
+ * A [YawnSqlProjection] whose expression is built through a [YawnSqlScope], as [YawnProjections.sqlValue] produces.
+ *
+ * This is preferred to [HibernateYawnSqlProjection]; because the expression is assembled here, while the query is
+ * being rendered, it can ask the ORM to resolve entity properties to physical columns, rather than being handed a
+ * finished string with names patched into it afterwards.
+ *
+ * Yawn owns the result alias for these projections. The expression is bare, so it is selected under a name taken from
+ * the compilation [context] and unique within it, meaning two SQL values in one query can never be read from the same
+ * column, and the caller never has to invent a name.
+ *
+ * So `sqlValue<Long> { "SUM(${'$'}{books.numberOfPages.sql})" }` renders as `SUM(this_.numberOfPages) as _yawn_ct0`.
+ */
+internal class ScopedYawnSqlProjection<SOURCE : Any>(
+    private val context: YawnCompilationContext,
+    private val leaf: ProjectionLeaf.SqlValue<SOURCE>,
+) : YawnSqlProjection(context.generateResultAlias(), leaf.resultType) {
+    override fun renderSql(
+        criteria: Criteria,
+        criteriaQuery: CriteriaQuery,
+    ): String {
+        val scope = CriteriaSqlScope<SOURCE>(context, criteria, criteriaQuery)
+        return "${leaf.render(scope)} as $columnAlias"
+    }
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/ScopedYawnSqlProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/ScopedYawnSqlProjection.kt
@@ -5,7 +5,8 @@ import org.hibernate.Criteria
 import org.hibernate.criterion.CriteriaQuery
 
 /**
- * A [YawnSqlProjection] whose expression is built through a [YawnSqlScope], as [YawnProjections.sqlValue] produces.
+ * A [YawnSqlProjection] whose expression is built through a [YawnSqlScope], as
+ * [com.faire.yawn.criteria.query.ProjectedYawnQueryScope.sqlValue] produces.
  *
  * This is preferred to [HibernateYawnSqlProjection]; because the expression is assembled here, while the query is
  * being rendered, it can ask the ORM to resolve entity properties to physical columns, rather than being handed a

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
@@ -5,8 +5,6 @@ import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
 import org.hibernate.criterion.Projections
 import org.hibernate.type.StandardBasicTypes
-import kotlin.reflect.KClass
-import kotlin.reflect.typeOf
 
 /**
  * Yawn equivalent of Hibernate [Projections].
@@ -189,48 +187,6 @@ object YawnProjections {
 
     fun <SOURCE : Any> selectConstant(constant: String): YawnQueryProjection<SOURCE, String> {
         return SelectConstant(constant)
-    }
-
-    /**
-     * Projects a single value computed by a raw SQL [expression], e.g. `SUM(quantity * price)`.
-     *
-     * Use this instead of implementing [YawnQueryProjection] by hand when all you need is one custom SQL value.
-     * The result composes anywhere an ordinary column does; see [YawnSingleValueProjection].
-     *
-     * Reference columns through [YawnSqlScope.sql], which substitutes the physical column backing a property,
-     * already qualified by its table's alias:
-     *
-     * ```
-     * project(YawnProjections.sqlValue<Long> { "SUM(${books.numberOfPages.sql} * 2)" })
-     * ```
-     *
-     * The type argument decides how the result is mapped, and should be nullable if the expression can evaluate
-     * to `NULL`. As with any raw SQL projection, this is a claim Yawn takes at face value rather than something
-     * it can verify: it is up to you to ensure the expression really does produce that type.
-     *
-     * Do not name the result yourself (no `AS total`): Yawn selects it under an alias it generates, unique within
-     * the query. Note also that raw SQL cannot bind parameters, so any value in [expression] is inlined verbatim
-     * — never interpolate untrusted input into it.
-     */
-    inline fun <SOURCE : Any, reified TO> sqlValue(
-        noinline expression: YawnSqlScope<SOURCE>.() -> String,
-    ): YawnSingleValueProjection<SOURCE, TO> {
-        val type = typeOf<TO>()
-        return sqlValueOf(
-            resultType = type.classifier as? KClass<*> ?: error("Cannot project to $type"),
-            expression = expression,
-        )
-    }
-
-    @PublishedApi
-    internal fun <SOURCE : Any, TO> sqlValueOf(
-        resultType: KClass<*>,
-        expression: YawnSqlScope<SOURCE>.() -> String,
-    ): YawnSingleValueProjection<SOURCE, TO> {
-        return YawnSingleValueProjection(ProjectionLeaf.SqlValue(expression, resultType)) {
-            @Suppress("UNCHECKED_CAST")
-            it as TO
-        }
     }
 
     internal class Coalesce<SOURCE : Any, FROM>(

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnProjections.kt
@@ -5,6 +5,8 @@ import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
 import org.hibernate.criterion.Projections
 import org.hibernate.type.StandardBasicTypes
+import kotlin.reflect.KClass
+import kotlin.reflect.typeOf
 
 /**
  * Yawn equivalent of Hibernate [Projections].
@@ -187,6 +189,48 @@ object YawnProjections {
 
     fun <SOURCE : Any> selectConstant(constant: String): YawnQueryProjection<SOURCE, String> {
         return SelectConstant(constant)
+    }
+
+    /**
+     * Projects a single value computed by a raw SQL [expression], e.g. `SUM(quantity * price)`.
+     *
+     * Use this instead of implementing [YawnQueryProjection] by hand when all you need is one custom SQL value.
+     * The result composes anywhere an ordinary column does; see [YawnSingleValueProjection].
+     *
+     * Reference columns through [YawnSqlScope.sql], which substitutes the physical column backing a property,
+     * already qualified by its table's alias:
+     *
+     * ```
+     * project(YawnProjections.sqlValue<Long> { "SUM(${books.numberOfPages.sql} * 2)" })
+     * ```
+     *
+     * The type argument decides how the result is mapped, and should be nullable if the expression can evaluate
+     * to `NULL`. As with any raw SQL projection, this is a claim Yawn takes at face value rather than something
+     * it can verify: it is up to you to ensure the expression really does produce that type.
+     *
+     * Do not name the result yourself (no `AS total`): Yawn selects it under an alias it generates, unique within
+     * the query. Note also that raw SQL cannot bind parameters, so any value in [expression] is inlined verbatim
+     * — never interpolate untrusted input into it.
+     */
+    inline fun <SOURCE : Any, reified TO> sqlValue(
+        noinline expression: YawnSqlScope<SOURCE>.() -> String,
+    ): YawnSingleValueProjection<SOURCE, TO> {
+        val type = typeOf<TO>()
+        return sqlValueOf(
+            resultType = type.classifier as? KClass<*> ?: error("Cannot project to $type"),
+            expression = expression,
+        )
+    }
+
+    @PublishedApi
+    internal fun <SOURCE : Any, TO> sqlValueOf(
+        resultType: KClass<*>,
+        expression: YawnSqlScope<SOURCE>.() -> String,
+    ): YawnSingleValueProjection<SOURCE, TO> {
+        return YawnSingleValueProjection(ProjectionLeaf.SqlValue(expression, resultType)) {
+            @Suppress("UNCHECKED_CAST")
+            it as TO
+        }
     }
 
     internal class Coalesce<SOURCE : Any, FROM>(

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnRawSqlProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnRawSqlProjection.kt
@@ -1,0 +1,39 @@
+package com.faire.yawn.project
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+/**
+ * A projection of a single value computed by a raw SQL expression.
+ *
+ * Normally produced by [com.faire.yawn.criteria.query.ProjectedYawnQueryScope.sqlValue], which is the ergonomic way
+ * in; constructing it directly is the same thing with the result type handed over explicitly.
+ *
+ * **You are responsible for the type-safety of the expression.** [resultType] tells Yawn how to read the value back
+ * out of the result set and what to hand you, and nothing checks that the SQL actually produces it: a `VARCHAR`
+ * column declared as `Long`, or a nullable expression declared non-null, will fail at the ORM boundary or hand you a
+ * value that lies about its type. This is the tradeoff for being able to write SQL that Yawn has no typed API for,
+ * and it is why the mapping below is an unchecked cast rather than something Yawn can verify. The rest of the
+ * projection API exists precisely so that you rarely need this one.
+ *
+ * Note also that raw SQL cannot bind parameters, so anything interpolated into the expression is inlined into the
+ * statement verbatim; never build one out of untrusted input.
+ */
+class YawnRawSqlProjection<SOURCE : Any, TO>(
+    expression: YawnSqlScope<SOURCE>.() -> String,
+    resultType: KType,
+) : YawnSingleValueProjection<SOURCE, TO>(
+    leaf = ProjectionLeaf.SqlValue(expression, resultType.toResultClass()),
+    mapper = {
+        @Suppress("UNCHECKED_CAST")
+        it as TO
+    },
+)
+
+/**
+ * A projected value is a single column, so its type has to be a class; a `List<String>` or a type variable has no
+ * column representation and there is nothing sensible to map.
+ */
+private fun KType.toResultClass(): KClass<*> {
+    return classifier as? KClass<*> ?: error("Cannot project a SQL value to $this, as it is not a class.")
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSingleValueProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSingleValueProjection.kt
@@ -1,0 +1,32 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.query.YawnCompilationContext
+import org.hibernate.criterion.Projection
+
+/**
+ * A projection of a single value, such as a custom SQL expression (see [YawnProjections.sqlValue]).
+ *
+ * This implements both projection interfaces on purpose, so that a single projected value composes everywhere an
+ * ordinary column does, with no adapter at the call site:
+ * * as a [YawnValueProjector], inside [ProjectionNode.composite], [ProjectionNode.mapped] and modifiers;
+ * * as a [YawnQueryProjection], inside [YawnProjections.pair], [YawnProjections.triple], the generated `create`
+ *   function of a [YawnProjection] class, and directly as a query's whole projection.
+ */
+class YawnSingleValueProjection<SOURCE : Any, TO> internal constructor(
+    private val leaf: ProjectionLeaf<SOURCE>,
+    private val mapper: (Any?) -> TO,
+) : YawnValueProjector<SOURCE, TO>, YawnQueryProjection<SOURCE, TO> {
+    override fun projection(): ProjectionNode.Value<SOURCE, TO> = ProjectionNode.Value(leaf, mapper)
+
+    /**
+     * Resolving a single value is cheap and context-free, so the bridge into the [YawnQueryProjection] pipeline is
+     * built once and reused. The expression itself is still rendered per query, from its own compilation context.
+     */
+    private val adapter: ResolvedProjectionAdapter<SOURCE, TO> by lazy {
+        ResolvedProjectionAdapter(ProjectorResolver<SOURCE>().resolve(this))
+    }
+
+    override fun compile(context: YawnCompilationContext): Projection = adapter.compile(context)
+
+    override fun project(value: Any?): TO = adapter.project(value)
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSingleValueProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSingleValueProjection.kt
@@ -4,7 +4,8 @@ import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
 
 /**
- * A projection of a single value, such as a custom SQL expression (see [YawnProjections.sqlValue]).
+ * A projection of a single value, such as a custom SQL expression (see
+ * [com.faire.yawn.criteria.query.ProjectedYawnQueryScope.sqlValue]).
  *
  * This implements both projection interfaces on purpose, so that a single projected value composes everywhere an
  * ordinary column does, with no adapter at the call site:
@@ -12,11 +13,11 @@ import org.hibernate.criterion.Projection
  * * as a [YawnQueryProjection], inside [YawnProjections.pair], [YawnProjections.triple], the generated `create`
  *   function of a [YawnProjection] class, and directly as a query's whole projection.
  */
-class YawnSingleValueProjection<SOURCE : Any, TO> internal constructor(
+open class YawnSingleValueProjection<SOURCE : Any, TO>(
     private val leaf: ProjectionLeaf<SOURCE>,
     private val mapper: (Any?) -> TO,
 ) : YawnValueProjector<SOURCE, TO>, YawnQueryProjection<SOURCE, TO> {
-    override fun projection(): ProjectionNode.Value<SOURCE, TO> = ProjectionNode.Value(leaf, mapper)
+    final override fun projection(): ProjectionNode.Value<SOURCE, TO> = ProjectionNode.Value(leaf, mapper)
 
     /**
      * Resolving a single value is cheap and context-free, so the bridge into the [YawnQueryProjection] pipeline is
@@ -26,7 +27,7 @@ class YawnSingleValueProjection<SOURCE : Any, TO> internal constructor(
         ResolvedProjectionAdapter(ProjectorResolver<SOURCE>().resolve(this))
     }
 
-    override fun compile(context: YawnCompilationContext): Projection = adapter.compile(context)
+    final override fun compile(context: YawnCompilationContext): Projection = adapter.compile(context)
 
-    override fun project(value: Any?): TO = adapter.project(value)
+    final override fun project(value: Any?): TO = adapter.project(value)
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlProjection.kt
@@ -3,32 +3,40 @@ package com.faire.yawn.project
 import org.hibernate.Criteria
 import org.hibernate.criterion.CriteriaQuery
 import org.hibernate.criterion.Projection
+import org.hibernate.type.StandardBasicTypes
 import org.hibernate.type.Type
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.sql.Date
+import kotlin.reflect.KClass
 
 /**
  * Hibernate [Projection] for a single raw SQL value.
  *
- * Yawn implements this rather than calling `Projections.sqlProjection`, because rendering the SQL ourselves is
- * what gives us access to [CriteriaQuery] at render time. That is the only place the ORM will resolve an entity
+ * Yawn implements this rather than calling `Projections.sqlProjection`, because rendering the SQL gives
+ * access to [CriteriaQuery] at render time. That is the only place the ORM will resolve an entity
  * property to the physical column(s) backing it, which raw SQL has to name.
  *
- * This renders exactly what Hibernate's own SQL projection does: [sqlExpression] verbatim, with `{alias}`
- * substituted, selected under [columnAlias]. The expression is therefore expected to name its own result.
+ * This encodes the concept of being a single-column projection, including mapping the leaf's Kotlin result
+ * type to the ORM's. Subclasses supply [renderSql], and the alias to select it under.
  */
-internal class YawnSqlProjection(
-    private val sqlExpression: String,
-    private val columnAlias: String,
-    private val type: Type,
+internal abstract class YawnSqlProjection(
+    protected val columnAlias: String,
+    resultType: KClass<*>,
 ) : Projection {
-    override fun toSqlString(
+    private val type: Type = resultType.toHibernateType()
+
+    /** Builds the select fragment, including its `as` clause. */
+    protected abstract fun renderSql(
+        criteria: Criteria,
+        criteriaQuery: CriteriaQuery,
+    ): String
+
+    final override fun toSqlString(
         criteria: Criteria,
         position: Int,
         criteriaQuery: CriteriaQuery,
-    ): String {
-        // `{alias}` is substituted with the SQL alias of the table this criteria selects from, matching how
-        // Hibernate's own SQL projections behave.
-        return sqlExpression.replace(TABLE_ALIAS_PLACEHOLDER, criteriaQuery.getSQLAlias(criteria))
-    }
+    ): String = renderSql(criteria, criteriaQuery)
 
     override fun toGroupSqlString(
         criteria: Criteria,
@@ -60,6 +68,20 @@ internal class YawnSqlProjection(
     override fun isGrouped(): Boolean = false
 
     private companion object {
-        private const val TABLE_ALIAS_PLACEHOLDER = "{alias}"
+        private fun KClass<*>.toHibernateType(): Type = when (this) {
+            String::class -> StandardBasicTypes.STRING
+            Long::class -> StandardBasicTypes.LONG
+            Int::class -> StandardBasicTypes.INTEGER
+            Double::class -> StandardBasicTypes.DOUBLE
+            Float::class -> StandardBasicTypes.FLOAT
+            Boolean::class -> StandardBasicTypes.BOOLEAN
+            Short::class -> StandardBasicTypes.SHORT
+            Byte::class -> StandardBasicTypes.BYTE
+            BigDecimal::class -> StandardBasicTypes.BIG_DECIMAL
+            BigInteger::class -> StandardBasicTypes.BIG_INTEGER
+            // SQL `date(...)` expressions (and friends) come back from the database as [java.sql.Date].
+            Date::class -> StandardBasicTypes.DATE
+            else -> error("Unsupported SQL projection result type: $this")
+        }
     }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlScope.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlScope.kt
@@ -1,7 +1,8 @@
 package com.faire.yawn.project
 
 /**
- * The context available while building a raw SQL expression, via [YawnProjections.sqlValue].
+ * The context available while building a raw SQL expression, via
+ * [com.faire.yawn.criteria.query.ProjectedYawnQueryScope.sqlValue].
  *
  * The SQL is assembled as the ORM renders the query, when it can be resolved to a physical backing column.
  */

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlScope.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/YawnSqlScope.kt
@@ -1,0 +1,16 @@
+package com.faire.yawn.project
+
+/**
+ * The context available while building a raw SQL expression, via [YawnProjections.sqlValue].
+ *
+ * The SQL is assembled as the ORM renders the query, when it can be resolved to a physical backing column.
+ */
+interface YawnSqlScope<SOURCE : Any> {
+    /**
+     * Resolves this column to the physical column backing it, qualified by its table alias, e.g. `this_.call_number`.
+     *
+     * Fails if the property cannot be resolved, or if it is backed by more than one column (a composite key, say),
+     * since there would be no single value to substitute into the expression.
+     */
+    val YawnPathProvider<SOURCE>.sql: String
+}

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSqlValueProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSqlValueProjectionTest.kt
@@ -2,10 +2,10 @@ package com.faire.yawn.database
 
 import com.faire.yawn.project.YawnProjection
 import com.faire.yawn.project.YawnProjections
-import com.faire.yawn.setup.entities.Book
-import com.faire.yawn.setup.entities.BookCover
 import com.faire.yawn.setup.entities.BookCoverTable
+import com.faire.yawn.setup.entities.BookProjectedQueryScope
 import com.faire.yawn.setup.entities.BookTable
+import com.faire.yawn.setup.entities.BookTableDefType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.hibernate.HibernateException
@@ -26,7 +26,7 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
                 project(
                     YawnSqlValueProjectionTest_AuthorPagesProjection.create(
                         author = YawnProjections.groupBy(authors.name),
-                        doubledPages = YawnProjections.sqlValue { "SUM(${books.numberOfPages.sql} * 2)" },
+                        doubledPages = sqlValue { "SUM(${books.numberOfPages.sql} * 2)" },
                     ),
                 )
             }.list()
@@ -44,7 +44,7 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
         transactor.open { session ->
             // Book.callNumber is @Column(name = "call_number"): naming the property would not resolve.
             val prefixes = session.project(BookTable) { books ->
-                project(YawnProjections.sqlValue<Book, String?> { "LEFT(${books.callNumber.sql}, 2)" })
+                project(sqlValue<String?> { "LEFT(${books.callNumber.sql}, 2)" })
             }.list()
 
             assertThat(prefixes.toSet()).containsExactlyInAnyOrder("PR", "PZ", null)
@@ -60,9 +60,9 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
                 project(
                     YawnProjections.pair(
                         // joined table: resolves with the join's own alias
-                        YawnProjections.sqlValue<Book, Long> { "LENGTH(${authors.name.sql})" },
+                        sqlValue<Long> { "LENGTH(${authors.name.sql})" },
                         // embedded property
-                        YawnProjections.sqlValue<Book, Long> { "${books.sales.paperBacksSold.sql} / 1000" },
+                        sqlValue<Long> { "${books.sales.paperBacksSold.sql} / 1000" },
                     ),
                 )
             }.uniqueResult()!!
@@ -81,7 +81,7 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
                 project(
                     YawnProjections.pair(
                         books.name,
-                        YawnProjections.sqlValue<Book, Int?> { "${books.rating.sql} * 10" },
+                        sqlValue<Int?> { "${books.rating.sql} * 10" },
                     ),
                 )
             }.list()
@@ -94,7 +94,7 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
             // and through uniqueResult()
             val nullRating = session.project(BookTable) { books ->
                 addEq(books.name, "Harry Potter")
-                project(YawnProjections.sqlValue<Book, Int?> { "${books.rating.sql} * 10" })
+                project(sqlValue<Int?> { "${books.rating.sql} * 10" })
             }.uniqueResult()
 
             assertThat(nullRating).isNull()
@@ -111,7 +111,7 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
                     YawnProjections.triple(
                         YawnProjections.groupBy(authors.name),
                         YawnProjections.count(books.id),
-                        YawnProjections.sqlValue<Book, Long> { "SUM(${books.numberOfPages.sql} * 2)" },
+                        sqlValue<Long> { "SUM(${books.numberOfPages.sql} * 2)" },
                     ),
                 )
             }.uniqueResult()!!
@@ -138,8 +138,8 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
                 project(
                     YawnSqlValueProjectionTest_QuadProjection.create(
                         books.name,
-                        YawnProjections.sqlValue { "111" },
-                        YawnProjections.sqlValue { "222" },
+                        sqlValue { "111" },
+                        sqlValue { "222" },
                         books.numberOfPages,
                     ),
                 )
@@ -149,25 +149,27 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
         }
     }
 
-    @Test
-    fun `an instance that captures no columns can be reused across queries`() {
-        transactor.open { session ->
-            // An expression that captures nothing is freely reusable. Note that one referencing a *joined*
-            // table's columns is not: the join's alias is baked into the resolved path, and belongs to the
-            // query that created the join, so reusing it elsewhere fails to resolve.
-            val rowCount = YawnProjections.sqlValue<Book, Long> { "COUNT(*)" }
+    /**
+     * Share one across queries by writing a helper on the scope. Taking the table definition as a parameter is what
+     * keeps it portable: an expression that captured a *joined* table's definition would bake in that query's alias.
+     */
+    private fun BookProjectedQueryScope<Long>.pagesPerBook(books: BookTableDefType) =
+        sqlValue<Long> { "SUM(${books.numberOfPages.sql}) / COUNT(*)" }
 
+    @Test
+    fun `a projection can be shared across queries via a scope helper`() {
+        transactor.open { session ->
             val tolkien = session.project(BookTable) { books ->
                 val authors = join(books.author)
                 addEq(authors.name, "J.R.R. Tolkien")
-                project(rowCount)
+                project(pagesPerBook(books))
             }.uniqueResult()!!
-            assertThat(tolkien).isEqualTo(2L)
+            assertThat(tolkien).isEqualTo(650L)
 
-            val all = session.project(BookTable) {
-                project(rowCount)
+            val everyone = session.project(BookTable) { books ->
+                project(pagesPerBook(books))
             }.uniqueResult()!!
-            assertThat(all).isEqualTo(6L)
+            assertThat(everyone).isEqualTo(355L)
         }
     }
 
@@ -176,11 +178,11 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
         transactor.open { session ->
             assertThatThrownBy {
                 session.project(BookCoverTable) { covers ->
-                    project(YawnProjections.sqlValue<BookCover, Long> { "LENGTH(${covers.cid.sql})" })
+                    project(sqlValue<Long> { "LENGTH(${covers.cid.sql})" })
                 }.list()
             }
                 .isInstanceOf(IllegalStateException::class.java)
-                .hasMessageContaining("Path \"cid\" is a multi-column mapping backend by columns")
+                .hasMessageContaining("Path \"cid\" is a multi-column mapping backed by columns")
                 .hasMessageContaining("(this_.book_id, this_.owner_id)")
                 .hasMessageContaining("and thus has no single-value substitute into a SQL projection.")
                 .hasMessageContaining("Reference one of its columns individually instead.")
@@ -191,7 +193,7 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
     fun `an individual column of a composite key can be a single value`() {
         transactor.open { session ->
             val bookTokens = session.project(BookCoverTable) { covers ->
-                project(YawnProjections.sqlValue<BookCover, String> { "CONCAT('book_', ${covers.cid.bookId.sql})" })
+                project(sqlValue<String> { "CONCAT('book_', ${covers.cid.bookId.sql})" })
             }.list()
 
             assertThat(bookTokens).containsExactlyInAnyOrder("book_1", "book_3")
@@ -206,7 +208,7 @@ internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
             assertThatThrownBy {
                 session.project(BookTable) { books ->
                     // bad: must call `.sql` to resolve column name in context!
-                    project(YawnProjections.sqlValue<Book, Long> { "SUM(${books.numberOfPages})" })
+                    project(sqlValue<Long> { "SUM(${books.numberOfPages})" })
                 }.uniqueResult()
             }.isInstanceOf(HibernateException::class.java)
         }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSqlValueProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSqlValueProjectionTest.kt
@@ -1,0 +1,214 @@
+package com.faire.yawn.database
+
+import com.faire.yawn.project.YawnProjection
+import com.faire.yawn.project.YawnProjections
+import com.faire.yawn.setup.entities.Book
+import com.faire.yawn.setup.entities.BookCover
+import com.faire.yawn.setup.entities.BookCoverTable
+import com.faire.yawn.setup.entities.BookTable
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.hibernate.HibernateException
+import org.junit.jupiter.api.Test
+
+internal class YawnSqlValueProjectionTest : BaseYawnDatabaseTest() {
+    @YawnProjection
+    internal data class AuthorPages(
+        val author: String,
+        val doubledPages: Long,
+    )
+
+    @Test
+    fun `computed SUM expression nested in a generated projection`() {
+        transactor.open { session ->
+            val results = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                project(
+                    YawnSqlValueProjectionTest_AuthorPagesProjection.create(
+                        author = YawnProjections.groupBy(authors.name),
+                        doubledPages = YawnProjections.sqlValue { "SUM(${books.numberOfPages.sql} * 2)" },
+                    ),
+                )
+            }.list()
+
+            assertThat(results).containsExactlyInAnyOrder(
+                AuthorPages("J.R.R. Tolkien", 2_600),
+                AuthorPages("J.K. Rowling", 1_000),
+                AuthorPages("Hans Christian Andersen", 660),
+            )
+        }
+    }
+
+    @Test
+    fun `resolves a property whose column is mapped to a different name`() {
+        transactor.open { session ->
+            // Book.callNumber is @Column(name = "call_number"): naming the property would not resolve.
+            val prefixes = session.project(BookTable) { books ->
+                project(YawnProjections.sqlValue<Book, String?> { "LEFT(${books.callNumber.sql}, 2)" })
+            }.list()
+
+            assertThat(prefixes.toSet()).containsExactlyInAnyOrder("PR", "PZ", null)
+        }
+    }
+
+    @Test
+    fun `resolves properties on joined tables and embedded types`() {
+        transactor.open { session ->
+            val result = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(books.name, "The Hobbit")
+                project(
+                    YawnProjections.pair(
+                        // joined table: resolves with the join's own alias
+                        YawnProjections.sqlValue<Book, Long> { "LENGTH(${authors.name.sql})" },
+                        // embedded property
+                        YawnProjections.sqlValue<Book, Long> { "${books.sales.paperBacksSold.sql} / 1000" },
+                    ),
+                )
+            }.uniqueResult()!!
+
+            assertThat(result).isEqualTo(14L to 2_000L)
+        }
+    }
+
+    @Test
+    fun `nullable result type`() {
+        transactor.open { session ->
+            // Harry Potter has no rating, so the expression evaluates to NULL for it
+            val ratings = session.project(BookTable) { books ->
+                addIn(books.name, setOf("The Hobbit", "Harry Potter"))
+                orderAsc(books.name)
+                project(
+                    YawnProjections.pair(
+                        books.name,
+                        YawnProjections.sqlValue<Book, Int?> { "${books.rating.sql} * 10" },
+                    ),
+                )
+            }.list()
+
+            assertThat(ratings).containsExactly(
+                "Harry Potter" to null,
+                "The Hobbit" to 90,
+            )
+
+            // and through uniqueResult()
+            val nullRating = session.project(BookTable) { books ->
+                addEq(books.name, "Harry Potter")
+                project(YawnProjections.sqlValue<Book, Int?> { "${books.rating.sql} * 10" })
+            }.uniqueResult()
+
+            assertThat(nullRating).isNull()
+        }
+    }
+
+    @Test
+    fun `composes with ordinary columns and aggregations`() {
+        transactor.open { session ->
+            val result = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+                project(
+                    YawnProjections.triple(
+                        YawnProjections.groupBy(authors.name),
+                        YawnProjections.count(books.id),
+                        YawnProjections.sqlValue<Book, Long> { "SUM(${books.numberOfPages.sql} * 2)" },
+                    ),
+                )
+            }.uniqueResult()!!
+
+            assertThat(result).isEqualTo(Triple("J.R.R. Tolkien", 2L, 2_600L))
+        }
+    }
+
+    @YawnProjection
+    internal data class Quad(
+        val name: String,
+        val first: Long,
+        val second: Long,
+        val pages: Long,
+    )
+
+    @Test
+    fun `two different sql values keep their own result slots`() {
+        transactor.open { session ->
+            // Each gets its own generated alias, so neither reads the other's column, and the ordinary columns
+            // on either side do not shift.
+            val result = session.project(BookTable) { books ->
+                addEq(books.name, "The Hobbit")
+                project(
+                    YawnSqlValueProjectionTest_QuadProjection.create(
+                        books.name,
+                        YawnProjections.sqlValue { "111" },
+                        YawnProjections.sqlValue { "222" },
+                        books.numberOfPages,
+                    ),
+                )
+            }.uniqueResult()!!
+
+            assertThat(result).isEqualTo(Quad("The Hobbit", 111L, 222L, 300L))
+        }
+    }
+
+    @Test
+    fun `an instance that captures no columns can be reused across queries`() {
+        transactor.open { session ->
+            // An expression that captures nothing is freely reusable. Note that one referencing a *joined*
+            // table's columns is not: the join's alias is baked into the resolved path, and belongs to the
+            // query that created the join, so reusing it elsewhere fails to resolve.
+            val rowCount = YawnProjections.sqlValue<Book, Long> { "COUNT(*)" }
+
+            val tolkien = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                addEq(authors.name, "J.R.R. Tolkien")
+                project(rowCount)
+            }.uniqueResult()!!
+            assertThat(tolkien).isEqualTo(2L)
+
+            val all = session.project(BookTable) {
+                project(rowCount)
+            }.uniqueResult()!!
+            assertThat(all).isEqualTo(6L)
+        }
+    }
+
+    @Test
+    fun `a property backed by several columns cannot be a single value`() {
+        transactor.open { session ->
+            assertThatThrownBy {
+                session.project(BookCoverTable) { covers ->
+                    project(YawnProjections.sqlValue<BookCover, Long> { "LENGTH(${covers.cid.sql})" })
+                }.list()
+            }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("Path \"cid\" is a multi-column mapping backend by columns")
+                .hasMessageContaining("(this_.book_id, this_.owner_id)")
+                .hasMessageContaining("and thus has no single-value substitute into a SQL projection.")
+                .hasMessageContaining("Reference one of its columns individually instead.")
+        }
+    }
+
+    @Test
+    fun `an individual column of a composite key can be a single value`() {
+        transactor.open { session ->
+            val bookTokens = session.project(BookCoverTable) { covers ->
+                project(YawnProjections.sqlValue<BookCover, String> { "CONCAT('book_', ${covers.cid.bookId.sql})" })
+            }.list()
+
+            assertThat(bookTokens).containsExactlyInAnyOrder("book_1", "book_3")
+        }
+    }
+
+    @Test
+    fun `interpolating a column without sql cannot silently succeed`() {
+        transactor.open { session ->
+            // Forgetting the scoped `.sql` helper interpolates the ColumnDef's default toString(),
+            // which ensures a sufficiently loud SQL error.
+            assertThatThrownBy {
+                session.project(BookTable) { books ->
+                    // bad: must call `.sql` to resolve column name in context!
+                    project(YawnProjections.sqlValue<Book, Long> { "SUM(${books.numberOfPages})" })
+                }.uniqueResult()
+            }.isInstanceOf(HibernateException::class.java)
+        }
+    }
+}


### PR DESCRIPTION
This adds a new way of writing single-value projections with many benefits; opt-in for v1, and default for v2 projection pipeline.

---

While we should strive for the built-in typed projects provided by Yawn to be sufficient, there will always be the need for user-defined projections.

Projecting a single computed SQL value required implementing `YawnQueryProjection` by hand, for example:

```kotlin
private fun <SOURCE : Any> sqlDoubleProjection(sql: String, alias: String): YawnQueryProjection<SOURCE, Double> {
    return object : YawnQueryProjection<SOURCE, Double> {
        override fun compile(context: YawnCompilationContext): Projection {
            return Projections.sqlProjection(
                "$sql as $alias",
                arrayOf(alias),
                arrayOf<Type>(DoubleType.INSTANCE),
            )
        }

        override fun project(value: Any?): Double = (value as Number?)?.toDouble() ?: 0.0
    }
}

// ...supporting exactly one call site:
project(sqlDoubleProjection("avg(length({alias}.description))", "average_length"))
```

Thirteen lines of ceremony, including an anonymous object, both interface methods, an alias written twice, two `arrayOf`s, a raw Hibernate `Type`, and a hand-written cast, just to select one number. With this PR that helper deletes entirely and the call site becomes:

```kotlin
project(sqlValue<Double> { "avg(length(${products.description.sql}))" })
```

That is shorter, but it has other advantages:

- **The alias is gone.** It used to be invented by the caller and written twice, which is the same class of bug fixed in Yawn's own `selectConstant`/`null` a release ago, where a shared hardcoded alias made two constants return the same value. Yawn now generates one per projected value, unique within the query.
- **No Hibernate in the query file.** `DoubleType.INSTANCE` and `Projection` no longer leak into application code; the type argument is ordinary Kotlin.
- **Columns resolve properly.** `{alias}.description` names a *physical column* and silently assumes it matches the property name. `.sql` asks the ORM, so it survives `@Column(name = "…")`, works across joins and embedded types, and fails loudly instead of producing a mystery SQL error.
- **Nullability becomes a decision.** The `?: 0.0` quietly turned `NULL` into zero. `sqlValue<Double>` versus `sqlValue<Double?>` states the intent in the type.

### Other Examples

**1. Computed aggregate**

```kotlin
// BEFORE
Projections.sqlProjection(
    "sum(quantity * price_minor) as total",
    arrayOf("total"),
    arrayOf<Type>(LongType.INSTANCE),
)

// AFTER
sqlValue<Long> { "SUM(${items.quantity.sql} * ${items.priceMinor.sql})" }
```

**2. Conditional aggregate**

```kotlin
// BEFORE
"sum(case when returned_at is not null then quantity else 0 end) as returned_quantity"

// AFTER
sqlValue<Long> {
    "SUM(CASE WHEN ${items.returnedAt.sql} IS NOT NULL THEN ${items.quantity.sql} ELSE 0 END)"
}
```

**3. Boolean flag**

```kotlin
// BEFORE
"user1_.id = account2_.owner_user_id AS is_owner"

// AFTER
sqlValue<Boolean> { "${users.id.sql} = ${accounts.ownerUserId.sql}" }
```

**4. `DISTINCT` over a string function with Kotlin interpolation**

```kotlin
// BEFORE
"DISTINCT(LEFT(postal_code, $numChars)) as postalCodePart"

// AFTER
sqlValue<String> { "DISTINCT(LEFT(${addresses.postalCode.sql}, $numChars))" }
```

**5. A hardcoded generated join alias**

```kotlin
// BEFORE: this is particularly bad - `customizat3_` is not a name chose in code; it was Hibernate generated, dependant on exact join order; very unstable
"COALESCE(SUM(customizat3_.active), 0) AS active_count"

// AFTER - let yawn do it for you
sqlValue<Long> { "COALESCE(SUM(${customizations.active.sql}), 0)" }
```

**6. A hardcoded root alias**

```kotlin
// BEFORE
"count(distinct this_.token) as total_count"

// AFTER
sqlValue<Long> { "COUNT(DISTINCT ${orders.token.sql})" }
```

**7. A hand-written `YawnQueryProjection` mixing columns and raw SQL, manually unpacking the row by index**

These become a generated `@YawnProjection` class whose fields are ordinary columns plus one `sqlValue`, deleting the anonymous object and the manual `value as Array<*>` / `row[0] as Long?` unpacking entirely.

**8. SQL group projections**

Cannot migrate yet. Usages of `Projections.sqlGroupProjection`, which carries a separate `GROUP BY` clause that `ProjectionLeaf` has no slot for. That will follow-up.

### API

```kotlin
// on ProjectedYawnQueryScope<SOURCE, …>
inline fun <reified TO> sqlValue(
    noinline expression: YawnSqlScope<SOURCE>.() -> String,
): YawnRawSqlProjection<SOURCE, TO>

interface YawnSqlScope<SOURCE : Any> {
    val YawnPathProvider<SOURCE>.sql: String
}
```

One reified function covers both nullabilities via `typeOf<TO>()`, so there is no `sqlValueOrNull`. It hangs off the projected query scope rather than `YawnProjections`, so `SOURCE` is already bound and only the result type is ever written by hand — `sqlValue<Long> { … }` and not `sqlValue<Book, Long> { … }`, which matters because Kotlin's type arguments are all-or-nothing. A projection meant to be shared across queries is therefore written as an extension on that same scope taking the table definition as a parameter, and can declare the public supertype `YawnSingleValueProjection<SOURCE, TO>` as its return type. The expression is a lambda rather than a string because it is assembled while the ORM renders the query; that is the only moment at which an entity property can be resolved to the column backing it. That is also what makes the scope extensible later without breaking callers.

### How it works

`ProjectionLeaf.SqlValue` holds the lambda instead of a string. It compiles to `ScopedYawnSqlProjection`, which invokes that lambda from `toSqlString` - the point at which Hibernate finally hands over a `CriteriaQuery`, so `.sql` can be `criteriaQuery.getColumnsUsingProjection(criteria, path)`. It also mints its own result alias off the compilation context, since it is the thing that needs one to be unique.

`YawnSqlProjection` (Yawn's own `org.hibernate.criterion.Projection`, added last release) became abstract in the process, and now owns everything common to a single-column projection (the SPI methods and the Kotlin-to-Hibernate result type mapping). Its two subclasses differ only in where the alias comes from and how the SQL renders. The older string-based `ProjectionLeaf.Sql` compiles to `HibernateYawnSqlProjection`, which is where the whole `{alias}` substitution business now lives (for now!), quarantined and documented. `ResolvedProjectionAdapter` is left as a pure dispatch, with no rendering, aliasing or type mapping in it at all.

The scope itself is split for the same reason the adapter exists: `YawnSqlScope` is the public contract and imports nothing, so `ProjectionLeaf` stays an ORM-agnostic description of a projection. `CriteriaSqlScope` is the Hibernate-aware implementation.

### Failure modes, all loud

The user is still responsible to guarantee the projection correctness, as usual - that is the tradeoff for the string flexibility, and this is intended for indeed edge cases (for example, on our entire codebase right now we have only a few dozen uses). Other than type mismatches or invalid SQLs, some other more specific failure cases are:

- **A property backed by several columns** (a composite key, say) has no single value to substitute, so it throws, naming the columns it found: `Path "cid" is a multi-column mapping … (this_.book_id, this_.owner_id) … Reference one of its columns individually instead.` Following that advice works: an individual part of a composite key is an ordinary single-column definition, and a test covers it right after. I will followup with a better shape, where we decouple the path provider interface (tangential).
- **An unresolvable property** surfaces Hibernate's `QueryException` wrapped with a hint about missing joins. The only way to proc this that I could find is by trafficking column defs (joined specifically) between queries, which we already treat as cardinal sin.
- **Forgetting `.sql`** is left to the database; interpolating a column definition directly yields its identity string, e.g. `com.faire.yawn.YawnTableDef$ColumnDef@6d1e7682`, which cannot parse as SQL under any dialect (H2 reports `Database "com" not found`). I deliberately decided not to check for this: a runtime guard in the render path would exist only to catch a mistake the statement itself already rejects on first execution. I will add a better `toString()` to ColumnDef on a followup, there are a few options - but ultimately _it is impossible to compile-time prevent a user from concatenating nonsense into their strings_.

## Considerations

1. **No runtime null check.** I intended `sqlValue<Int>` to throw when the expression returns `NULL`. It cannot work: `YawnQueryBuilder.uniqueResult()` is `compile().uniqueResult()?.let { mapper(it) }`, so the mapper is skipped entirely when the raw value is null - and this is unfixable in principle, because a null `uniqueResult()` is ambiguous between "no rows" and "one row holding null". A check that fires inside composites but not for a standalone value teaches a false lesson, so the type argument is documented as an unverified claim, consistent with every other raw-SQL projection in Yawn.
2. **Expressions referencing joined columns are not portable across queries**: `.sql` resolves a column to `alias.column`, and for a joined table that alias belongs to the query that created the join - so handing the same expression to another query yields `Could not resolve path "a.name"`. Capture-free expressions (`sqlValue<Long> { "COUNT(*)" }`) are freely reusable, and a test covers that case. A root-table column reference happens to resolve too, since its path carries no join alias, but that is an artifact of how the criteria is aliased rather than a guarantee - treat "don't reuse a column-referencing expression across queries" as the rule.
3. **`SqlValue` leaves never deduplicate.** `ProjectionLeaf` deduplication relies on data-class equality, and two lambdas are never equal, so two identical `sqlValue` expressions occupy two result slots. A performance nit, not a correctness one.
4. **Raw SQL cannot bind parameters.** The Hibernate `Projection` SPI has no `getTypedValues`, so anything interpolated into the expression is inlined into the statement verbatim. Never build one from untrusted input. Called out in the docs with a warning admonition (this is a pre-existing property of raw SQL projections, not something this PR introduces).