### PR TITLE
feat: Support ordering by an aggregate/projected expression

### DIFF
--- a/docs/projections.md
+++ b/docs/projections.md
@@ -111,9 +111,8 @@ yawn.project(VisitTable) { visits ->
 This groups visits by brand and returns each brand's most recent visit time, sorted with the most-recently-visited
 brands first - a "top-N per group" query expressed as a single SQL-side query instead of fetching every row and
 sorting in Kotlin. The value returned by `orderDescBy`/`orderAscBy` must be passed to `project(...)` (nesting it
-inside a `pair`/`triple`/`@YawnProjection` data class is fine): Hibernate can only order by an alias that is actually
-present in the query's SELECT list, so if the returned value isn't projected, resolving the order will fail at query
-time.
+inside a `pair`/`triple`/`@YawnProjection` data class is fine): the expression can only be ordered by once it's also
+selected, so if the returned value isn't projected, resolving the order will fail at query time.
 
 ### Project to Data Class
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -95,6 +95,27 @@ val authorNames = yawn.project(BookTable) { books ->
 > 🥱 If something isn’t support by **Yawn**, you can also create your own custom `YawnQueryProjection` by implementing the interface. However, in that case you
 > will need to guarantee the type-safety of your implementation!
 
+#### Ordering by an aggregate
+
+A plain column can be ordered directly (`orderAsc`/`orderDesc`, or `YawnQueryOrder.asc`/`.desc`), but an aggregate or
+other projected expression has no property name of its own to order by. Wrap it with `.orderable()` to give it one,
+then pass that *same* wrapped instance to both `order(...)` and `project(...)`:
+
+```kotlin
+val mostRecentVisit = YawnProjections.max(visits.createdAt).orderable()
+
+yawn.project(VisitTable) { visits ->
+    order(YawnQueryOrder.desc(mostRecentVisit))
+    project(YawnProjections.pair(YawnProjections.groupBy(visits.brandId), mostRecentVisit))
+}.list()
+```
+
+This groups visits by brand and returns each brand's most recent visit time, sorted with the most-recently-visited
+brands first - a "top-N per group" query expressed as a single SQL-side query instead of fetching every row and
+sorting in Kotlin. The wrapped instance must be passed to `project(...)` too (nesting it inside a `pair`/`triple`/
+`@YawnProjection` data class is fine): Hibernate can only order by an alias that is actually present in the query's
+SELECT list, so if it isn't projected, resolving the order will fail at query time.
+
 ### Project to Data Class
 
 Sometimes you want to return more than a single field. For that, you can project to a data class with any assortment of columns you desire, built off of other

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -98,23 +98,22 @@ val authorNames = yawn.project(BookTable) { books ->
 #### Ordering by an aggregate
 
 A plain column can be ordered directly (`orderAsc`/`orderDesc`, or `YawnQueryOrder.asc`/`.desc`), but an aggregate or
-other projected expression has no property name of its own to order by. Wrap it with `.orderable()` to give it one,
-then pass that *same* wrapped instance to both `order(...)` and `project(...)`:
+other projected expression has no property name of its own to order by. `orderAscBy`/`orderDescBy` handle this for
+you: pass them the projection, and use the *returned* value in `project(...)`:
 
 ```kotlin
-val mostRecentVisit = YawnProjections.max(visits.createdAt).orderable()
-
 yawn.project(VisitTable) { visits ->
-    order(YawnQueryOrder.desc(mostRecentVisit))
+    val mostRecentVisit = orderDescBy(YawnProjections.max(visits.createdAt))
     project(YawnProjections.pair(YawnProjections.groupBy(visits.brandId), mostRecentVisit))
 }.list()
 ```
 
 This groups visits by brand and returns each brand's most recent visit time, sorted with the most-recently-visited
 brands first - a "top-N per group" query expressed as a single SQL-side query instead of fetching every row and
-sorting in Kotlin. The wrapped instance must be passed to `project(...)` too (nesting it inside a `pair`/`triple`/
-`@YawnProjection` data class is fine): Hibernate can only order by an alias that is actually present in the query's
-SELECT list, so if it isn't projected, resolving the order will fail at query time.
+sorting in Kotlin. The value returned by `orderDescBy`/`orderAscBy` must be passed to `project(...)` (nesting it
+inside a `pair`/`triple`/`@YawnProjection` data class is fine): Hibernate can only order by an alias that is actually
+present in the query's SELECT list, so if the returned value isn't projected, resolving the order will fail at query
+time.
 
 ### Project to Data Class
 

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnQueryScopeWithOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnQueryScopeWithOrder.kt
@@ -1,6 +1,8 @@
 package com.faire.yawn.criteria.query
 
+import com.faire.yawn.project.AliasedYawnQueryProjection
 import com.faire.yawn.project.YawnPathProvider
+import com.faire.yawn.project.YawnQueryProjection
 import com.faire.yawn.query.YawnQuery
 import com.faire.yawn.query.YawnQueryOrder
 
@@ -8,8 +10,10 @@ import com.faire.yawn.query.YawnQueryOrder
  * A delegatable interface for Query DSL classes supporting ORDER clauses (via [order], etc.).
  * This serves [EntityYawnQueryScope], [ProjectionYawnQueryScope] and [ProjectedYawnQueryScope].
  *
- * [orderAsc]/[orderDesc] accept a plain [com.faire.yawn.YawnTableDef.ColumnDef] as well as a projected/aggregate
- * expression wrapped via [com.faire.yawn.project.orderable] (e.g. to order grouped rows by `max(createdAt)`).
+ * [orderAsc]/[orderDesc] accept a plain [com.faire.yawn.YawnTableDef.ColumnDef]. To order by a projected/aggregate
+ * expression instead (e.g. `max(createdAt)`), see [orderAscBy]/[orderDescBy] below - a distinct name is needed
+ * since a member function of this name would otherwise shadow an extension of the same name entirely, regardless
+ * of parameter types.
  */
 sealed interface YawnQueryScopeWithOrder<SOURCE : Any, T : Any> {
     fun order(vararg orders: YawnQueryOrder<SOURCE>)
@@ -33,4 +37,36 @@ internal class YawnQueryScopeWithOrderDelegate<SOURCE : Any, T : Any>(
     override fun orderDesc(property: YawnPathProvider<SOURCE>) {
         order(YawnQueryOrder.desc(property))
     }
+}
+
+/**
+ * Orders by a projected/aggregate expression (e.g. `YawnProjections.max(col)`), ascending.
+ *
+ * Unlike a plain column, such an expression has no property name of its own for Hibernate to order by, so this
+ * assigns it a unique SQL alias internally and returns the now-orderable projection - pass the *returned*
+ * instance to `project(...)` (nesting it inside a `pair`/`triple`/`@YawnProjection` data class is fine), since
+ * Hibernate can only order by an alias that is actually present in the query's SELECT list.
+ *
+ * ```kotlin
+ * yawn.project(VisitTable) { visits ->
+ *     val mostRecentVisit = orderDescBy(YawnProjections.max(visits.createdAt))
+ *     project(YawnProjections.pair(YawnProjections.groupBy(visits.brandId), mostRecentVisit))
+ * }.list()
+ * ```
+ */
+fun <SOURCE : Any, TO> YawnQueryScopeWithOrder<SOURCE, *>.orderAscBy(
+    projection: YawnQueryProjection<SOURCE, TO>,
+): YawnQueryProjection<SOURCE, TO> {
+    val aliased = AliasedYawnQueryProjection(projection)
+    order(YawnQueryOrder.asc(aliased))
+    return aliased
+}
+
+/** Descending counterpart of [orderAscBy]. */
+fun <SOURCE : Any, TO> YawnQueryScopeWithOrder<SOURCE, *>.orderDescBy(
+    projection: YawnQueryProjection<SOURCE, TO>,
+): YawnQueryProjection<SOURCE, TO> {
+    val aliased = AliasedYawnQueryProjection(projection)
+    order(YawnQueryOrder.desc(aliased))
+    return aliased
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnQueryScopeWithOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnQueryScopeWithOrder.kt
@@ -42,10 +42,10 @@ internal class YawnQueryScopeWithOrderDelegate<SOURCE : Any, T : Any>(
 /**
  * Orders by a projected/aggregate expression (e.g. `YawnProjections.max(col)`), ascending.
  *
- * Unlike a plain column, such an expression has no property name of its own for Hibernate to order by, so this
- * assigns it a unique SQL alias internally and returns the now-orderable projection - pass the *returned*
- * instance to `project(...)` (nesting it inside a `pair`/`triple`/`@YawnProjection` data class is fine), since
- * Hibernate can only order by an alias that is actually present in the query's SELECT list.
+ * Unlike a plain column, such an expression has no name of its own to order by, so this gives it one and returns
+ * the now-orderable projection - pass the *returned* instance to `project(...)` (nesting it inside a
+ * `pair`/`triple`/`@YawnProjection` data class is fine). It can only be ordered by once it's also selected, so if
+ * the returned value isn't projected, resolving the order will fail at query time.
  *
  * ```kotlin
  * yawn.project(VisitTable) { visits ->

--- a/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnQueryScopeWithOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/criteria/query/YawnQueryScopeWithOrder.kt
@@ -1,17 +1,20 @@
 package com.faire.yawn.criteria.query
 
-import com.faire.yawn.YawnTableDef
+import com.faire.yawn.project.YawnPathProvider
 import com.faire.yawn.query.YawnQuery
 import com.faire.yawn.query.YawnQueryOrder
 
 /**
  * A delegatable interface for Query DSL classes supporting ORDER clauses (via [order], etc.).
  * This serves [EntityYawnQueryScope], [ProjectionYawnQueryScope] and [ProjectedYawnQueryScope].
+ *
+ * [orderAsc]/[orderDesc] accept a plain [com.faire.yawn.YawnTableDef.ColumnDef] as well as a projected/aggregate
+ * expression wrapped via [com.faire.yawn.project.orderable] (e.g. to order grouped rows by `max(createdAt)`).
  */
 sealed interface YawnQueryScopeWithOrder<SOURCE : Any, T : Any> {
     fun order(vararg orders: YawnQueryOrder<SOURCE>)
-    fun orderAsc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>)
-    fun orderDesc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>)
+    fun orderAsc(property: YawnPathProvider<SOURCE>)
+    fun orderDesc(property: YawnPathProvider<SOURCE>)
 }
 
 internal class YawnQueryScopeWithOrderDelegate<SOURCE : Any, T : Any>(
@@ -23,11 +26,11 @@ internal class YawnQueryScopeWithOrderDelegate<SOURCE : Any, T : Any>(
         }
     }
 
-    override fun orderAsc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>) {
+    override fun orderAsc(property: YawnPathProvider<SOURCE>) {
         order(YawnQueryOrder.asc(property))
     }
 
-    override fun orderDesc(property: YawnTableDef<SOURCE, *>.ColumnDef<*>) {
+    override fun orderDesc(property: YawnPathProvider<SOURCE>) {
         order(YawnQueryOrder.desc(property))
     }
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/AliasedYawnQueryProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/AliasedYawnQueryProjection.kt
@@ -1,0 +1,54 @@
+package com.faire.yawn.project
+
+import com.faire.yawn.query.YawnCompilationContext
+import org.hibernate.criterion.Projection
+import org.hibernate.criterion.Projections
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Wraps a [YawnQueryProjection] with a unique SQL alias, so that it can also be used as a
+ * [com.faire.yawn.query.YawnQueryOrder] target via [YawnPathProvider] - see [orderable].
+ *
+ * Hibernate can only resolve `ORDER BY` against an alias that is present in the query's own SELECT list (unlike a
+ * plain mapped column, an aggregate or other projected expression has no property name of its own to order by).
+ * The *same* [AliasedYawnQueryProjection] instance returned by [orderable] must therefore be passed to `project(...)`
+ * (directly, or nested inside a `pair`/`triple`/`@YawnProjection` data class/etc.) for ordering by it to work -
+ * the alias is otherwise never selected, and Hibernate will fail to resolve it at query time.
+ */
+class AliasedYawnQueryProjection<SOURCE : Any, TO> internal constructor(
+    private val projection: YawnQueryProjection<SOURCE, TO>,
+) : YawnQueryProjection<SOURCE, TO>, YawnPathProvider<SOURCE> {
+    private val alias: String = "${ALIAS_PREFIX}${aliasCounter.getAndIncrement()}"
+
+    override fun compile(context: YawnCompilationContext): Projection {
+        return Projections.alias(projection.compile(context), alias)
+    }
+
+    override fun project(value: Any?): TO = projection.project(value)
+
+    override fun generatePath(context: YawnCompilationContext): String = alias
+
+    private companion object {
+        private const val ALIAS_PREFIX = "yawn_orderable_"
+        private val aliasCounter = AtomicLong()
+    }
+}
+
+/**
+ * Wraps this projection with a unique alias so it can be used as an ORDER BY target, most commonly to sort grouped
+ * rows by an aggregate (e.g. ordering `groupBy(brandId)` rows by their `max(createdAt)`, to get the most recently
+ * touched groups first) - something a plain mapped column doesn't need, since it can already be ordered by directly.
+ *
+ * ```kotlin
+ * val mostRecentVisit = YawnProjections.max(visits.createdAt).orderable()
+ * session.project(VisitTable) { visits ->
+ *     order(YawnQueryOrder.desc(mostRecentVisit))
+ *     project(YawnProjections.pair(YawnProjections.groupBy(visits.brandId), mostRecentVisit))
+ * }.list()
+ * ```
+ *
+ * See [AliasedYawnQueryProjection] for why the same returned instance must also be passed to `project(...)`.
+ */
+fun <SOURCE : Any, TO> YawnQueryProjection<SOURCE, TO>.orderable(): AliasedYawnQueryProjection<SOURCE, TO> {
+    return AliasedYawnQueryProjection(this)
+}

--- a/yawn-api/src/main/kotlin/com/faire/yawn/project/AliasedYawnQueryProjection.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/project/AliasedYawnQueryProjection.kt
@@ -3,52 +3,43 @@ package com.faire.yawn.project
 import com.faire.yawn.query.YawnCompilationContext
 import org.hibernate.criterion.Projection
 import org.hibernate.criterion.Projections
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Wraps a [YawnQueryProjection] with a unique SQL alias, so that it can also be used as a
- * [com.faire.yawn.query.YawnQueryOrder] target via [YawnPathProvider] - see [orderable].
+ * [com.faire.yawn.query.YawnQueryOrder] target via [YawnPathProvider].
  *
- * Hibernate can only resolve `ORDER BY` against an alias that is present in the query's own SELECT list (unlike a
- * plain mapped column, an aggregate or other projected expression has no property name of its own to order by).
- * The *same* [AliasedYawnQueryProjection] instance returned by [orderable] must therefore be passed to `project(...)`
- * (directly, or nested inside a `pair`/`triple`/`@YawnProjection` data class/etc.) for ordering by it to work -
- * the alias is otherwise never selected, and Hibernate will fail to resolve it at query time.
+ * This is an internal implementation detail of [com.faire.yawn.criteria.query.orderAsc]/
+ * [com.faire.yawn.criteria.query.orderDesc] (see those for the public entry point to order by a projected/
+ * aggregate expression) and should never be constructed directly: Hibernate can only resolve `ORDER BY` against an
+ * alias that is present in the query's own SELECT list (unlike a plain mapped column, an aggregate or other
+ * projected expression has no property name of its own to order by), so [orderAsc]/[orderDesc] return this same
+ * instance for the caller to pass to `project(...)`, ensuring the alias is actually selected.
+ *
+ * The alias is generated lazily via [YawnCompilationContext.generateResultAlias] and cached per context - rather
+ * than assigned once at construction - because the same query (and so the same instance of this class) can be
+ * compiled more than once, e.g. re-executed, or cloned for a separate count query. Each compilation gets its own
+ * alias, but caching per context means it doesn't matter whether the SELECT list or the ORDER BY clause happens
+ * to compile this projection first within a single compilation - both resolve to the same alias.
  */
-class AliasedYawnQueryProjection<SOURCE : Any, TO> internal constructor(
+internal class AliasedYawnQueryProjection<SOURCE : Any, TO>(
     private val projection: YawnQueryProjection<SOURCE, TO>,
 ) : YawnQueryProjection<SOURCE, TO>, YawnPathProvider<SOURCE> {
-    private val alias: String = "${ALIAS_PREFIX}${aliasCounter.getAndIncrement()}"
+    private var aliasContext: YawnCompilationContext? = null
+    private var alias: String? = null
+
+    private fun aliasFor(context: YawnCompilationContext): String {
+        if (aliasContext !== context) {
+            aliasContext = context
+            alias = context.generateResultAlias()
+        }
+        return checkNotNull(alias)
+    }
 
     override fun compile(context: YawnCompilationContext): Projection {
-        return Projections.alias(projection.compile(context), alias)
+        return Projections.alias(projection.compile(context), aliasFor(context))
     }
 
     override fun project(value: Any?): TO = projection.project(value)
 
-    override fun generatePath(context: YawnCompilationContext): String = alias
-
-    private companion object {
-        private const val ALIAS_PREFIX = "yawn_orderable_"
-        private val aliasCounter = AtomicLong()
-    }
-}
-
-/**
- * Wraps this projection with a unique alias so it can be used as an ORDER BY target, most commonly to sort grouped
- * rows by an aggregate (e.g. ordering `groupBy(brandId)` rows by their `max(createdAt)`, to get the most recently
- * touched groups first) - something a plain mapped column doesn't need, since it can already be ordered by directly.
- *
- * ```kotlin
- * val mostRecentVisit = YawnProjections.max(visits.createdAt).orderable()
- * session.project(VisitTable) { visits ->
- *     order(YawnQueryOrder.desc(mostRecentVisit))
- *     project(YawnProjections.pair(YawnProjections.groupBy(visits.brandId), mostRecentVisit))
- * }.list()
- * ```
- *
- * See [AliasedYawnQueryProjection] for why the same returned instance must also be passed to `project(...)`.
- */
-fun <SOURCE : Any, TO> YawnQueryProjection<SOURCE, TO>.orderable(): AliasedYawnQueryProjection<SOURCE, TO> {
-    return AliasedYawnQueryProjection(this)
+    override fun generatePath(context: YawnCompilationContext): String = aliasFor(context)
 }

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
@@ -14,8 +14,8 @@ import org.hibernate.criterion.Order
  *
  * @property property the property by which to order. Usually a [YawnTableDef.ColumnDef]; to order by a projected/
  * aggregate expression instead (e.g. ordering grouped rows by `max(createdAt)`), use the
- * [com.faire.yawn.criteria.query.orderAsc]/[com.faire.yawn.criteria.query.orderDesc] extension functions rather
- * than constructing a [YawnQueryOrder] directly.
+ * [com.faire.yawn.criteria.query.orderAscBy]/[com.faire.yawn.criteria.query.orderDescBy] extension functions
+ * rather than constructing a [YawnQueryOrder] directly.
  * @property direction the direction by which to order, either ascending or descending
  * @property nullPrecedence the precedence of null values, either first, last, or none
  */

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
@@ -12,9 +12,10 @@ import org.hibernate.criterion.Order
  * Compiles into a Hibernate's [Order].
  * It restricts construction of this class by requiring the [SOURCE] of the query.
  *
- * @property property the property by which to order. Usually a [YawnTableDef.ColumnDef], but can also be an
- * [com.faire.yawn.project.AliasedYawnQueryProjection] to order by a projected/aggregate expression (e.g. ordering
- * grouped rows by `max(createdAt)`) - see [com.faire.yawn.project.orderable].
+ * @property property the property by which to order. Usually a [YawnTableDef.ColumnDef]; to order by a projected/
+ * aggregate expression instead (e.g. ordering grouped rows by `max(createdAt)`), use the
+ * [com.faire.yawn.criteria.query.orderAsc]/[com.faire.yawn.criteria.query.orderDesc] extension functions rather
+ * than constructing a [YawnQueryOrder] directly.
  * @property direction the direction by which to order, either ascending or descending
  * @property nullPrecedence the precedence of null values, either first, last, or none
  */

--- a/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
+++ b/yawn-api/src/main/kotlin/com/faire/yawn/query/YawnQueryOrder.kt
@@ -1,6 +1,7 @@
 package com.faire.yawn.query
 
 import com.faire.yawn.YawnTableDef
+import com.faire.yawn.project.YawnPathProvider
 import org.hibernate.NullPrecedence
 import org.hibernate.NullPrecedence.NONE
 import org.hibernate.criterion.Order
@@ -11,12 +12,14 @@ import org.hibernate.criterion.Order
  * Compiles into a Hibernate's [Order].
  * It restricts construction of this class by requiring the [SOURCE] of the query.
  *
- * @property property the property by which to order
+ * @property property the property by which to order. Usually a [YawnTableDef.ColumnDef], but can also be an
+ * [com.faire.yawn.project.AliasedYawnQueryProjection] to order by a projected/aggregate expression (e.g. ordering
+ * grouped rows by `max(createdAt)`) - see [com.faire.yawn.project.orderable].
  * @property direction the direction by which to order, either ascending or descending
  * @property nullPrecedence the precedence of null values, either first, last, or none
  */
 data class YawnQueryOrder<SOURCE : Any>(
-    val property: YawnTableDef<SOURCE, *>.ColumnDef<*>,
+    val property: YawnPathProvider<SOURCE>,
     val direction: Direction,
     val nullPrecedence: NullPrecedence,
 ) {
@@ -38,14 +41,14 @@ data class YawnQueryOrder<SOURCE : Any>(
 
     companion object {
         fun <SOURCE : Any> asc(
-            property: YawnTableDef<SOURCE, *>.ColumnDef<*>,
+            property: YawnPathProvider<SOURCE>,
             nullPrecedence: NullPrecedence = NONE,
         ): YawnQueryOrder<SOURCE> {
             return YawnQueryOrder(property, Direction.ASC, nullPrecedence)
         }
 
         fun <SOURCE : Any> desc(
-            property: YawnTableDef<SOURCE, *>.ColumnDef<*>,
+            property: YawnPathProvider<SOURCE>,
             nullPrecedence: NullPrecedence = NONE,
         ): YawnQueryOrder<SOURCE> {
             return YawnQueryOrder(property, Direction.DESC, nullPrecedence)

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -543,13 +543,6 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
         }
     }
 
-    @YawnProjection
-    internal data class AuthorBookStats(
-        val author: String,
-        val numberOfBooks: Long,
-        val totalPages: Long,
-    )
-
     @Test
     fun `yawn query with group by ordered by one aggregate field among several`() {
         transactor.open { session ->
@@ -982,5 +975,12 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
     internal data class BookNameAndNotes(
         val name: String,
         val notes: String,
+    )
+
+    @YawnProjection
+    internal data class AuthorBookStats(
+        val author: String,
+        val numberOfBooks: Long,
+        val totalPages: Long,
     )
 }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -1,9 +1,10 @@
 package com.faire.yawn.database
 
+import com.faire.yawn.criteria.query.orderAscBy
+import com.faire.yawn.criteria.query.orderDescBy
 import com.faire.yawn.project.YawnProjection
 import com.faire.yawn.project.YawnProjections
 import com.faire.yawn.project.YawnQueryProjection
-import com.faire.yawn.project.orderable
 import com.faire.yawn.query.YawnCompilationContext
 import com.faire.yawn.query.YawnQueryOrder
 import com.faire.yawn.setup.entities.Book
@@ -519,8 +520,7 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
             // "top-N per group": group books by language, then order the *groups* by their own max(numberOfPages),
             // pushing the sort to SQL instead of fetching every row and sorting in Kotlin.
             val resultsDesc = session.project(BookTable) { books ->
-                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
-                order(YawnQueryOrder.desc(maxPages))
+                val maxPages = orderDescBy(YawnProjections.max(books.numberOfPages))
                 project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
             }.list()
 
@@ -531,38 +531,7 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
             )
 
             val resultsAsc = session.project(BookTable) { books ->
-                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
-                order(YawnQueryOrder.asc(maxPages))
-                project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
-            }.list()
-
-            assertThat(resultsAsc).containsExactly(
-                DANISH to 120L,
-                ENGLISH to 1_000L,
-            )
-        }
-    }
-
-    @Test
-    fun `yawn query with group by ordered by an aggregate via orderAsc-orderDesc`() {
-        transactor.open { session ->
-            // Same as `yawn query with group by ordered by an aggregate`, but through the orderAsc/orderDesc DSL
-            // sugar instead of `order(YawnQueryOrder...)`, since both were widened to accept an orderable
-            // projection alongside a plain ColumnDef.
-            val resultsDesc = session.project(BookTable) { books ->
-                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
-                orderDesc(maxPages)
-                project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
-            }.list()
-
-            assertThat(resultsDesc).containsExactly(
-                ENGLISH to 1_000L,
-                DANISH to 120L,
-            )
-
-            val resultsAsc = session.project(BookTable) { books ->
-                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
-                orderAsc(maxPages)
+                val maxPages = orderAscBy(YawnProjections.max(books.numberOfPages))
                 project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
             }.list()
 
@@ -581,8 +550,7 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
             // plays no part in the alias/ordering machinery.
             val results = session.project(BookTable) { books ->
                 val authors = join(books.author)
-                val totalPages = YawnProjections.sum(books.numberOfPages).orderable()
-                order(YawnQueryOrder.desc(totalPages))
+                val totalPages = orderDescBy(YawnProjections.sum(books.numberOfPages))
                 project(
                     YawnProjectionTest_AuthorBookStatsProjection.create(
                         author = YawnProjections.groupBy(authors.name),

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -3,9 +3,11 @@ package com.faire.yawn.database
 import com.faire.yawn.project.YawnProjection
 import com.faire.yawn.project.YawnProjections
 import com.faire.yawn.project.YawnQueryProjection
+import com.faire.yawn.project.orderable
 import com.faire.yawn.query.YawnCompilationContext
 import com.faire.yawn.query.YawnQueryOrder
 import com.faire.yawn.setup.entities.Book
+import com.faire.yawn.setup.entities.Book.Language.DANISH
 import com.faire.yawn.setup.entities.Book.Language.ENGLISH
 import com.faire.yawn.setup.entities.BookTable
 import com.faire.yawn.setup.entities.PublisherTable
@@ -507,6 +509,36 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
                 AuthorAndBooks("J.R.R. Tolkien", 2),
                 AuthorAndBooks("J.K. Rowling", 1),
                 AuthorAndBooks("Hans Christian Andersen", 3),
+            )
+        }
+    }
+
+    @Test
+    fun `yawn query with group by ordered by an aggregate`() {
+        transactor.open { session ->
+            // "top-N per group": group books by language, then order the *groups* by their own max(numberOfPages),
+            // pushing the sort to SQL instead of fetching every row and sorting in Kotlin.
+            val resultsDesc = session.project(BookTable) { books ->
+                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
+                order(YawnQueryOrder.desc(maxPages))
+                project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
+            }.list()
+
+            // ENGLISH's max (Lord of the Rings, 1000) outranks DANISH's max (The Emperor's New Clothes, 120)
+            assertThat(resultsDesc).containsExactly(
+                ENGLISH to 1_000L,
+                DANISH to 120L,
+            )
+
+            val resultsAsc = session.project(BookTable) { books ->
+                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
+                order(YawnQueryOrder.asc(maxPages))
+                project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
+            }.list()
+
+            assertThat(resultsAsc).containsExactly(
+                DANISH to 120L,
+                ENGLISH to 1_000L,
             )
         }
     }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -543,6 +543,43 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
         }
     }
 
+    @YawnProjection
+    internal data class AuthorBookStats(
+        val author: String,
+        val numberOfBooks: Long,
+        val totalPages: Long,
+    )
+
+    @Test
+    fun `yawn query with group by ordered by one aggregate field among several`() {
+        transactor.open { session ->
+            // Group by author, projecting *two* aggregates per group (book count and total page count), but only
+            // order by one of them (totalPages) - the other aggregate (numberOfBooks) is along for the ride and
+            // plays no part in the alias/ordering machinery.
+            val results = session.project(BookTable) { books ->
+                val authors = join(books.author)
+                val totalPages = YawnProjections.sum(books.numberOfPages).orderable()
+                order(YawnQueryOrder.desc(totalPages))
+                project(
+                    YawnProjectionTest_AuthorBookStatsProjection.create(
+                        author = YawnProjections.groupBy(authors.name),
+                        numberOfBooks = YawnProjections.count(books.name),
+                        totalPages = totalPages,
+                    ),
+                )
+            }.list()
+
+            assertThat(results).containsExactly(
+                // Tolkien: Lord of the Rings (1000) + The Hobbit (300)
+                AuthorBookStats("J.R.R. Tolkien", numberOfBooks = 2, totalPages = 1_300),
+                // Rowling: Harry Potter (500)
+                AuthorBookStats("J.K. Rowling", numberOfBooks = 1, totalPages = 500),
+                // Andersen: The Little Mermaid (100) + The Ugly Duckling (110) + The Emperor's New Clothes (120)
+                AuthorBookStats("Hans Christian Andersen", numberOfBooks = 3, totalPages = 330),
+            )
+        }
+    }
+
     @Test
     fun `yawn query with projection and join`() {
         transactor.open { session ->

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -544,6 +544,36 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
     }
 
     @Test
+    fun `yawn query with group by ordered by an aggregate via orderAsc-orderDesc`() {
+        transactor.open { session ->
+            // Same as `yawn query with group by ordered by an aggregate`, but through the orderAsc/orderDesc DSL
+            // sugar instead of `order(YawnQueryOrder...)`, since both were widened to accept an orderable
+            // projection alongside a plain ColumnDef.
+            val resultsDesc = session.project(BookTable) { books ->
+                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
+                orderDesc(maxPages)
+                project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
+            }.list()
+
+            assertThat(resultsDesc).containsExactly(
+                ENGLISH to 1_000L,
+                DANISH to 120L,
+            )
+
+            val resultsAsc = session.project(BookTable) { books ->
+                val maxPages = YawnProjections.max(books.numberOfPages).orderable()
+                orderAsc(maxPages)
+                project(YawnProjections.pair(YawnProjections.groupBy(books.originalLanguage), maxPages))
+            }.list()
+
+            assertThat(resultsAsc).containsExactly(
+                DANISH to 120L,
+                ENGLISH to 1_000L,
+            )
+        }
+    }
+
+    @Test
     fun `yawn query with group by ordered by one aggregate field among several`() {
         transactor.open { session ->
             // Group by author, projecting *two* aggregates per group (book count and total page count), but only


### PR DESCRIPTION
# Summary

YawnQueryOrder, orderAsc, and orderDesc only accepted a plain ColumnDef, so there was no way to order a query by an aggregate or other projected expression (e.g. max(createdAt) in a grouped projection). This forced "top-N per group" queries into workarounds - fetching every row and sorting/limiting in Kotlin instead of pushing ORDER BY ... LIMIT down to SQL.

Closes [#140](https://github.com/Faire/yawn/issues/140).

Changes
Widened YawnQueryOrder's target (and the orderAsc/orderDesc/YawnQueryOrder.asc/.desc parameter types) from YawnTableDef.ColumnDef to the more general YawnPathProvider interface. ColumnDef already implements YawnPathProvider, so this is purely additive - no behavior change for existing plain-column ordering.
Added new orderAscBy/orderDescBy extension functions (distinct names from the existing orderAsc/orderDesc members - a same-named extension would be shadowed outright by Kotlin's member-over-extension resolution, regardless of parameter types) as the entry point for ordering by a projected/aggregate expression: pass them the projection (e.g. YawnProjections.max(col)), and pass the returned value to project(...).
Internally, orderAscBy/orderDescBy wrap the projection in AliasedYawnQueryProjection, giving it a unique SQL alias (via the existing YawnCompilationContext.generateResultAlias(), cached per compilation) so it can be resolved in ORDER BY. This type is fully internal and never appears in a public signature - callers only see it through the YawnQueryProjection interface it implements.
Documented the pattern in [docs/projections.md](https://github.com/Faire/yawn/blob/claude/yawn-order-by-aggregate/docs/projections.md) with a "top-N per group" example, phrased in terms of Yawn's own semantics rather than Hibernate internals.
Added tests covering ordering a grouped aggregate ascending/descending, and ordering by one aggregate among several projected fields in the same @YawnProjection data class - all verified against the real H2/Hibernate execution path.

---
_Generated by [Claude Code](https://claude.ai/code)_
