### PR TITLE
chore: Clean up docs and test examples

### DIFF
--- a/docs/basic_queries.md
+++ b/docs/basic_queries.md
@@ -105,7 +105,7 @@ Use `forShare()` for "find or create" patterns where you need to prevent concurr
 
 ```kotlin
 val existing = yawn.query(BookTable) { books ->
-    addEq(books.token, bookToken)
+    addEq(books.id, bookId)
 }
     .forShare()
     .uniqueResult()

--- a/docs/nullability.md
+++ b/docs/nullability.md
@@ -105,18 +105,18 @@ to change that if there are other sub-typing use cases.
 
 There are still cases where you might need some helper functions though. So far we provide two:
 
-## `TypedProjections.coalesce`
+## `YawnProjections.coalesce`
 
 This will do a Kotlin side (not SQL side) coalesce, allowing you to provide a nullable string into a non-null column with default value:
 
 ```kotlin
     // [in a projection]
-    aString = TypedProjections.coalesce(books.notes, "fallback"),
+    aString = YawnProjections.coalesce(books.notes, "fallback"),
 ```
 
 Note that we don’t currently support a type-safe SQL-side coalesce, but we plan on implementing that soon.
 
-## `TypedProjections.null`
+## `YawnProjections.null`
 
 If you want to always set `null` to the projection field, we also provide a `null()` function. This actually works on the SQL-side, but we plan to change this
 (and its sibling `selectConstant`) to a more robust, generic, “constant” selector projection that works on the Kotlin side and pairs with the enhanced
@@ -126,7 +126,7 @@ But for now you can do:
 
 ```kotlin
     // [in a projection]
-    aNullableString = TypedProjections.`null`(),
+    aNullableString = YawnProjections.`null`(),
 ```
 
 ## `addIsNotNull` returns a non-nullable column

--- a/docs/piecemeal_queries.md
+++ b/docs/piecemeal_queries.md
@@ -61,10 +61,10 @@ KSP generates the scope aliases and a `TableDefType` alias for every `@YawnEntit
 table-definition, and projection generics:
 
 ```kotlin
-private fun BookEntityQueryScope.addPublishedFilter(
+private fun BookEntityQueryScope.addHasPublisherFilter(
     books: BookTableDefType,
 ) {
-    addEq(books.published, true)
+    addEq(books.hasPublisher, true)
 }
 ```
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -50,7 +50,7 @@ For example, the following query returns the publishers of books whose names sta
 ```kotlin
 val publishers = yawn.project(BookTable) { books ->
     addLike(books.name, "The %")
-    addIsNotNull(books.publisher.foreignKey)
+    addIsNotNull(books.publisher)
 
     project(books.publisher)
 }.set()
@@ -65,7 +65,7 @@ Sometimes you want to project to a derived value, like a count or sum. To do tha
 use our version `YawnProjections`. For example:
 
 ```kotlin
-project(YawnProjections.count(books.token))
+project(YawnProjections.count(books.id))
 ```
 
 or
@@ -76,8 +76,20 @@ project(YawnProjections.sum(books.numberOfPages))
 
 Again, **Yawn** knows that `sum` must take a numerical type, and that both `count` and `sum` return `Long`.
 
-Other projection functions include the usual suspects such as `distinct`, `countDistinct`, `avg`, `min` and `max`. You can see all currently supported
+Other projection functions include the usual suspects such as `countDistinct`, `avg`, `min` and `max`. You can see all currently supported
 projection functions on [the `YawnProjections` file][yawn-projections-file].
+
+Note that `countDistinct` is an *aggregate-level* distinct, i.e. `COUNT(DISTINCT column)`. That is a different thing from a query-level `SELECT DISTINCT`,
+which applies to the whole projection and is requested on the builder instead:
+
+```kotlin
+val authorNames = yawn.project(BookTable) { books ->
+    val authors = join(books.author)
+    project(authors.name)
+}.distinct().list()
+```
+
+`distinct()` is only available on projected queries, since Hibernate only supports `DISTINCT` through projections.
 
 > [!NOTE]
 > 🥱 If something isn’t support by **Yawn**, you can also create your own custom `YawnQueryProjection` by implementing the interface. However, in that case you
@@ -133,7 +145,7 @@ internal data class AuthorAndBooks(
 )
 
 // later:
-yawn.project(BookTable) { 
+yawn.project(BookTable) {
   project(
     AuthorAndBooksProjectionDef.create(
       author = TypedProjections.groupBy(books.author),

--- a/docs/sub_queries.md
+++ b/docs/sub_queries.md
@@ -15,14 +15,15 @@ a restriction.
 
 ```kotlin
     // outside the transaction
-    val detachedSubQuery = Yawn.createProjectedDetachedCriteria(DbPersonTable) { person ->
-        addLike(person.name, "J.%")
-        project(YawnProjections.distinct(person.name))
-    }
+    val selectAuthorsStartingWithJ = Yawn.createProjectedDetachedCriteria(PersonTable) { people ->
+        addLike(people.name, "J.%")
+        project(people.name)
+    }.distinct()
 
     // within your transaction
-    val books = yawn.query(DbBookTable) { books ->
-        addIn(books.authorName, detachedSubQuery)
+    val books = yawn.query(BookTable) { books ->
+        val authors = join(books.author)
+        addIn(authors.name, selectAuthorsStartingWithJ)
         addLt(books.numberOfPages, 500)
     }.list()
 ```
@@ -33,13 +34,13 @@ Within a query, you can create a sub-query that can access the context of the pa
 
 ```kotlin
 val people = session.query(PersonTable) { people ->
-    val correlatedSubQuery = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
+    val selectAuthorsOfLargeBooks = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
         addEq(books.author.foreignKey, people.id) // access people from outer query
         addGt(books.numberOfPages, 500)
         project(books.author.foreignKey)
     }
 
-    addExists(correlatedSubQuery)
+    addExists(selectAuthorsOfLargeBooks)
 }.list()
 ```
 

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/ResolvedProjectionAdapterTest.kt
@@ -368,7 +368,7 @@ internal class ResolvedProjectionAdapterTest : BaseYawnDatabaseTest() {
 
             val publisherWithThe = session.project(BookTable) { books ->
                 addLike(books.name, "The %")
-                addIsNotNull(books.publisher.foreignKey)
+                addIsNotNull(books.publisher)
                 project(adapt(YawnValueProjector { ProjectionNode.property(books.publisher.foreignKey) }))
             }.set()
             assertThat(publisherWithThe)
@@ -384,7 +384,7 @@ internal class ResolvedProjectionAdapterTest : BaseYawnDatabaseTest() {
         transactor.open { session ->
             val publishers = session.project(BookTable) { books ->
                 addLike(books.name, "The %")
-                addIsNotNull(books.publisher.foreignKey)
+                addIsNotNull(books.publisher)
                 project(adapt(books.publisher))
             }.set()
 

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnCriterionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnCriterionTest.kt
@@ -102,8 +102,8 @@ internal class YawnCriterionTest : BaseYawnDatabaseTest() {
         transactor.open { session ->
             // Find all books by J.R.R. Tolkien
             val results = session.query(BookTable) { books ->
-                val author = join(books.author)
-                add(eq(author.name, "J.R.R. Tolkien"))
+                val authors = join(books.author)
+                add(eq(authors.name, "J.R.R. Tolkien"))
             }.list()
 
             assertThat(results)
@@ -114,9 +114,9 @@ internal class YawnCriterionTest : BaseYawnDatabaseTest() {
         // Find all people who have a favorite book by J.R.R. Tolkien
         transactor.open { session ->
             val results = session.query(PersonTable) { people ->
-                val favoriteBook = join(people.favoriteBook)
-                val favoriteBookAuthor = join(favoriteBook.author)
-                add(eq(favoriteBookAuthor.name, "J.R.R. Tolkien"))
+                val favoriteBooks = join(people.favoriteBook)
+                val authorsOfFavoriteBooks = join(favoriteBooks.author)
+                add(eq(authorsOfFavoriteBooks.name, "J.R.R. Tolkien"))
             }.list()
 
             assertThat(results)

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnForeignAndCompositeKeyTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnForeignAndCompositeKeyTest.kt
@@ -21,8 +21,8 @@ internal class YawnForeignAndCompositeKeyTest : BaseYawnDatabaseTest() {
                 project(books.id)
             }.uniqueResult()!!
 
-            val bookRanking = session.query(BookRankingTable) { bookRankings ->
-                addEq(bookRankings.bestSeller.foreignKey, bookId)
+            val bookRanking = session.query(BookRankingTable) { rankings ->
+                addEq(rankings.bestSeller.foreignKey, bookId)
             }.uniqueResult()!!
 
             assertThat(bookRanking.ratingYear).isEqualTo(2007)
@@ -39,16 +39,16 @@ internal class YawnForeignAndCompositeKeyTest : BaseYawnDatabaseTest() {
                 project(books.id)
             }.uniqueResult()!!
 
-            val hpRanking = session.query(BookRankingTable) { bookRankings ->
-                addEq(bookRankings.bestSeller, hpBookId)
+            val hpRanking = session.query(BookRankingTable) { rankings ->
+                addEq(rankings.bestSeller, hpBookId)
             }.uniqueResult()!!
 
             assertThat(hpRanking.ratingYear).isEqualTo(2007)
             assertThat(hpRanking.ratingMonth).isEqualTo(1)
             assertThat(hpRanking.bestSeller.id).isEqualTo(hpBookId)
 
-            val lordOfTheRingsRanking = session.query(BookRankingTable) { bookRankings ->
-                addNotEq(bookRankings.bestSeller, hpBookId)
+            val lordOfTheRingsRanking = session.query(BookRankingTable) { rankings ->
+                addNotEq(rankings.bestSeller, hpBookId)
             }.uniqueResult()!!
 
             assertThat(lordOfTheRingsRanking.ratingYear).isEqualTo(1966)
@@ -70,15 +70,15 @@ internal class YawnForeignAndCompositeKeyTest : BaseYawnDatabaseTest() {
                 project(books.id)
             }.uniqueResult()!!
 
-            val singleInResult = session.query(BookRankingTable) { bookRankings ->
-                addIn(bookRankings.bestSeller, setOf(lordOfTheRingsBookId))
+            val singleInResult = session.query(BookRankingTable) { rankings ->
+                addIn(rankings.bestSeller, setOf(lordOfTheRingsBookId))
             }.list()
 
             assertThat(singleInResult.map { Pair(it.ratingYear, it.bestSeller.name) })
                 .containsExactly(Pair(1966, "Lord of the Rings"))
 
-            val multipleInResult = session.query(BookRankingTable) { bookRankings ->
-                addIn(bookRankings.bestSeller, setOf(hpBookId, lordOfTheRingsBookId))
+            val multipleInResult = session.query(BookRankingTable) { rankings ->
+                addIn(rankings.bestSeller, setOf(hpBookId, lordOfTheRingsBookId))
             }.list()
 
             assertThat(multipleInResult.map { Pair(it.ratingYear, it.bestSeller.name) })
@@ -91,15 +91,15 @@ internal class YawnForeignAndCompositeKeyTest : BaseYawnDatabaseTest() {
 
     @Test
     fun `simplified foreign key in clause and subquery syntax`() {
-        val subQuery = Yawn.createProjectedDetachedCriteria(PersonTable) { people ->
+        val selectFavoriteBookIds = Yawn.createProjectedDetachedCriteria(PersonTable) { people ->
             addIn(people.name, "J.K. Rowling", "Luan Nico")
 
             project(people.favoriteBook.foreignKey)
         }
 
         transactor.open { session ->
-            val bookRankings = session.query(BookRankingTable) { bookRankings ->
-                addIn(bookRankings.bestSeller, subQuery)
+            val bookRankings = session.query(BookRankingTable) { rankings ->
+                addIn(rankings.bestSeller, selectFavoriteBookIds)
             }.list()
 
             assertThat(bookRankings.map { Pair(it.ratingYear, it.bestSeller.name) })

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnJoinsTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnJoinsTest.kt
@@ -17,14 +17,14 @@ internal class YawnJoinsTest : BaseYawnDatabaseTest() {
     @Test
     fun `yawn one-to-one inner join`() {
         transactor.open { session ->
-            val results1 = session.query(BookRankingTable) { ranking ->
-                val books = join(ranking.bestSeller)
+            val results1 = session.query(BookRankingTable) { rankings ->
+                val books = join(rankings.bestSeller)
                 addEq(books.name, "The Hobbit")
             }.list()
             assertThat(results1).isEmpty()
 
-            val results2 = session.query(BookRankingTable) { ranking ->
-                val books = join(ranking.bestSeller)
+            val results2 = session.query(BookRankingTable) { rankings ->
+                val books = join(rankings.bestSeller)
                 addEq(books.name, "Harry Potter")
             }.list()
             assertThat(results2.single().bestSeller.name).isEqualTo("Harry Potter")
@@ -312,17 +312,17 @@ internal class YawnJoinsTest : BaseYawnDatabaseTest() {
 
     @Test
     fun `yawn deeply-nested join structure - authors who's favorite books are not their own writing'`() {
-        val authors = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
-            val author = join(books.author)
-            project(author.name)
+        val selectAllAuthorNames = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
+            val authors = join(books.author)
+            project(authors.name)
         }
 
         val results = transactor.open { session ->
             session.query(PersonTable) { people ->
                 val favoriteBooks = join(people.favoriteBook)
-                val favoriteBooksAuthors = join(favoriteBooks.author)
-                addIn(people.name, authors)
-                addNotEq(people.name, favoriteBooksAuthors.name)
+                val authorsOfFavoriteBooks = join(favoriteBooks.author)
+                addIn(people.name, selectAllAuthorNames)
+                addNotEq(people.name, authorsOfFavoriteBooks.name)
             }.list()
         }
         assertThat(results.map { it.name }).containsExactlyInAnyOrder(
@@ -612,19 +612,19 @@ internal class YawnJoinsTest : BaseYawnDatabaseTest() {
     fun `use attachJoinRef to reuse reference which has been called in the query before, without creating duplicate path`() {
         transactor.open { session ->
             val criteriaAttachJoinRef = session.query(BookReviewTable) { bookReviews ->
-                val reviewer = join(bookReviews.reviewer)
-                val book = join(bookReviews.book)
+                val reviewers = join(bookReviews.reviewer)
+                val books = join(bookReviews.book)
 
-                addLike(reviewer.name, "%Doe%")
-                addEq(book.originalLanguage, ENGLISH)
+                addLike(reviewers.name, "%Doe%")
+                addEq(books.originalLanguage, ENGLISH)
             }.attachJoinRef { book }
 
             val criteria = criteriaAttachJoinRef.criteria
             val bookJoinRef = criteriaAttachJoinRef.joinRef
 
-            criteria.applyJoinRef(bookJoinRef) { book ->
-                val publisher = join(book.publisher)
-                addEq(publisher.name, "HarperCollins")
+            criteria.applyJoinRef(bookJoinRef) { books ->
+                val publishers = join(books.publisher)
+                addEq(publishers.name, "HarperCollins")
             }
 
             val results = criteria.list()

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnProjectionTest.kt
@@ -70,7 +70,7 @@ internal class YawnProjectionTest : BaseYawnDatabaseTest() {
                 addLike(books.name, "The %")
 
                 // TODO(yawn): publisher should be nullable
-                addIsNotNull(nullable(books.publisher.foreignKey))
+                addIsNotNull(books.publisher)
 
                 project(books.publisher)
             }.set()

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSimpleQueriesTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSimpleQueriesTest.kt
@@ -356,10 +356,10 @@ internal class YawnSimpleQueriesTest : BaseYawnDatabaseTest() {
     @Test
     fun `supports nested joins`() {
         transactor.open { session ->
-            val ranking = session.query(BookRankingTable) { ranking ->
-                val bestSeller = join(ranking.bestSeller)
-                val author = join(bestSeller.author)
-                addEq(author.name, "J.K. Rowling")
+            val ranking = session.query(BookRankingTable) { rankings ->
+                val bestSellers = join(rankings.bestSeller)
+                val authors = join(bestSellers.author)
+                addEq(authors.name, "J.K. Rowling")
             }.uniqueResult()!!
 
             assertThat(ranking.ratingYear).isEqualTo(2007)
@@ -802,8 +802,8 @@ internal class YawnSimpleQueriesTest : BaseYawnDatabaseTest() {
     fun `people whose favorite book was written by their favorite author`() {
         transactor.open { session ->
             val result = session.query(PersonTable) { people ->
-                val favoriteBook = join(people.favoriteBook)
-                addEq(people.favoriteAuthor, favoriteBook.author)
+                val favoriteBooks = join(people.favoriteBook)
+                addEq(people.favoriteAuthor, favoriteBooks.author)
             }.list()
             assertThat(result.map { it.name }).containsExactlyInAnyOrder("J.K. Rowling", "J.R.R. Tolkien")
         }

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSubQueryTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnSubQueryTest.kt
@@ -11,16 +11,16 @@ import org.junit.jupiter.api.Test
 internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
     @Test
     fun `yawn query with a sub query using detached criteria`() {
-        val detachedCriteria = Yawn.createProjectedDetachedCriteria(PersonTable) { person ->
-            addEq(person.name, "J.R.R. Tolkien")
+        val selectTolkienNames = Yawn.createProjectedDetachedCriteria(PersonTable) { people ->
+            addEq(people.name, "J.R.R. Tolkien")
 
-            project(person.name)
+            project(people.name)
         }
 
         transactor.open { session ->
             val book = session.query(BookTable) { books ->
                 val authors = join(books.author)
-                addEq(authors.name, detachedCriteria)
+                addEq(authors.name, selectTolkienNames)
 
                 addLt(books.numberOfPages, 500)
             }.uniqueResult()!!
@@ -34,14 +34,14 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
 
     @Test
     fun `yawn query with a sub query using detached criteria with join`() {
-        val detachedCriteria = Yawn.createProjectedDetachedCriteria(PersonTable) { person ->
-            addEq(person.name, "J.R.R. Tolkien")
-            project(person.id)
+        val selectTolkienIds = Yawn.createProjectedDetachedCriteria(PersonTable) { people ->
+            addEq(people.name, "J.R.R. Tolkien")
+            project(people.id)
         }
 
         transactor.open { session ->
             val book = session.query(BookTable) { books ->
-                addEq(books.author, detachedCriteria)
+                addEq(books.author, selectTolkienIds)
                 addLt(books.numberOfPages, 500)
             }.uniqueResult()!!
 
@@ -54,15 +54,15 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
 
     @Test
     fun `yawn query with a sub query using detached criteria with query-level distinct`() {
-        val detachedCriteria = Yawn.createProjectedDetachedCriteria(PersonTable) { person ->
-            addLike(person.name, "J.%")
-            project(person.name)
+        val selectAuthorsStartingWithJ = Yawn.createProjectedDetachedCriteria(PersonTable) { people ->
+            addLike(people.name, "J.%")
+            project(people.name)
         }.distinct()
 
         transactor.open { session ->
             val books = session.query(BookTable) { books ->
                 val authors = join(books.author)
-                addIn(authors.name, detachedCriteria)
+                addIn(authors.name, selectAuthorsStartingWithJ)
                 addLt(books.numberOfPages, 500)
             }.list()
 
@@ -76,7 +76,7 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
 
     @Test
     fun `yawn query with a sub query using detached criteria with left join`() {
-        val detachedCriteria = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
+        val selectAuthorsWithoutPublisher = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
             val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN)
             addIsNull(publishers.id)
             project(books.author.foreignKey)
@@ -84,7 +84,7 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
 
         transactor.open { session ->
             val people = session.query(PersonTable) { people ->
-                addIn(people.id, detachedCriteria)
+                addIn(people.id, selectAuthorsWithoutPublisher)
             }.list()
 
             assertThat(people).hasSize(1)
@@ -94,10 +94,10 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
 
     @Test
     fun `yawn query with a sub query using detached criteria with join criteria`() {
-        val detachedCriteria = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
-            val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN) { publisher ->
-                addNotLike(publisher.name, "%-%")
-                addNotLike(publisher.name, "% %")
+        val selectAuthorsWithoutSimplePublisher = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
+            val publishers = join(books.publisher, joinType = JoinType.LEFT_OUTER_JOIN) { publishers ->
+                addNotLike(publishers.name, "%-%")
+                addNotLike(publishers.name, "% %")
             }
             addIsNull(publishers.id)
             project(books.author.foreignKey)
@@ -105,7 +105,7 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
 
         transactor.open { session ->
             val people = session.query(PersonTable) { people ->
-                addIn(people.id, detachedCriteria)
+                addIn(people.id, selectAuthorsWithoutSimplePublisher)
             }.list()
 
             assertThat(people).hasSize(2)
@@ -118,20 +118,20 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
         transactor.open { session ->
             // Authors who have written a 500+ page book
             val people = session.query(PersonTable) { people ->
-                val subQuery = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
+                val selectAuthorsOfLargeBooks = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
                     addEq(books.author.foreignKey, people.id)
                     addGt(books.numberOfPages, 500)
                     project(books.author.foreignKey)
                 }
 
-                val secondSubQuery = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
+                val selectAuthorsOfRealBooks = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
                     addEq(books.author.foreignKey, people.id)
                     addNotEq(books.name, "Fake book")
                     project(books.author.foreignKey)
                 }
 
-                addExists(subQuery)
-                addExists(secondSubQuery)
+                addExists(selectAuthorsOfLargeBooks)
+                addExists(selectAuthorsOfRealBooks)
             }.list()
 
             assertThat(people.single().name).isEqualTo("J.R.R. Tolkien")
@@ -143,21 +143,21 @@ internal class YawnSubQueryTest : BaseYawnDatabaseTest() {
         transactor.open { session ->
             // Authors who have written a 500+ page book or who have written a book < 100 pages
             val people = session.query(PersonTable) { people ->
-                val greaterThan500Pages = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
+                val selectAuthorsOfLargeBooks = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
                     addEq(books.author.foreignKey, people.id)
                     addGt(books.numberOfPages, 500)
                     project(books.author.foreignKey)
                 }
 
-                val lessThan100Pages = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
+                val selectAuthorsOfShortBooks = createProjectedSubQuery(BookTable.forSubQuery()) { books ->
                     addEq(books.author.foreignKey, people.id)
                     addLe(books.numberOfPages, 100)
                     project(books.author.foreignKey)
                 }
 
                 addOr(
-                    YawnSubQueryRestrictions.exists(greaterThan500Pages),
-                    YawnSubQueryRestrictions.exists(lessThan100Pages),
+                    YawnSubQueryRestrictions.exists(selectAuthorsOfLargeBooks),
+                    YawnSubQueryRestrictions.exists(selectAuthorsOfShortBooks),
                 )
             }.list()
 

--- a/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnTypeAliasUsageTest.kt
+++ b/yawn-database-test/src/test/kotlin/com/faire/yawn/database/YawnTypeAliasUsageTest.kt
@@ -100,14 +100,14 @@ internal class YawnTypeAliasUsageTest : BaseYawnDatabaseTest() {
 
     @Test
     fun `projected scope alias works for a detached criteria`() {
-        val shortBookNames = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
+        val selectAndersenBookNames = Yawn.createProjectedDetachedCriteria(BookTable) { books ->
             filterToAuthor(books, "Hans Christian Andersen")
             project(books.name)
         }
 
         transactor.open { session ->
             val books = session.query(BookTable) { books ->
-                addIn(books.name, shortBookNames)
+                addIn(books.name, selectAndersenBookNames)
             }.list()
 
             assertThat(books.map { it.name }).containsExactlyInAnyOrder(


### PR DESCRIPTION
Some standardizations across all example code in both docs and tests:

* use fields from the fixture data model (on docs; some wouldn't have compiled)
* use current names of yawn classes (on docs; old names galore)
* remove an unnecessary `.foreignKey` helper when not necessary
* update docs about distinct that were missing after the refacotr
* standardize convention of table def names to plural (we settle this but there were stragglers)
* introduce a new convention for sub-queries (detached or correlated) naming: `selectFooBar` (see examples)

Ultimately this stemmed from making sure all examples compile and that our naming conventions are respected. I considered adding some automation for either parts but both seemed overkill for now.